### PR TITLE
feat(skills): allow configurable fix-loop budgets

### DIFF
--- a/plugins/genie/skills/dream/SKILL.md
+++ b/plugins/genie/skills/dream/SKILL.md
@@ -61,7 +61,7 @@ Each worker, independently:
 
 1. Dispatch one reviewer subagent per PR via the native delegation surface (reviewer ≠ worker) to run `review` against the wish's acceptance criteria.
 2. Read bot comments critically — never blindly accept automated findings.
-3. On FIX-FIRST: diagnose first; return an overdesigned plan to wish/design review, otherwise dispatch `fix` for valid gaps (max 2 loops per PR). On another architectural issue: escalate in the report, no fix attempt.
+3. On FIX-FIRST: diagnose first; return an overdesigned plan to wish/design review, otherwise dispatch `fix` for valid gaps using the resolved fix-loop budget (default 2 unless a higher-priority instruction overrides it). On another architectural issue: escalate in the report, no fix attempt.
 4. CI must be green before proceeding — poll status, do not sleep.
 5. On SHIP: mark the PR review-complete.
 

--- a/plugins/genie/skills/fix/SKILL.md
+++ b/plugins/genie/skills/fix/SKILL.md
@@ -9,6 +9,11 @@ description: "Dispatch fix subagent for FIX-FIRST gaps from review, re-review, t
 
 Resolve FIX-FIRST gaps from `review`: dispatch a fix subagent, re-review, repeat up to 2 loops, then diagnose and route any unresolved failure.
 
+Two loops is the default budget. Before the first fix dispatch, resolve the budget once for the group: an explicit
+higher-priority user or workspace instruction may set another positive integer; otherwise use two. Call the resolved
+value `B`. An override changes only the attempt cap—it does not permit broader scope, repeated unchanged attempts, or
+skipping diagnosis and review.
+
 ## When to Use
 - `review` returned a **FIX-FIRST** verdict with CRITICAL or HIGH gaps
 - Orchestrator hands off unresolved gaps after execution review
@@ -22,8 +27,8 @@ Resolve FIX-FIRST gaps from `review`: dispatch a fix subagent, re-review, repeat
 | Verdict | Condition | Action |
 |---------|-----------|--------|
 | SHIP | — | Done. Return to orchestrator. |
-| FIX-FIRST | loop < 2 | Increment loop, go to step 2. |
-| FIX-FIRST | loop = 2 | Stop fixing and run Escalation Diagnosis; max loops reached. |
+| FIX-FIRST | loop < B | Increment loop, go to step 2. |
+| FIX-FIRST | loop = B | Stop fixing and run Escalation Diagnosis; max loops reached. |
 | BLOCKED | — | Run Escalation Diagnosis and take the cause-specific route. |
 
 5. **Route the diagnosis:** report the remaining gaps with exact files, failing checks, cause class, and corrective route; the group's task stays `in_progress`.
@@ -59,14 +64,14 @@ The fix loop never mutates task state. The group's task stays `in_progress` thro
 ## Diagnosis / Appeal Format
 
 ```
-Fix loop exhausted (2/2). Group remains in progress.
+Fix loop exhausted (<B>/<B>). Group remains in progress.
 Remaining gaps:
 - [CRITICAL] <gap description> — <file>
 - [HIGH] <gap description> — <file>
 Cause: <model-capacity|missing-context|ambiguous-spec|env-tool-failure|overdesigned-plan>
 New evidence: <new output/diagnosis, or "none — model/effort escalation prohibited">
 Corrective route: <one cause-specific next step>
-Budget: attempts=<used>/2; effort_escalations=<used>/2
+Budget: attempts=<used>/<B>; effort_escalations=<used>/2
 Appeal: <reviewer/final-gate disagreement record, or "none">
 ```
 
@@ -79,12 +84,12 @@ Appeal: <reviewer/final-gate disagreement record, or "none">
 - [HIGH] sendMessage result not checked — dispatch.ts:541
 ```
 
-Loop 1: native delegation surface → fixer briefed with both gaps, the wish criteria, and `bun test` as validation. The fixer edits, runs the validation, reports its changes with outcomes, and ends `done`. Then native delegation surface → a fresh reviewer briefed to re-run `review` against the same criteria. SHIP → report success to the orchestrator. FIX-FIRST again → loop 2; after that, classify the cause and take its corrective route. A model or effort raise is permitted only for evidenced `model-capacity` within both caps. An `overdesigned-plan` diagnosis stops immediately and returns to planning instead.
+With the default `B=2`, loop 1 dispatches a fixer with both gaps, the wish criteria, and `bun test` as validation. The fixer edits, validates, reports outcomes, and ends `done`. Then dispatch a fresh reviewer against the same criteria. SHIP returns success; FIX-FIRST proceeds to loop 2, then classifies and routes the cause. A model or effort raise is permitted only for evidenced `model-capacity` within both caps. An `overdesigned-plan` diagnosis stops immediately and returns to planning instead.
 
 ## Rules
 - Tight scope: fix exactly the tagged gaps — no unrequested refactors, features, or drive-by cleanups.
 - Never fix and review in the same session — always separate subagents.
-- Never exceed 2 fix loops — stop, diagnose, and take the cause-specific route.
+- Never exceed the resolved fix-loop budget (default 2) — stop, diagnose, and take the cause-specific route.
 - Never use a fix loop to preserve optional machinery when a simpler plan satisfies the user stories.
 - Include the original wish criteria in every fix dispatch.
 - Identical gaps across loops = no progress; classify the cause. Repetition is not new evidence and never authorizes a model or effort raise.

--- a/plugins/genie/skills/genie/reference/lifecycle.md
+++ b/plugins/genie/skills/genie/reference/lifecycle.md
@@ -46,7 +46,7 @@ verdict that was not persisted does not advance the lifecycle.
 | `wish` | Convert a design into a structured plan at `.genie/wishes/<slug>/WISH.md` — scope, execution groups, acceptance criteria, validation | Idea is concrete, needs a plan |
 | `review` | Genie criteria gate — SHIP / FIX-FIRST / BLOCKED with severity-tagged gaps | Before and after `work`, or any plan/PR |
 | `work` | Execute an approved wish — dispatch native subagents per group in waves, fix loops, validation | Wish is SHIP-approved |
-| `fix` | Resolve FIX-FIRST gaps, re-review, escalate after 2 failed loops | Review returned FIX-FIRST |
+| `fix` | Resolve FIX-FIRST gaps, re-review, escalate after the resolved budget (default 2; higher-priority instructions may override it) | Review returned FIX-FIRST |
 | `council` | Multi-perspective deliberation with specialist viewpoints | Major design decisions, tradeoffs |
 | `refine` | Transform a brief into a production-ready prompt | Prompt needs sharpening |
 | `report` | Investigate bugs — trace, capture evidence, open a GitHub issue with confirmation | Bug reports |

--- a/plugins/genie/skills/pm/SKILL.md
+++ b/plugins/genie/skills/pm/SKILL.md
@@ -36,7 +36,7 @@ The lifecycle is owned by its skills — route to them, never restate them here:
 | Explore | `brainstorm` | Dispatch when scope is fuzzy |
 | Plan | `wish` | Dispatch when scope is clear; the wish creates per-group tasks |
 | Execute | `work` | Dispatch orchestration; waves come from WISH.md |
-| Validate | `review` | Gate every group; FIX-FIRST → `fix` (max 2 loops) |
+| Validate | `review` | Gate every group; FIX-FIRST → `fix` (resolved budget, default 2) |
 | Investigate | `trace`, `report` | Unknown failure: diagnose before fixing |
 | Ship | PR to `dev` | Request or consume task-scoped PR/merge authority; merge only when CI green + review SHIP |
 
@@ -51,7 +51,7 @@ Default chain: engineer → reviewer → qa → fix. Augment when the work calls
 | Docs deliverables in scope | docs subagent, parallel with engineer |
 | Architecture restructuring | refactor-briefed engineer for that group |
 | Failure with unknown root cause | `trace` before `fix` |
-| Review returns FIX-FIRST | Diagnose first; simplify an overdesigned plan, otherwise `fix` (max 2 loops, then escalate) |
+| Review returns FIX-FIRST | Diagnose first; simplify an overdesigned plan, otherwise `fix` (resolved budget, default 2, then escalate) |
 | High-stakes decision with tradeoffs | `council` (advisory) |
 
 ## Dispatch

--- a/plugins/genie/skills/review/SKILL.md
+++ b/plugins/genie/skills/review/SKILL.md
@@ -132,8 +132,8 @@ write. Never edit WISH.md, the brainstorm jar, or task state as the reviewer.
 ### FIX-FIRST loop
 1. Diagnose first. For `overdesigned-plan`, return to `brainstorm`/`wish` without consuming a fix attempt.
 2. Otherwise auto-invoke `fix` with the severity-tagged gap list.
-3. After `fix` completes, re-run `review` (max 2 fix loops).
-4. Still FIX-FIRST after 2 loops → return BLOCKED with an Escalation Diagnosis; never raise model or effort automatically.
+3. After `fix` completes, re-run `review` (resolved fix-loop budget; default 2 unless a higher-priority instruction overrides it).
+4. Still FIX-FIRST after the resolved budget → return BLOCKED with an Escalation Diagnosis; never raise model or effort automatically.
 
 When a failure's root cause is unclear, invoke `trace` before dispatching `fix` — `fix` then applies the cause-specific correction from the trace report. An unclear cause is not evidence of `model-capacity`.
 

--- a/plugins/genie/skills/work/SKILL.md
+++ b/plugins/genie/skills/work/SKILL.md
@@ -26,7 +26,7 @@ When you are spawned as a subagent for a group, your dispatch prompt carries the
    ```
    If two agents race one task, exactly one wins; the loser gets a conflict error and stands down.
 4. **Await completion — never poll:** background subagents notify you when they finish. Inspect `genie board --wish <slug>` on demand; completion is push, not poll.
-5. **Local review:** per finished group, dispatch a reviewer subagent (reviewer ≠ engineer) to run `review` against that group's acceptance criteria. The orchestrator appends each returned evidence block under `## Review Results`; the reviewer never edits it. Diagnose before fixing: `overdesigned-plan` returns to wish/design review without consuming a fix attempt; other FIX-FIRST gaps may use at most 2 fix loops.
+5. **Local review:** per finished group, dispatch a reviewer subagent (reviewer ≠ engineer) to run `review` against that group's acceptance criteria. The orchestrator appends each returned evidence block under `## Review Results`; the reviewer never edits it. Diagnose before fixing: `overdesigned-plan` returns to wish/design review without consuming a fix attempt; other FIX-FIRST gaps use the resolved fix-loop budget (default 2 unless a higher-priority instruction overrides it).
 6. **Quality review:** dispatch a reviewer for a quality pass (security, maintainability, perf). On FIX-FIRST, one fix loop.
 7. **Validate:** run the group's validation command yourself (Bash); record the output as evidence.
 8. **Group done** — only after clean review AND passing validation:

--- a/scripts/release-docs.test.ts
+++ b/scripts/release-docs.test.ts
@@ -970,6 +970,9 @@ describe('Group E release and documentation contracts', () => {
     expect(review).toContain('a HIGH gap');
     for (const lifecycleSkill of [review, fix, work]) expect(lifecycleSkill).toContain('`overdesigned-plan`');
     expect(fix).toContain('up to 2 loops');
+    expect(fix).toContain('higher-priority user or workspace instruction');
+    expect(review).toContain('resolved fix-loop budget');
+    expect(work).toContain('resolved fix-loop budget');
     expect(work).toContain('A user-approved simplification invalidates the superseded plan/review evidence');
   });
 

--- a/skills/dream/SKILL.md
+++ b/skills/dream/SKILL.md
@@ -61,7 +61,7 @@ Each worker, independently:
 
 1. Dispatch one reviewer subagent per PR via the native delegation surface (reviewer ≠ worker) to run `review` against the wish's acceptance criteria.
 2. Read bot comments critically — never blindly accept automated findings.
-3. On FIX-FIRST: diagnose first; return an overdesigned plan to wish/design review, otherwise dispatch `fix` for valid gaps (max 2 loops per PR). On another architectural issue: escalate in the report, no fix attempt.
+3. On FIX-FIRST: diagnose first; return an overdesigned plan to wish/design review, otherwise dispatch `fix` for valid gaps using the resolved fix-loop budget (default 2 unless a higher-priority instruction overrides it). On another architectural issue: escalate in the report, no fix attempt.
 4. CI must be green before proceeding — poll status, do not sleep.
 5. On SHIP: mark the PR review-complete.
 

--- a/skills/fix/SKILL.md
+++ b/skills/fix/SKILL.md
@@ -9,6 +9,11 @@ description: "Dispatch fix subagent for FIX-FIRST gaps from review, re-review, t
 
 Resolve FIX-FIRST gaps from `review`: dispatch a fix subagent, re-review, repeat up to 2 loops, then diagnose and route any unresolved failure.
 
+Two loops is the default budget. Before the first fix dispatch, resolve the budget once for the group: an explicit
+higher-priority user or workspace instruction may set another positive integer; otherwise use two. Call the resolved
+value `B`. An override changes only the attempt cap—it does not permit broader scope, repeated unchanged attempts, or
+skipping diagnosis and review.
+
 ## When to Use
 - `review` returned a **FIX-FIRST** verdict with CRITICAL or HIGH gaps
 - Orchestrator hands off unresolved gaps after execution review
@@ -22,8 +27,8 @@ Resolve FIX-FIRST gaps from `review`: dispatch a fix subagent, re-review, repeat
 | Verdict | Condition | Action |
 |---------|-----------|--------|
 | SHIP | — | Done. Return to orchestrator. |
-| FIX-FIRST | loop < 2 | Increment loop, go to step 2. |
-| FIX-FIRST | loop = 2 | Stop fixing and run Escalation Diagnosis; max loops reached. |
+| FIX-FIRST | loop < B | Increment loop, go to step 2. |
+| FIX-FIRST | loop = B | Stop fixing and run Escalation Diagnosis; max loops reached. |
 | BLOCKED | — | Run Escalation Diagnosis and take the cause-specific route. |
 
 5. **Route the diagnosis:** report the remaining gaps with exact files, failing checks, cause class, and corrective route; the group's task stays `in_progress`.
@@ -59,14 +64,14 @@ The fix loop never mutates task state. The group's task stays `in_progress` thro
 ## Diagnosis / Appeal Format
 
 ```
-Fix loop exhausted (2/2). Group remains in progress.
+Fix loop exhausted (<B>/<B>). Group remains in progress.
 Remaining gaps:
 - [CRITICAL] <gap description> — <file>
 - [HIGH] <gap description> — <file>
 Cause: <model-capacity|missing-context|ambiguous-spec|env-tool-failure|overdesigned-plan>
 New evidence: <new output/diagnosis, or "none — model/effort escalation prohibited">
 Corrective route: <one cause-specific next step>
-Budget: attempts=<used>/2; effort_escalations=<used>/2
+Budget: attempts=<used>/<B>; effort_escalations=<used>/2
 Appeal: <reviewer/final-gate disagreement record, or "none">
 ```
 
@@ -79,12 +84,12 @@ Appeal: <reviewer/final-gate disagreement record, or "none">
 - [HIGH] sendMessage result not checked — dispatch.ts:541
 ```
 
-Loop 1: native delegation surface → fixer briefed with both gaps, the wish criteria, and `bun test` as validation. The fixer edits, runs the validation, reports its changes with outcomes, and ends `done`. Then native delegation surface → a fresh reviewer briefed to re-run `review` against the same criteria. SHIP → report success to the orchestrator. FIX-FIRST again → loop 2; after that, classify the cause and take its corrective route. A model or effort raise is permitted only for evidenced `model-capacity` within both caps. An `overdesigned-plan` diagnosis stops immediately and returns to planning instead.
+With the default `B=2`, loop 1 dispatches a fixer with both gaps, the wish criteria, and `bun test` as validation. The fixer edits, validates, reports outcomes, and ends `done`. Then dispatch a fresh reviewer against the same criteria. SHIP returns success; FIX-FIRST proceeds to loop 2, then classifies and routes the cause. A model or effort raise is permitted only for evidenced `model-capacity` within both caps. An `overdesigned-plan` diagnosis stops immediately and returns to planning instead.
 
 ## Rules
 - Tight scope: fix exactly the tagged gaps — no unrequested refactors, features, or drive-by cleanups.
 - Never fix and review in the same session — always separate subagents.
-- Never exceed 2 fix loops — stop, diagnose, and take the cause-specific route.
+- Never exceed the resolved fix-loop budget (default 2) — stop, diagnose, and take the cause-specific route.
 - Never use a fix loop to preserve optional machinery when a simpler plan satisfies the user stories.
 - Include the original wish criteria in every fix dispatch.
 - Identical gaps across loops = no progress; classify the cause. Repetition is not new evidence and never authorizes a model or effort raise.

--- a/skills/genie/reference/lifecycle.md
+++ b/skills/genie/reference/lifecycle.md
@@ -46,7 +46,7 @@ verdict that was not persisted does not advance the lifecycle.
 | `wish` | Convert a design into a structured plan at `.genie/wishes/<slug>/WISH.md` — scope, execution groups, acceptance criteria, validation | Idea is concrete, needs a plan |
 | `review` | Genie criteria gate — SHIP / FIX-FIRST / BLOCKED with severity-tagged gaps | Before and after `work`, or any plan/PR |
 | `work` | Execute an approved wish — dispatch native subagents per group in waves, fix loops, validation | Wish is SHIP-approved |
-| `fix` | Resolve FIX-FIRST gaps, re-review, escalate after 2 failed loops | Review returned FIX-FIRST |
+| `fix` | Resolve FIX-FIRST gaps, re-review, escalate after the resolved budget (default 2; higher-priority instructions may override it) | Review returned FIX-FIRST |
 | `council` | Multi-perspective deliberation with specialist viewpoints | Major design decisions, tradeoffs |
 | `refine` | Transform a brief into a production-ready prompt | Prompt needs sharpening |
 | `report` | Investigate bugs — trace, capture evidence, open a GitHub issue with confirmation | Bug reports |

--- a/skills/pm/SKILL.md
+++ b/skills/pm/SKILL.md
@@ -36,7 +36,7 @@ The lifecycle is owned by its skills — route to them, never restate them here:
 | Explore | `brainstorm` | Dispatch when scope is fuzzy |
 | Plan | `wish` | Dispatch when scope is clear; the wish creates per-group tasks |
 | Execute | `work` | Dispatch orchestration; waves come from WISH.md |
-| Validate | `review` | Gate every group; FIX-FIRST → `fix` (max 2 loops) |
+| Validate | `review` | Gate every group; FIX-FIRST → `fix` (resolved budget, default 2) |
 | Investigate | `trace`, `report` | Unknown failure: diagnose before fixing |
 | Ship | PR to `dev` | Request or consume task-scoped PR/merge authority; merge only when CI green + review SHIP |
 
@@ -51,7 +51,7 @@ Default chain: engineer → reviewer → qa → fix. Augment when the work calls
 | Docs deliverables in scope | docs subagent, parallel with engineer |
 | Architecture restructuring | refactor-briefed engineer for that group |
 | Failure with unknown root cause | `trace` before `fix` |
-| Review returns FIX-FIRST | Diagnose first; simplify an overdesigned plan, otherwise `fix` (max 2 loops, then escalate) |
+| Review returns FIX-FIRST | Diagnose first; simplify an overdesigned plan, otherwise `fix` (resolved budget, default 2, then escalate) |
 | High-stakes decision with tradeoffs | `council` (advisory) |
 
 ## Dispatch

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -132,8 +132,8 @@ write. Never edit WISH.md, the brainstorm jar, or task state as the reviewer.
 ### FIX-FIRST loop
 1. Diagnose first. For `overdesigned-plan`, return to `brainstorm`/`wish` without consuming a fix attempt.
 2. Otherwise auto-invoke `fix` with the severity-tagged gap list.
-3. After `fix` completes, re-run `review` (max 2 fix loops).
-4. Still FIX-FIRST after 2 loops → return BLOCKED with an Escalation Diagnosis; never raise model or effort automatically.
+3. After `fix` completes, re-run `review` (resolved fix-loop budget; default 2 unless a higher-priority instruction overrides it).
+4. Still FIX-FIRST after the resolved budget → return BLOCKED with an Escalation Diagnosis; never raise model or effort automatically.
 
 When a failure's root cause is unclear, invoke `trace` before dispatching `fix` — `fix` then applies the cause-specific correction from the trace report. An unclear cause is not evidence of `model-capacity`.
 

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -26,7 +26,7 @@ When you are spawned as a subagent for a group, your dispatch prompt carries the
    ```
    If two agents race one task, exactly one wins; the loser gets a conflict error and stands down.
 4. **Await completion — never poll:** background subagents notify you when they finish. Inspect `genie board --wish <slug>` on demand; completion is push, not poll.
-5. **Local review:** per finished group, dispatch a reviewer subagent (reviewer ≠ engineer) to run `review` against that group's acceptance criteria. The orchestrator appends each returned evidence block under `## Review Results`; the reviewer never edits it. Diagnose before fixing: `overdesigned-plan` returns to wish/design review without consuming a fix attempt; other FIX-FIRST gaps may use at most 2 fix loops.
+5. **Local review:** per finished group, dispatch a reviewer subagent (reviewer ≠ engineer) to run `review` against that group's acceptance criteria. The orchestrator appends each returned evidence block under `## Review Results`; the reviewer never edits it. Diagnose before fixing: `overdesigned-plan` returns to wish/design review without consuming a fix attempt; other FIX-FIRST gaps use the resolved fix-loop budget (default 2 unless a higher-priority instruction overrides it).
 6. **Quality review:** dispatch a reviewer for a quality pass (security, maintainability, perf). On FIX-FIRST, one fix loop.
 7. **Validate:** run the group's validation command yourself (Bash); record the output as evidence.
 8. **Group done** — only after clean review AND passing validation:


### PR DESCRIPTION
## Summary

- keep Genie's default FIX-FIRST budget at two loops
- allow an explicit higher-priority user or workspace instruction to select another positive loop budget
- resolve the budget once per group and use it consistently across fix, review, work, PM, dream, and lifecycle guidance
- preserve the existing safety boundaries: overrides do not expand scope, permit unchanged retries, skip diagnosis, or skip independent re-review

## Why

Different users and workspaces may deliberately choose a larger bounded retry budget without needing to maintain a fork that rewrites Genie's default policy. This makes that instruction-layer override explicit while leaving existing behavior unchanged for everyone else.

## Validation

- `bunx biome check` on all changed files
- `bun run skills:lint`
- `bun test scripts/release-docs.test.ts scripts/sync-plugin-skills.test.ts` — 50 passed, 0 failed
- push hook gate: typecheck, lint, dead-code, skill/wish lint, complexity budget, council workflow, hook parity/content, and plugin executable checks
