### PR TITLE
feat: add strict Orca lifecycle mode guards

### DIFF
--- a/src/lib/orchestration-mode.test.ts
+++ b/src/lib/orchestration-mode.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { GenieConfigSchema } from '../types/genie-config.js';
+import {
+  LocalLifecycleDisabledError,
+  assertLocalLifecycleEnabled,
+  resolveOrchestrationMode,
+} from './orchestration-mode.js';
+
+const originalGenieHome = process.env.GENIE_HOME;
+const roots: string[] = [];
+
+function fixture(config?: unknown): string {
+  const root = mkdtempSync(join(tmpdir(), 'genie-orchestration-mode-'));
+  roots.push(root);
+  process.env.GENIE_HOME = join(root, '.genie-home');
+  if (config !== undefined) {
+    mkdirSync(process.env.GENIE_HOME, { recursive: true });
+    writeFileSync(join(process.env.GENIE_HOME, 'config.json'), JSON.stringify(config));
+  }
+  return root;
+}
+
+afterEach(() => {
+  if (originalGenieHome === undefined) process.env.GENIE_HOME = undefined;
+  else process.env.GENIE_HOME = originalGenieHome;
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('orchestration authority mode', () => {
+  test('the config schema accepts exactly standalone and orca', () => {
+    expect(GenieConfigSchema.parse({}).orchestration.mode).toBe('standalone');
+    expect(GenieConfigSchema.parse({ orchestration: { mode: 'orca' } }).orchestration.mode).toBe('orca');
+    expect(() => GenieConfigSchema.parse({ orchestration: { mode: 'automatic' } })).toThrow();
+  });
+
+  test('absent and explicit standalone configurations resolve to standalone', () => {
+    fixture();
+    expect(resolveOrchestrationMode()).toBe('standalone');
+    fixture({ orchestration: { mode: 'standalone' } });
+    expect(resolveOrchestrationMode()).toBe('standalone');
+  });
+
+  test('Orca mode is explicit and returns the stable typed lifecycle refusal', () => {
+    fixture({ orchestration: { mode: 'orca' } });
+    expect(resolveOrchestrationMode()).toBe('orca');
+    expect(() => assertLocalLifecycleEnabled()).toThrow(LocalLifecycleDisabledError);
+    try {
+      assertLocalLifecycleEnabled();
+    } catch (error) {
+      expect(error).toBeInstanceOf(LocalLifecycleDisabledError);
+      expect((error as LocalLifecycleDisabledError).code).toBe('local_lifecycle_disabled_in_orca_mode');
+    }
+  });
+});

--- a/src/lib/orchestration-mode.test.ts
+++ b/src/lib/orchestration-mode.test.ts
@@ -63,6 +63,7 @@ describe('orchestration authority mode', () => {
 
   for (const config of [
     { orchestration: { mode: 'automatic' }, runtime: { defaultAgent: 'invalid' } },
+    { orchestration: {} },
     { orchestration: { mod: 'orca' } },
     { orchestration: { mode: 'orca', extra: true } },
   ]) {

--- a/src/lib/orchestration-mode.test.ts
+++ b/src/lib/orchestration-mode.test.ts
@@ -61,15 +61,21 @@ describe('orchestration authority mode', () => {
     expect(resolveOrchestrationMode()).toBe('standalone');
   });
 
-  test('malformed authority selection fails closed with a stable typed error', () => {
-    fixture({ orchestration: { mode: 'automatic' }, runtime: { defaultAgent: 'invalid' } });
-    expect(() => resolveOrchestrationMode()).toThrow(InvalidOrchestrationAuthorityError);
-    try {
-      assertLocalLifecycleEnabled();
-    } catch (error) {
-      expect(error).toBeInstanceOf(InvalidOrchestrationAuthorityError);
-      expect((error as InvalidOrchestrationAuthorityError).code).toBe('invalid_orchestration_authority');
-      expect((error as Error).message).toContain('orchestration.mode must be either "standalone" or "orca"');
-    }
-  });
+  for (const config of [
+    { orchestration: { mode: 'automatic' }, runtime: { defaultAgent: 'invalid' } },
+    { orchestration: { mod: 'orca' } },
+    { orchestration: { mode: 'orca', extra: true } },
+  ]) {
+    test(`malformed authority selection fails closed: ${JSON.stringify(config.orchestration)}`, () => {
+      fixture(config);
+      expect(() => resolveOrchestrationMode()).toThrow(InvalidOrchestrationAuthorityError);
+      try {
+        assertLocalLifecycleEnabled();
+      } catch (error) {
+        expect(error).toBeInstanceOf(InvalidOrchestrationAuthorityError);
+        expect((error as InvalidOrchestrationAuthorityError).code).toBe('invalid_orchestration_authority');
+        expect((error as Error).message).toContain('orchestration.mode must be either "standalone" or "orca"');
+      }
+    });
+  }
 });

--- a/src/lib/orchestration-mode.test.ts
+++ b/src/lib/orchestration-mode.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { GenieConfigSchema } from '../types/genie-config.js';
 import {
+  InvalidOrchestrationAuthorityError,
   LocalLifecycleDisabledError,
   assertLocalLifecycleEnabled,
   resolveOrchestrationMode,
@@ -44,7 +45,7 @@ describe('orchestration authority mode', () => {
   });
 
   test('Orca mode is explicit and returns the stable typed lifecycle refusal', () => {
-    fixture({ orchestration: { mode: 'orca' } });
+    fixture({ orchestration: { mode: 'orca' }, runtime: { defaultAgent: 'invalid' } });
     expect(resolveOrchestrationMode()).toBe('orca');
     expect(() => assertLocalLifecycleEnabled()).toThrow(LocalLifecycleDisabledError);
     try {
@@ -52,6 +53,23 @@ describe('orchestration authority mode', () => {
     } catch (error) {
       expect(error).toBeInstanceOf(LocalLifecycleDisabledError);
       expect((error as LocalLifecycleDisabledError).code).toBe('local_lifecycle_disabled_in_orca_mode');
+    }
+  });
+
+  test('authority resolution ignores unrelated malformed config fields', () => {
+    fixture({ orchestration: { mode: 'standalone' }, runtime: { defaultAgent: 'invalid' } });
+    expect(resolveOrchestrationMode()).toBe('standalone');
+  });
+
+  test('malformed authority selection fails closed with a stable typed error', () => {
+    fixture({ orchestration: { mode: 'automatic' }, runtime: { defaultAgent: 'invalid' } });
+    expect(() => resolveOrchestrationMode()).toThrow(InvalidOrchestrationAuthorityError);
+    try {
+      assertLocalLifecycleEnabled();
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidOrchestrationAuthorityError);
+      expect((error as InvalidOrchestrationAuthorityError).code).toBe('invalid_orchestration_authority');
+      expect((error as Error).message).toContain('orchestration.mode must be either "standalone" or "orca"');
     }
   });
 });

--- a/src/lib/orchestration-mode.ts
+++ b/src/lib/orchestration-mode.ts
@@ -10,7 +10,7 @@ export const INVALID_ORCHESTRATION_AUTHORITY_CODE = 'invalid_orchestration_autho
 
 const OrchestrationAuthoritySchema = z
   .object({
-    orchestration: OrchestrationConfigSchema.optional(),
+    orchestration: OrchestrationConfigSchema.strict().optional(),
   })
   .passthrough();
 

--- a/src/lib/orchestration-mode.ts
+++ b/src/lib/orchestration-mode.ts
@@ -1,10 +1,27 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { GenieConfigSchema } from '../types/genie-config.js';
+import { z } from 'zod';
+import { OrchestrationConfigSchema } from '../types/genie-config.js';
 import { getGenieConfigPath } from './genie-config.js';
 
 export type OrchestrationMode = 'standalone' | 'orca';
 
 export const LOCAL_LIFECYCLE_DISABLED_CODE = 'local_lifecycle_disabled_in_orca_mode' as const;
+export const INVALID_ORCHESTRATION_AUTHORITY_CODE = 'invalid_orchestration_authority' as const;
+
+const OrchestrationAuthoritySchema = z
+  .object({
+    orchestration: OrchestrationConfigSchema.optional(),
+  })
+  .passthrough();
+
+export class InvalidOrchestrationAuthorityError extends Error {
+  readonly code = INVALID_ORCHESTRATION_AUTHORITY_CODE;
+
+  constructor() {
+    super(`${INVALID_ORCHESTRATION_AUTHORITY_CODE}: config orchestration.mode must be either "standalone" or "orca"`);
+    this.name = 'InvalidOrchestrationAuthorityError';
+  }
+}
 
 export class LocalLifecycleDisabledError extends Error {
   readonly code = LOCAL_LIFECYCLE_DISABLED_CODE;
@@ -21,12 +38,17 @@ export class LocalLifecycleDisabledError extends Error {
 export function resolveOrchestrationMode(): OrchestrationMode {
   const path = getGenieConfigPath();
   if (!existsSync(path)) return 'standalone';
+
+  let raw: unknown;
   try {
-    const parsed = GenieConfigSchema.safeParse(JSON.parse(readFileSync(path, 'utf8')));
-    return parsed.success ? parsed.data.orchestration.mode : 'standalone';
+    raw = JSON.parse(readFileSync(path, 'utf8'));
   } catch {
-    return 'standalone';
+    throw new InvalidOrchestrationAuthorityError();
   }
+
+  const parsed = OrchestrationAuthoritySchema.safeParse(raw);
+  if (!parsed.success) throw new InvalidOrchestrationAuthorityError();
+  return parsed.data.orchestration?.mode ?? 'standalone';
 }
 
 /** Fail closed before any local lifecycle store can be opened or changed. */

--- a/src/lib/orchestration-mode.ts
+++ b/src/lib/orchestration-mode.ts
@@ -1,0 +1,35 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { GenieConfigSchema } from '../types/genie-config.js';
+import { getGenieConfigPath } from './genie-config.js';
+
+export type OrchestrationMode = 'standalone' | 'orca';
+
+export const LOCAL_LIFECYCLE_DISABLED_CODE = 'local_lifecycle_disabled_in_orca_mode' as const;
+
+export class LocalLifecycleDisabledError extends Error {
+  readonly code = LOCAL_LIFECYCLE_DISABLED_CODE;
+
+  constructor() {
+    super(
+      `${LOCAL_LIFECYCLE_DISABLED_CODE}: local Genie lifecycle state is disabled because orchestration.mode is "orca"`,
+    );
+    this.name = 'LocalLifecycleDisabledError';
+  }
+}
+
+/** Resolve lifecycle authority without creating or changing configuration. */
+export function resolveOrchestrationMode(): OrchestrationMode {
+  const path = getGenieConfigPath();
+  if (!existsSync(path)) return 'standalone';
+  try {
+    const parsed = GenieConfigSchema.safeParse(JSON.parse(readFileSync(path, 'utf8')));
+    return parsed.success ? parsed.data.orchestration.mode : 'standalone';
+  } catch {
+    return 'standalone';
+  }
+}
+
+/** Fail closed before any local lifecycle store can be opened or changed. */
+export function assertLocalLifecycleEnabled(): void {
+  if (resolveOrchestrationMode() === 'orca') throw new LocalLifecycleDisabledError();
+}

--- a/src/lib/orchestration-mode.ts
+++ b/src/lib/orchestration-mode.ts
@@ -1,6 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { z } from 'zod';
-import { OrchestrationConfigSchema } from '../types/genie-config.js';
 import { getGenieConfigPath } from './genie-config.js';
 
 export type OrchestrationMode = 'standalone' | 'orca';
@@ -10,7 +9,10 @@ export const INVALID_ORCHESTRATION_AUTHORITY_CODE = 'invalid_orchestration_autho
 
 const OrchestrationAuthoritySchema = z
   .object({
-    orchestration: OrchestrationConfigSchema.strict().optional(),
+    orchestration: z
+      .object({ mode: z.enum(['standalone', 'orca']) })
+      .strict()
+      .optional(),
   })
   .passthrough();
 

--- a/src/lib/v5/authority-barriers.test.ts
+++ b/src/lib/v5/authority-barriers.test.ts
@@ -12,7 +12,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { openReadonlyHandle } from '../../term-commands/context.js';
-import { LocalLifecycleDisabledError } from '../orchestration-mode.js';
+import { InvalidOrchestrationAuthorityError, LocalLifecycleDisabledError } from '../orchestration-mode.js';
 import { openDb } from './genie-db.js';
 import { openReadonlyDb } from './mcp-tools.js';
 import { writeSnapshotFile } from './roadmap-sync.js';
@@ -21,15 +21,17 @@ const originalGenieHome = process.env.GENIE_HOME;
 const roots: string[] = [];
 const GENIE = join(import.meta.dir, '..', '..', 'genie.ts');
 
-function orcaFixture(): string {
+function authorityFixture(config: unknown = { orchestration: { mode: 'orca' } }): string {
   const root = mkdtempSync(join(tmpdir(), 'genie-authority-barrier-'));
   roots.push(root);
   const home = join(root, 'home');
   mkdirSync(home, { recursive: true });
-  writeFileSync(join(home, 'config.json'), JSON.stringify({ orchestration: { mode: 'orca' } }));
+  writeFileSync(join(home, 'config.json'), JSON.stringify(config));
   process.env.GENIE_HOME = home;
   return root;
 }
+
+const orcaFixture = (): string => authorityFixture();
 
 afterEach(() => {
   if (originalGenieHome === undefined) process.env.GENIE_HOME = undefined;
@@ -120,4 +122,52 @@ describe('Orca authority barriers', () => {
     expect(existsSync(dbPath)).toBe(true);
     expect(JSON.parse(readFileSync(roadmap, 'utf8'))).toEqual({ version: 1 });
   });
+
+  for (const fixtureCase of [
+    {
+      name: 'explicit Orca with an unrelated invalid field',
+      config: { orchestration: { mode: 'orca' }, runtime: { defaultAgent: 'invalid' } },
+      error: LocalLifecycleDisabledError,
+      code: 'local_lifecycle_disabled_in_orca_mode',
+    },
+    {
+      name: 'malformed authority field',
+      config: { orchestration: { mode: 'automatic' } },
+      error: InvalidOrchestrationAuthorityError,
+      code: 'invalid_orchestration_authority',
+    },
+  ] as const) {
+    test(`${fixtureCase.name} refuses CLI and low-level operations without lifecycle mutations`, async () => {
+      const root = authorityFixture(fixtureCase.config);
+      const repo = join(root, 'repo');
+      const dbPath = join(repo, '.genie', 'genie.db');
+      const roadmap = join(repo, '.genie', 'roadmap.json');
+      mkdirSync(repo);
+
+      for (const args of [['task', 'list'], ['board'], ['idea', 'do not persist']]) {
+        const proc = Bun.spawn(['bun', GENIE, ...args], {
+          cwd: repo,
+          env: { ...process.env, GENIE_HOME: process.env.GENIE_HOME as string, NO_COLOR: '1' },
+          stdout: 'pipe',
+          stderr: 'pipe',
+        });
+        const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
+        expect(exitCode).toBe(1);
+        expect(stderr).toContain(fixtureCase.code);
+        expect(existsSync(join(repo, '.genie'))).toBe(false);
+      }
+
+      expect(() => openDb({ path: dbPath })).toThrow(fixtureCase.error);
+      expect(() => openReadonlyHandle(dbPath)).toThrow(fixtureCase.error);
+      expect(() => openReadonlyDb(repo)).toThrow(fixtureCase.error);
+      expect(() => writeSnapshotFile(roadmap, { forbidden: true })).toThrow(fixtureCase.error);
+
+      expect(existsSync(dbPath)).toBe(false);
+      expect(existsSync(`${dbPath}-wal`)).toBe(false);
+      expect(existsSync(`${dbPath}-shm`)).toBe(false);
+      expect(existsSync(roadmap)).toBe(false);
+      expect(existsSync(`${roadmap}.${process.pid}.tmp`)).toBe(false);
+      expect(existsSync(join(repo, '.genie'))).toBe(false);
+    });
+  }
 });

--- a/src/lib/v5/authority-barriers.test.ts
+++ b/src/lib/v5/authority-barriers.test.ts
@@ -136,6 +136,18 @@ describe('Orca authority barriers', () => {
       error: InvalidOrchestrationAuthorityError,
       code: 'invalid_orchestration_authority',
     },
+    {
+      name: 'misspelled authority field',
+      config: { orchestration: { mod: 'orca' } },
+      error: InvalidOrchestrationAuthorityError,
+      code: 'invalid_orchestration_authority',
+    },
+    {
+      name: 'extra authority field',
+      config: { orchestration: { mode: 'orca', extra: true } },
+      error: InvalidOrchestrationAuthorityError,
+      code: 'invalid_orchestration_authority',
+    },
   ] as const) {
     test(`${fixtureCase.name} refuses CLI and low-level operations without lifecycle mutations`, async () => {
       const root = authorityFixture(fixtureCase.config);

--- a/src/lib/v5/authority-barriers.test.ts
+++ b/src/lib/v5/authority-barriers.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { openReadonlyHandle } from '../../term-commands/context.js';
+import { LocalLifecycleDisabledError } from '../orchestration-mode.js';
+import { openDb } from './genie-db.js';
+import { openReadonlyDb } from './mcp-tools.js';
+import { writeSnapshotFile } from './roadmap-sync.js';
+
+const originalGenieHome = process.env.GENIE_HOME;
+const roots: string[] = [];
+const GENIE = join(import.meta.dir, '..', '..', 'genie.ts');
+
+function orcaFixture(): string {
+  const root = mkdtempSync(join(tmpdir(), 'genie-authority-barrier-'));
+  roots.push(root);
+  const home = join(root, 'home');
+  mkdirSync(home, { recursive: true });
+  writeFileSync(join(home, 'config.json'), JSON.stringify({ orchestration: { mode: 'orca' } }));
+  process.env.GENIE_HOME = home;
+  return root;
+}
+
+afterEach(() => {
+  if (originalGenieHome === undefined) process.env.GENIE_HOME = undefined;
+  else process.env.GENIE_HOME = originalGenieHome;
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('Orca authority barriers', () => {
+  test('task, board, and idea CLI routes return the stable refusal without creating repository state', async () => {
+    const root = orcaFixture();
+    const repo = join(root, 'repo');
+    mkdirSync(repo);
+
+    for (const args of [['task', 'list'], ['board'], ['idea', 'do not persist']]) {
+      const proc = Bun.spawn(['bun', GENIE, ...args], {
+        cwd: repo,
+        env: { ...process.env, GENIE_HOME: process.env.GENIE_HOME as string, NO_COLOR: '1' },
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+      const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain('local_lifecycle_disabled_in_orca_mode');
+      expect(existsSync(join(repo, '.genie'))).toBe(false);
+    }
+  });
+
+  test('direct and indirect writable DB opens fail before SQLite creates any filesystem state', () => {
+    const root = orcaFixture();
+    const direct = join(root, 'direct', 'genie.db');
+    const repo = join(root, 'repo');
+    mkdirSync(repo);
+
+    expect(() => openDb({ path: direct })).toThrow(LocalLifecycleDisabledError);
+    expect(() => openDb({ cwd: repo })).toThrow(LocalLifecycleDisabledError);
+    expect(existsSync(join(root, 'direct'))).toBe(false);
+    expect(existsSync(join(repo, '.genie'))).toBe(false);
+  });
+
+  test('context and MCP read paths refuse an existing local DB without creating sidecars or changing bytes', () => {
+    const root = mkdtempSync(join(tmpdir(), 'genie-authority-existing-'));
+    roots.push(root);
+    const home = join(root, 'home');
+    const dbPath = join(root, 'repo', '.genie', 'genie.db');
+    process.env.GENIE_HOME = home;
+    const db = openDb({ path: dbPath });
+    db.close();
+    mkdirSync(home, { recursive: true });
+    writeFileSync(join(home, 'config.json'), JSON.stringify({ orchestration: { mode: 'orca' } }));
+    const directory = join(root, 'repo', '.genie');
+    const beforeNames = readdirSync(directory);
+    const beforeBytes = readFileSync(dbPath);
+    const beforeMtime = statSync(dbPath).mtimeMs;
+
+    expect(() => openReadonlyHandle(dbPath)).toThrow(LocalLifecycleDisabledError);
+    expect(() => openReadonlyDb(join(root, 'repo'))).toThrow(LocalLifecycleDisabledError);
+
+    expect(readdirSync(directory)).toEqual(beforeNames);
+    expect(readFileSync(dbPath)).toEqual(beforeBytes);
+    expect(statSync(dbPath).mtimeMs).toBe(beforeMtime);
+  });
+
+  test('roadmap writes fail before bytes, metadata, or temporary siblings change', () => {
+    const root = orcaFixture();
+    const roadmap = join(root, 'roadmap.json');
+    writeFileSync(roadmap, '{"sentinel":true}\n');
+    const before = statSync(roadmap);
+
+    expect(() => writeSnapshotFile(roadmap, { sentinel: false })).toThrow(LocalLifecycleDisabledError);
+
+    const after = statSync(roadmap);
+    expect(readFileSync(roadmap, 'utf8')).toBe('{"sentinel":true}\n');
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+    expect(existsSync(`${roadmap}.${process.pid}.tmp`)).toBe(false);
+  });
+
+  test('standalone remains the default for DB creation and roadmap writes', () => {
+    const root = mkdtempSync(join(tmpdir(), 'genie-authority-standalone-'));
+    roots.push(root);
+    process.env.GENIE_HOME = join(root, 'absent-home');
+    const dbPath = join(root, 'repo', '.genie', 'genie.db');
+    const roadmap = join(root, 'repo', '.genie', 'roadmap.json');
+
+    const db = openDb({ path: dbPath });
+    db.close();
+    writeSnapshotFile(roadmap, { version: 1 });
+
+    expect(existsSync(dbPath)).toBe(true);
+    expect(JSON.parse(readFileSync(roadmap, 'utf8'))).toEqual({ version: 1 });
+  });
+});

--- a/src/lib/v5/authority-barriers.test.ts
+++ b/src/lib/v5/authority-barriers.test.ts
@@ -137,6 +137,12 @@ describe('Orca authority barriers', () => {
       code: 'invalid_orchestration_authority',
     },
     {
+      name: 'missing authority mode',
+      config: { orchestration: {} },
+      error: InvalidOrchestrationAuthorityError,
+      code: 'invalid_orchestration_authority',
+    },
+    {
       name: 'misspelled authority field',
       config: { orchestration: { mod: 'orca' } },
       error: InvalidOrchestrationAuthorityError,

--- a/src/lib/v5/genie-db.ts
+++ b/src/lib/v5/genie-db.ts
@@ -17,6 +17,7 @@ import type { Database } from 'bun:sqlite';
 import { execFileSync, execSync } from 'node:child_process';
 import { existsSync, lstatSync, realpathSync } from 'node:fs';
 import { basename, dirname, join, normalize } from 'node:path';
+import { assertLocalLifecycleEnabled } from '../orchestration-mode.js';
 import { openSqlite } from './sqlite-open.js';
 
 // Concurrency + typed-error primitives now live in sqlite-open.ts (shared with
@@ -402,6 +403,7 @@ export interface OpenOptions {
  * errors. Idempotent: safe to call on every CLI invocation.
  */
 export function openDb(opts: OpenOptions = {}): Database {
+  assertLocalLifecycleEnabled();
   return openSqlite({
     path: opts.path ?? resolveDbPath(opts.cwd),
     schemaVersion: CURRENT_SCHEMA_VERSION,

--- a/src/lib/v5/mcp-tools.ts
+++ b/src/lib/v5/mcp-tools.ts
@@ -20,6 +20,7 @@
 import { constants, Database } from 'bun:sqlite';
 import { execFileSync } from 'node:child_process';
 import { accessSync, constants as fsConstants } from 'node:fs';
+import { assertLocalLifecycleEnabled } from '../orchestration-mode.js';
 import {
   BusyDbError,
   type ProjectContext,
@@ -127,6 +128,7 @@ export function openReadonlyDb(
   target?: string | ProjectDatabaseBinding,
   dependencies: ReadonlyDbOpenDependencies = {},
 ): Database | null {
+  assertLocalLifecycleEnabled();
   const initial =
     typeof target === 'object'
       ? resolveProjectDatabaseBinding(target.logicalPath, target)

--- a/src/lib/v5/roadmap-sync.ts
+++ b/src/lib/v5/roadmap-sync.ts
@@ -23,6 +23,7 @@ import type { Database } from 'bun:sqlite';
 import { createHash } from 'node:crypto';
 import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { assertLocalLifecycleEnabled } from '../orchestration-mode.js';
 import { resolveRepoRoot, resolveRoadmapPath } from './genie-db.js';
 import { SnapshotFormatError, type StateExport, exportState, hasOperationalState, importState } from './task-state.js';
 
@@ -73,6 +74,7 @@ function readMarker(path: string): SyncMarker | null {
 }
 
 function writeMarker(path: string, marker: SyncMarker): void {
+  assertLocalLifecycleEnabled();
   writeFileSync(path, `${JSON.stringify(marker, null, 2)}\n`);
 }
 
@@ -86,6 +88,7 @@ function serializeSnapshot(state: unknown): string {
  * canonical board would otherwise read as invalid JSON on the next sync.
  */
 export function writeSnapshotFile(target: string, state: unknown): void {
+  assertLocalLifecycleEnabled();
   const tmp = `${target}.${process.pid}.tmp`;
   writeFileSync(tmp, serializeSnapshot(state));
   renameSync(tmp, target);
@@ -102,6 +105,7 @@ export function writeSnapshotFile(target: string, state: unknown): void {
  * produced `state` and wrote the file.
  */
 export function recordExportBaseline(state: StateExport, cwd?: string): void {
+  assertLocalLifecycleEnabled();
   // The file holds exactly `serializeSnapshot(state)`, and sync hashes the
   // PARSED file — structurally identical to `state`, so one hash covers both.
   const hash = canonicalHash(state);
@@ -116,6 +120,7 @@ export function recordExportBaseline(state: StateExport, cwd?: string): void {
  * happen under the caller's immediate transaction, alongside the import itself.
  */
 export function recordImportBaseline(db: Database, snapshot: unknown, cwd?: string): void {
+  assertLocalLifecycleEnabled();
   writeMarker(resolveSyncMarkerPath(cwd), {
     fileHash: canonicalHash(snapshot),
     dbHash: canonicalHash(roadmapSnapshot(db)),
@@ -129,6 +134,7 @@ export function recordImportBaseline(db: Database, snapshot: unknown, cwd?: stri
  * on pull (post-merge / post-rewrite) and before commit (pre-commit).
  */
 export function syncRoadmap(db: Database, cwd?: string): SyncResult {
+  assertLocalLifecycleEnabled();
   // BEGIN IMMEDIATE for the whole compare-and-act sequence: the db-side hash
   // must not go stale between comparison and a replace-import, or a task write
   // committed in that window would be silently destroyed. Holding the write

--- a/src/term-commands/context.ts
+++ b/src/term-commands/context.ts
@@ -56,6 +56,7 @@ import { Database } from 'bun:sqlite';
 import { existsSync, statSync } from 'node:fs';
 import type { Command } from 'commander';
 import { resolveGitWorktreeRoot } from '../lib/codex-project-mcp.js';
+import { assertLocalLifecycleEnabled } from '../lib/orchestration-mode.js';
 import {
   type IntegrationBranch,
   peelCommit,
@@ -175,6 +176,7 @@ function failClosed(code: string, reason: string): never {
  * wrong about the resolved base policy.
  */
 export function openReadonlyHandle(dbPath: string): Database | null {
+  assertLocalLifecycleEnabled();
   try {
     let walBytes = 0;
     try {

--- a/src/types/genie-config.ts
+++ b/src/types/genie-config.ts
@@ -59,6 +59,10 @@ const RuntimeConfigSchema = z.object({
   defaultAgent: z.enum(['auto', 'claude', 'codex']).default('auto'),
 });
 
+export const OrchestrationConfigSchema = z.object({
+  mode: z.enum(['standalone', 'orca']).default('standalone'),
+});
+
 // Worker profile configuration
 // Defines how to launch a Claude worker
 // Uses preprocess to migrate legacy "claudio" launcher values to "claude"
@@ -213,6 +217,7 @@ export const GenieConfigSchema = z.object({
   shortcuts: ShortcutsConfigSchema.default({}),
   codex: CodexConfigSchema.optional(),
   runtime: RuntimeConfigSchema.default({}),
+  orchestration: OrchestrationConfigSchema.default({}),
   installMethod: z.enum(['source', 'npm', 'bun']).optional(),
   // Release channel preference. Canonical values: 'latest' (stable) or
   // 'dev' (pre-release). Two read-time aliases are accepted so configs


### PR DESCRIPTION
## Summary

- add strict, authority-only standalone/Orca mode resolution
- block lifecycle DB, read-only MCP, context, and roadmap entry points in Orca mode before state access
- prove absent/invalid/misspelled/extra mode configurations leave no Genie state

## Verification

- `bun test src/lib/orchestration-mode.test.ts src/lib/v5/authority-barriers.test.ts` — 18 tests, 145 assertions
- `bun run check` reached the pre-existing checked-out mode mismatch (`plugins/genie/scripts/validate-wish.cjs` is 0700; tree requires 0755) after typecheck, Biome, knip, skill/wish, complexity and council gates
- independent review: SHIP at `f8fb31c4b10dd8c2c8d8ee5d6bfacd228977a42c`

Requires the later adapter/plugin PRs for a complete Orca transport; this PR only establishes the fail-closed local-state authority boundary.