### PR TITLE
feat: add safe public Orca orchestration adapter

### DIFF
--- a/src/lib/orca-orchestration-adapter.test.ts
+++ b/src/lib/orca-orchestration-adapter.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  MAX_ORCA_STDERR_BYTES,
+  MAX_ORCA_STDOUT_BYTES,
+  OrcaAdapterError,
+  type OrcaOperation,
+  type OrcaProcessExecutor,
+  buildOrcaOrchestrationArgv,
+  createOrcaOrchestrationAdapter,
+  resolveOrcaExecutable,
+} from './orca-orchestration-adapter.js';
+
+const cases: ReadonlyArray<[string, OrcaOperation, readonly string[]]> = [
+  ['run-create', { operation: 'run-create', objective: 'Ship it' }, ['--objective', 'Ship it']],
+  ['run-list', { operation: 'run-list', limit: 10, cursor: 'cursor_1' }, ['--limit', '10', '--cursor', 'cursor_1']],
+  ['run-show', { operation: 'run-show', id: 'run_1' }, ['--id', 'run_1']],
+  ['run-current', { operation: 'run-current' }, []],
+  ['run-use', { operation: 'run-use', id: 'run_1' }, ['--id', 'run_1']],
+  [
+    'task-create',
+    { operation: 'task-create', spec: 'Implement', title: 'Adapter', deps: ['task_a'], parent: 'task_p' },
+    ['--spec', 'Implement', '--task-title', 'Adapter', '--deps', '["task_a"]', '--parent', 'task_p'],
+  ],
+  [
+    'task-list',
+    { operation: 'task-list', status: 'ready', ready: true, brief: true },
+    ['--status', 'ready', '--ready', '--brief'],
+  ],
+  [
+    'task-update',
+    { operation: 'task-update', id: 'task_a', status: 'completed', result: { summary: 'done', artifacts: ['a.md'] } },
+    ['--id', 'task_a', '--status', 'completed', '--result', '{"summary":"done","artifacts":["a.md"]}'],
+  ],
+  [
+    'worker-start',
+    { operation: 'worker-start', task: 'task_a', agent: 'codex', model: 'gpt-5', effort: 'high', timeoutMs: 500 },
+    [
+      '--task',
+      'task_a',
+      '--worktree',
+      'current',
+      '--agent',
+      'codex',
+      '--model',
+      'gpt-5',
+      '--effort',
+      'high',
+      '--timeout-ms',
+      '500',
+    ],
+  ],
+  ['worker-show', { operation: 'worker-show', dispatch: 'dispatch_a' }, ['--dispatch', 'dispatch_a']],
+  [
+    'worker-read',
+    { operation: 'worker-read', dispatch: 'dispatch_a', source: 'auto', cursor: 'c1', limit: 2 },
+    ['--dispatch', 'dispatch_a', '--source', 'auto', '--cursor', 'c1', '--limit', '2'],
+  ],
+  ['worker-release', { operation: 'worker-release', dispatch: 'dispatch_a' }, ['--dispatch', 'dispatch_a']],
+  [
+    'send',
+    {
+      operation: 'send',
+      subject: 'alive',
+      body: 'working',
+      type: 'heartbeat',
+      priority: 'normal',
+      threadId: 'thread_a',
+      payload: { taskId: 'task_a', phase: '-nested-is-safe' },
+    },
+    [
+      '--subject',
+      'alive',
+      '--body',
+      'working',
+      '--type',
+      'heartbeat',
+      '--priority',
+      'normal',
+      '--thread-id',
+      'thread_a',
+      '--payload',
+      '{"taskId":"task_a","phase":"-nested-is-safe"}',
+    ],
+  ],
+  [
+    'check',
+    {
+      operation: 'check',
+      ack: 'delivery_a',
+      unread: true,
+      types: ['worker_done', 'question'],
+      wait: true,
+      timeoutMs: 500,
+    },
+    ['--ack', 'delivery_a', '--unread', '--types', 'worker_done,question', '--wait', '--timeout-ms', '500'],
+  ],
+  ['reply', { operation: 'reply', id: 'message_a', body: 'yes' }, ['--id', 'message_a', '--body', 'yes']],
+  [
+    'ask',
+    { operation: 'ask', question: 'Choose', options: ['one', 'two'], timeoutMs: 500 },
+    ['--question', 'Choose', '--options', 'one,two', '--timeout-ms', '500'],
+  ],
+  [
+    'gate-create',
+    { operation: 'gate-create', task: 'task_a', question: 'Choose', options: ['a,b', 'c\nd'] },
+    ['--task', 'task_a', '--question', 'Choose', '--options', '["a,b","c\\nd"]'],
+  ],
+  [
+    'gate-list',
+    { operation: 'gate-list', task: 'task_a', status: 'pending' },
+    ['--task', 'task_a', '--status', 'pending'],
+  ],
+  [
+    'gate-resolve',
+    { operation: 'gate-resolve', id: 'gate_a', resolution: 'approved', task: 'task_a' },
+    ['--id', 'gate_a', '--resolution', 'approved'],
+  ],
+];
+
+describe('closed Orca orchestration argv grammar', () => {
+  for (const [verb, input, flags] of cases) {
+    test(verb, () => {
+      expect(buildOrcaOrchestrationArgv(input)).toEqual(['orchestration', verb, ...flags, '--json']);
+    });
+  }
+
+  test('rejects unknown operations and caller-controlled fields', () => {
+    for (const input of [
+      { operation: 'dispatch', task: 'task_a' },
+      { operation: 'run-current', argv: ['--terminal', 'term_a'] },
+      { operation: 'run-show', id: 'run_a', json: true },
+      { operation: 'worker-start', task: 'task_a', agent: 'codex', worktree: 'other' },
+      { operation: 'send', subject: 'x', to: 'term_a' },
+    ]) {
+      expect(() => buildOrcaOrchestrationArgv(input)).toThrow(OrcaAdapterError);
+    }
+  });
+
+  test('rejects flag-shaped scalar values after domain validation', () => {
+    for (const value of ['-', '--', '-x', '--json', '-1', '-é']) {
+      expect(() => buildOrcaOrchestrationArgv({ operation: 'run-create', objective: value })).toThrow(OrcaAdapterError);
+    }
+    expect(buildOrcaOrchestrationArgv({ operation: 'run-create', objective: 'x-y' })[3]).toBe('x-y');
+    expect(buildOrcaOrchestrationArgv({ operation: 'run-create', objective: '–dash' })[3]).toBe('–dash');
+  });
+
+  test('rejects invalid dependent, structured, and delimiter-sensitive values', () => {
+    for (const input of [
+      { operation: 'worker-start', task: 'task_a', agent: 'codex', effort: 'high' },
+      { operation: 'check', wait: false, timeoutMs: 500 },
+      { operation: 'check', unread: true, peek: true },
+      { operation: 'check', types: ['question', 'question'] },
+      { operation: 'ask', question: 'q', resume: 'message_a' },
+      { operation: 'ask', resume: 'message_a', options: ['yes'] },
+      { operation: 'ask', question: 'q', options: ['a,b'] },
+      { operation: 'ask', question: 'q', options: ['a\rb'] },
+      { operation: 'ask', question: 'q', options: ['a\nb'] },
+      { operation: 'task-create', spec: 'x', deps: ['task_a', 'task_a'] },
+      { operation: 'task-update', id: 'task_a', status: 'completed', result: { summary: 'x', extra: true } },
+      { operation: 'send', subject: 'x', payload: {} },
+      { operation: 'send', subject: 'x', payload: { taskId: 'task_a', extra: true } },
+    ]) {
+      expect(() => buildOrcaOrchestrationArgv(input)).toThrow(OrcaAdapterError);
+    }
+  });
+});
+
+describe('runtime and executor boundary', () => {
+  test('resolves one deterministic executable without fallback', () => {
+    expect(resolveOrcaExecutable({ platform: 'win32', env: {} })).toBe('orca.exe');
+    expect(resolveOrcaExecutable({ platform: 'darwin', env: {} })).toBe('orca');
+    expect(resolveOrcaExecutable({ platform: 'linux', env: {}, managedTerminal: false })).toBe('orca-ide');
+    expect(resolveOrcaExecutable({ platform: 'linux', env: {}, managedTerminal: true })).toBe('orca');
+    expect(resolveOrcaExecutable({ platform: 'linux', env: { ORCA_CLI_COMMAND: '/opt/orca/bin/orca' } })).toBe(
+      '/opt/orca/bin/orca',
+    );
+    expect(() => resolveOrcaExecutable({ platform: 'linux', env: { ORCA_CLI_COMMAND: 'wrapper --flag' } })).toThrow(
+      OrcaAdapterError,
+    );
+  });
+
+  test('does not spawn on invalid input and owns all process controls', async () => {
+    const requests: Parameters<OrcaProcessExecutor>[0][] = [];
+    const adapter = createOrcaOrchestrationAdapter({
+      executable: 'orca-test',
+      env: { SAFE: 'yes' },
+      executor: async (request) => {
+        requests.push(request);
+        return { exitCode: 0, stdout: '{"id":"request_a","ok":true,"result":{"runs":[]}}', stderr: '' };
+      },
+    });
+    await expect(adapter.execute({ operation: 'run-show', id: '--json' })).rejects.toBeInstanceOf(OrcaAdapterError);
+    expect(requests).toHaveLength(0);
+    await adapter.execute({ operation: 'run-list' });
+    expect(requests).toEqual([
+      {
+        executable: 'orca-test',
+        argv: ['orchestration', 'run-list', '--json'],
+        shell: false,
+        timeoutMs: 30_000,
+        maxStdoutBytes: MAX_ORCA_STDOUT_BYTES,
+        maxStderrBytes: MAX_ORCA_STDERR_BYTES,
+        env: { SAFE: 'yes' },
+      },
+    ]);
+  });
+
+  test('requires one strict success envelope', async () => {
+    for (const stdout of ['', '{}', '{"id":"x","ok":true}', '{"id":"x","ok":true,"result":{},"extra":1}', '{}\n{}']) {
+      const adapter = createOrcaOrchestrationAdapter({
+        executable: 'orca-test',
+        executor: async () => ({ exitCode: 0, stdout, stderr: '' }),
+      });
+      await expect(adapter.execute({ operation: 'run-list' })).rejects.toBeInstanceOf(OrcaAdapterError);
+    }
+  });
+
+  test('classifies an acknowledgement timeout as unrecoverably ambiguous', async () => {
+    const adapter = createOrcaOrchestrationAdapter({
+      executable: 'orca-test',
+      executor: async () => ({ exitCode: null, stdout: '', stderr: '', timedOut: true }),
+    });
+    try {
+      await adapter.execute({ operation: 'check', ack: 'delivery_a' });
+      throw new Error('expected failure');
+    } catch (error) {
+      expect(error).toBeInstanceOf(OrcaAdapterError);
+      expect((error as OrcaAdapterError).code).toBe('ambiguous_after_possible_commit');
+      expect((error as OrcaAdapterError).retrySafety).toBe('unrecoverably-ambiguous');
+    }
+  });
+});

--- a/src/lib/orca-orchestration-adapter.test.ts
+++ b/src/lib/orca-orchestration-adapter.test.ts
@@ -700,6 +700,73 @@ describe('runtime and executor boundary', () => {
     }
   });
 
+  test('redacts secrets and request values echoed by a direct error envelope', async () => {
+    const secret = 'direct-api-secret';
+    const requestedId = 'run_private';
+    const adapter = __orcaAdapterTestOnly.createAdapter({
+      env: { API_TOKEN: secret },
+      executor: async () => ({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          id: 'request_a',
+          ok: false,
+          error: { code: 'read_failed', message: `could not read ${requestedId} with ${secret}` },
+        }),
+        stderr: '',
+      }),
+    });
+
+    try {
+      await adapter.execute({ operation: 'run-show', id: requestedId });
+      throw new Error('expected failure');
+    } catch (error) {
+      expect(error).toBeInstanceOf(OrcaAdapterError);
+      expect((error as OrcaAdapterError).message).not.toContain(requestedId);
+      expect((error as OrcaAdapterError).message).not.toContain(secret);
+      expect((error as OrcaAdapterError).message).toContain('[REDACTED]');
+    }
+  });
+
+  test('keeps error-envelope diagnostics redacted when reattributing a post-receipt readback failure', async () => {
+    const secret = 'postreceipt-secret';
+    const requestedId = 'run_private';
+    const adapter = __orcaAdapterTestOnly.createAdapter({
+      env: { AUTH_PASSWORD: secret },
+      executor: async (request) =>
+        request.argv[1] === 'run-use'
+          ? {
+              exitCode: 0,
+              stdout: JSON.stringify({
+                id: 'request_a',
+                ok: true,
+                result: { runId: requestedId, coordinatorTerminalHandle: 'term_a' },
+                _meta: { runtimeId: 'runtime_a', runtimeVersion: '1.2.3', invokingTerminal: 'term_a' },
+              }),
+              stderr: '',
+            }
+          : {
+              exitCode: 0,
+              stdout: JSON.stringify({
+                id: 'request_b',
+                ok: false,
+                error: { code: 'read_failed', message: `could not read ${requestedId} with ${secret}` },
+              }),
+              stderr: '',
+            },
+    });
+
+    try {
+      await adapter.execute({ operation: 'run-use', id: requestedId });
+      throw new Error('expected failure');
+    } catch (error) {
+      expect(error).toBeInstanceOf(OrcaAdapterError);
+      expect(error).toMatchObject({ operation: 'run-use', phase: 'readback', retrySafety: 'readback-required' });
+      expect((error as OrcaAdapterError).message).not.toContain(requestedId);
+      expect((error as OrcaAdapterError).message).not.toContain(secret);
+      expect((error as OrcaAdapterError).message).toContain('[REDACTED]');
+    }
+  });
+
   test('rejects non-finite ask states and mixed success/error envelopes', async () => {
     for (const stdout of [
       '{"id":"r","ok":true,"result":{"messageId":"message_a","state":"pending","answer":"no"},"_meta":{"runtimeId":"runtime_a","runtimeVersion":"1"}}',

--- a/src/lib/orca-orchestration-adapter.test.ts
+++ b/src/lib/orca-orchestration-adapter.test.ts
@@ -701,19 +701,24 @@ describe('runtime and executor boundary', () => {
   });
 
   test('redacts secrets and request values echoed by a direct error envelope', async () => {
-    const secret = 'direct-api-secret';
+    const secret = 'credential';
+    const databaseUrl = `postgres://brain:${secret}@db/internal`;
     const requestedId = 'run_private';
+    let calls = 0;
     const adapter = __orcaAdapterTestOnly.createAdapter({
-      env: { API_TOKEN: secret },
-      executor: async () => ({
-        exitCode: 0,
-        stdout: JSON.stringify({
-          id: 'request_a',
-          ok: false,
-          error: { code: 'read_failed', message: `could not read ${requestedId} with ${secret}` },
-        }),
-        stderr: '',
-      }),
+      env: { DATABASE_URL: databaseUrl },
+      executor: async () => {
+        calls += 1;
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            id: 'request_a',
+            ok: false,
+            error: { code: 'read_failed', message: `could not read ${requestedId} via ${databaseUrl}` },
+          }),
+          stderr: '',
+        };
+      },
     });
 
     try {
@@ -723,17 +728,23 @@ describe('runtime and executor boundary', () => {
       expect(error).toBeInstanceOf(OrcaAdapterError);
       expect((error as OrcaAdapterError).message).not.toContain(requestedId);
       expect((error as OrcaAdapterError).message).not.toContain(secret);
+      expect((error as OrcaAdapterError).message).not.toContain(databaseUrl);
       expect((error as OrcaAdapterError).message).toContain('[REDACTED]');
+      expect((error as OrcaAdapterError).message).toContain('postgres://brain:[REDACTED]@db/internal');
+      expect(calls).toBe(1);
     }
   });
 
   test('keeps error-envelope diagnostics redacted when reattributing a post-receipt readback failure', async () => {
-    const secret = 'postreceipt-secret';
+    const secret = 'credential';
+    const databaseUrl = `postgres://brain:${secret}@db/internal`;
     const requestedId = 'run_private';
+    const calls: string[] = [];
     const adapter = __orcaAdapterTestOnly.createAdapter({
-      env: { AUTH_PASSWORD: secret },
-      executor: async (request) =>
-        request.argv[1] === 'run-use'
+      env: { DATABASE_URL: databaseUrl },
+      executor: async (request) => {
+        calls.push(request.argv[1] ?? '');
+        return request.argv[1] === 'run-use'
           ? {
               exitCode: 0,
               stdout: JSON.stringify({
@@ -749,10 +760,11 @@ describe('runtime and executor boundary', () => {
               stdout: JSON.stringify({
                 id: 'request_b',
                 ok: false,
-                error: { code: 'read_failed', message: `could not read ${requestedId} with ${secret}` },
+                error: { code: 'read_failed', message: `could not read ${requestedId} via ${databaseUrl}` },
               }),
               stderr: '',
-            },
+            };
+      },
     });
 
     try {
@@ -763,7 +775,11 @@ describe('runtime and executor boundary', () => {
       expect(error).toMatchObject({ operation: 'run-use', phase: 'readback', retrySafety: 'readback-required' });
       expect((error as OrcaAdapterError).message).not.toContain(requestedId);
       expect((error as OrcaAdapterError).message).not.toContain(secret);
+      expect((error as OrcaAdapterError).message).not.toContain(databaseUrl);
       expect((error as OrcaAdapterError).message).toContain('[REDACTED]');
+      expect((error as OrcaAdapterError).message).toContain('postgres://brain:[REDACTED]@db/internal');
+      expect((error as OrcaAdapterError).recovery).toContain('do not retry the mutation automatically');
+      expect(calls).toEqual(['run-use', 'run-current']);
     }
   });
 

--- a/src/lib/orca-orchestration-adapter.test.ts
+++ b/src/lib/orca-orchestration-adapter.test.ts
@@ -282,14 +282,17 @@ describe('runtime and executor boundary', () => {
       now: () => instants.shift() as Date,
       executor: async (request) => {
         requests.push([...request.argv]);
-        const result = request.argv[1] === 'run-use' ? { runId: 'run_a' } : { run: { id: 'run_a' } };
+        const result =
+          request.argv[1] === 'run-use'
+            ? { runId: 'run_a', coordinatorTerminalHandle: 'term_a' }
+            : { run: { id: 'run_a' }, coordinatorTerminalHandle: 'term_a' };
         return {
           exitCode: 0,
           stdout: JSON.stringify({
             id: 'request_a',
             ok: true,
             result,
-            _meta: { runtimeId: 'runtime_a', runtimeVersion: '1.2.3' },
+            _meta: { runtimeId: 'runtime_a', runtimeVersion: '1.2.3', invokingTerminal: 'term_a' },
           }),
           stderr: '',
         };
@@ -318,7 +321,12 @@ describe('runtime and executor boundary', () => {
           verbs.push(verb);
           return {
             exitCode: 0,
-            stdout: JSON.stringify({ id: `request_${verb}`, ok: true, result: results[verb] }),
+            stdout: JSON.stringify({
+              id: `request_${verb}`,
+              ok: true,
+              result: results[verb],
+              _meta: { runtimeId: 'runtime_a', runtimeVersion: '1.2.3' },
+            }),
             stderr: '',
           };
         },
@@ -330,7 +338,9 @@ describe('runtime and executor boundary', () => {
       { operation: 'gate-resolve', id: 'gate_a', resolution: 'yes', task: 'task_a' },
       {
         'gate-resolve': { gateId: 'gate_a', taskId: 'task_a' },
-        'gate-list': { gates: [{ id: 'gate_a', taskId: 'task_a', status: 'resolved', resolution: 'yes' }] },
+        'gate-list': {
+          gates: [{ id: 'gate_a', taskId: 'task_a', question: 'Choose', status: 'resolved', resolution: 'yes' }],
+        },
       },
     );
     expect(gate.verbs).toEqual(['gate-resolve', 'gate-list']);
@@ -339,8 +349,10 @@ describe('runtime and executor boundary', () => {
     const worker = await run(
       { operation: 'worker-release', dispatch: 'dispatch_a' },
       {
-        'worker-release': { dispatchId: 'dispatch_a', released: true },
-        'worker-show': { dispatch: { id: 'dispatch_a', state: 'released' } },
+        'worker-release': { dispatchId: 'dispatch_a' },
+        'worker-show': {
+          dispatch: { id: 'dispatch_a', taskId: 'task_a', terminalDisposition: 'released' },
+        },
       },
     );
     expect(worker.verbs).toEqual(['worker-release', 'worker-show']);
@@ -354,8 +366,20 @@ describe('runtime and executor boundary', () => {
       executor: async (request) => {
         const verb = request.argv[1] as string;
         verbs.push(verb);
-        const result = verb === 'run-use' ? { runId: 'run_a' } : { run: { id: 'run_other' } };
-        return { exitCode: 0, stdout: JSON.stringify({ id: 'request_a', ok: true, result }), stderr: '' };
+        const result =
+          verb === 'run-use'
+            ? { runId: 'run_a', coordinatorTerminalHandle: 'term_a' }
+            : { run: { id: 'run_other' }, coordinatorTerminalHandle: 'term_a' };
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            id: 'request_a',
+            ok: true,
+            result,
+            _meta: { runtimeId: 'runtime_a', runtimeVersion: '1.2.3', invokingTerminal: 'term_a' },
+          }),
+          stderr: '',
+        };
       },
     });
     try {
@@ -379,13 +403,124 @@ describe('runtime and executor boundary', () => {
         executor: async (request) => {
           calls += 1;
           const result =
-            request.argv[1] === 'check' ? { deliveryId: 'delivery_a', messages: [] } : { messageId: 'message_a' };
-          return { exitCode: 0, stdout: JSON.stringify({ id: 'request_a', ok: true, result }), stderr: '' };
+            request.argv[1] === 'check'
+              ? { deliveryId: 'delivery_a', acknowledged: true, messages: [] }
+              : { messageId: 'message_a' };
+          return {
+            exitCode: 0,
+            stdout: JSON.stringify({
+              id: 'request_a',
+              ok: true,
+              result,
+              _meta: { runtimeId: 'runtime_a', runtimeVersion: '1.2.3' },
+            }),
+            stderr: '',
+          };
         },
       });
       const response = await adapter.execute(input);
       expect(response.receipt?.verb).toBe(input.operation);
       expect(response.receipt?.readbackVerb).toBeNull();
+      expect(calls).toBe(1);
+    }
+  });
+
+  test('rejects duplicate JSON keys and arbitrary nested identifiers', async () => {
+    for (const stdout of [
+      '{"id":"request_a","ok":true,"result":{"runs":[],"runs":[]}}',
+      '{"id":"request_a","ok":true,"result":{"nested":{"runId":"run_a"}}}',
+    ]) {
+      let calls = 0;
+      const adapter = createOrcaOrchestrationAdapter({
+        executable: 'orca-test',
+        executor: async () => {
+          calls += 1;
+          return { exitCode: 0, stdout, stderr: '' };
+        },
+      });
+      await expect(adapter.execute({ operation: 'run-create', objective: 'x' })).rejects.toBeInstanceOf(
+        OrcaAdapterError,
+      );
+      expect(calls).toBe(1);
+    }
+  });
+
+  test('requires exact acknowledgement state and runtime-attested terminal binding', async () => {
+    const ack = createOrcaOrchestrationAdapter({
+      executable: 'orca-test',
+      executor: async () => ({
+        exitCode: 0,
+        stdout:
+          '{"id":"request_a","ok":true,"result":{"deliveryId":"delivery_a","acknowledged":false},"_meta":{"runtimeId":"runtime_a","runtimeVersion":"1.2.3"}}',
+        stderr: '',
+      }),
+    });
+    await expect(ack.execute({ operation: 'check', ack: 'delivery_a' })).rejects.toMatchObject({
+      code: 'missing_receipt',
+    });
+
+    const terminal = createOrcaOrchestrationAdapter({
+      executable: 'orca-test',
+      executor: async () => ({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          id: 'request_a',
+          ok: true,
+          result: { runId: 'run_a', coordinatorTerminalHandle: 'term_wrong' },
+          _meta: { runtimeId: 'runtime_a', runtimeVersion: '1.2.3', invokingTerminal: 'term_a' },
+        }),
+        stderr: '',
+      }),
+    });
+    await expect(terminal.execute({ operation: 'run-use', id: 'run_a' })).rejects.toMatchObject({
+      code: 'readback_mismatch',
+    });
+  });
+
+  test('accepts the public retained worker disposition', async () => {
+    const verbs: string[] = [];
+    const adapter = createOrcaOrchestrationAdapter({
+      executable: 'orca-test',
+      executor: async (request) => {
+        const verb = request.argv[1] as string;
+        verbs.push(verb);
+        const result =
+          verb === 'worker-release'
+            ? { dispatchId: 'dispatch_a' }
+            : { dispatch: { id: 'dispatch_a', taskId: 'task_a', terminalDisposition: 'retained' } };
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            id: 'request_a',
+            ok: true,
+            result,
+            _meta: { runtimeId: 'runtime_a', runtimeVersion: '1.2.3' },
+          }),
+          stderr: '',
+        };
+      },
+    });
+    await adapter.execute({ operation: 'worker-release', dispatch: 'dispatch_a' });
+    expect(verbs).toEqual(['worker-release', 'worker-show']);
+  });
+
+  test('classifies output and transport loss after mutation spawn as ambiguous without persistence or retry', async () => {
+    for (const result of [
+      { exitCode: null, stdout: '', stderr: '', outputLimited: true },
+      { exitCode: null, stdout: '', stderr: '', transportLost: true },
+    ]) {
+      let calls = 0;
+      const adapter = createOrcaOrchestrationAdapter({
+        executable: 'orca-test',
+        executor: async () => {
+          calls += 1;
+          return result;
+        },
+      });
+      await expect(adapter.execute({ operation: 'send', subject: 'once' })).rejects.toMatchObject({
+        code: 'ambiguous_after_possible_commit',
+        retrySafety: 'unrecoverably-ambiguous',
+      });
       expect(calls).toBe(1);
     }
   });

--- a/src/lib/orca-orchestration-adapter.test.ts
+++ b/src/lib/orca-orchestration-adapter.test.ts
@@ -378,6 +378,101 @@ describe('runtime and executor boundary', () => {
     expect(verbs).toEqual(['run-use', 'run-current']);
   });
 
+  test('maps every post-receipt readback failure onto the mutation and never makes it safe to retry', async () => {
+    const failures: ReadonlyArray<{
+      name: string;
+      result?: Awaited<ReturnType<OrcaProcessExecutor>>;
+      rejection?: Error;
+      code: string;
+    }> = [
+      {
+        name: 'timeout',
+        result: { exitCode: null, stdout: '', stderr: '', timedOut: true },
+        code: 'timeout',
+      },
+      {
+        name: 'process exit',
+        result: { exitCode: 7, stdout: '', stderr: 'read failed' },
+        code: 'process_exit',
+      },
+      {
+        name: 'launch transport',
+        rejection: Object.assign(new Error('ENOENT'), { code: 'ENOENT' }),
+        code: 'executable_unavailable',
+      },
+      {
+        name: 'transport loss',
+        result: { exitCode: null, stdout: '', stderr: '', transportLost: true },
+        code: 'process_exit',
+      },
+      {
+        name: 'output limit',
+        result: { exitCode: null, stdout: '', stderr: '', outputLimited: true },
+        code: 'output_limit',
+      },
+      {
+        name: 'malformed JSON',
+        result: { exitCode: 0, stdout: 'not-json', stderr: '' },
+        code: 'malformed_json',
+      },
+      {
+        name: 'invalid JSON envelope',
+        result: { exitCode: 0, stdout: '{"id":"r","ok":true,"result":{}}', stderr: '' },
+        code: 'unexpected_response',
+      },
+      {
+        name: 'error envelope',
+        result: {
+          exitCode: 0,
+          stdout: '{"id":"r","ok":false,"error":{"code":"read_failed","message":"failed"}}',
+          stderr: '',
+        },
+        code: 'unexpected_response',
+      },
+    ];
+    for (const failure of failures) {
+      const verbs: string[] = [];
+      const adapter = __orcaAdapterTestOnly.createAdapter({
+        executor: async (request) => {
+          const verb = request.argv[1] as string;
+          verbs.push(verb);
+          if (verb === 'run-current') {
+            if (failure.rejection !== undefined) throw failure.rejection;
+            return failure.result as Awaited<ReturnType<OrcaProcessExecutor>>;
+          }
+          return {
+            exitCode: 0,
+            stdout: JSON.stringify({
+              id: 'request_a',
+              ok: true,
+              result: { runId: 'run_a', coordinatorTerminalHandle: 'term_a' },
+              _meta: {
+                runtimeId: 'runtime_a',
+                runtimeVersion: '1.2.3',
+                invokingTerminal: 'term_a',
+              },
+            }),
+            stderr: '',
+          };
+        },
+      });
+      try {
+        await adapter.execute({ operation: 'run-use', id: 'run_a' });
+        throw new Error(`expected ${failure.name} failure`);
+      } catch (error) {
+        expect(error).toBeInstanceOf(OrcaAdapterError);
+        expect(error).toMatchObject({
+          code: failure.code,
+          operation: 'run-use',
+          phase: 'readback',
+          retrySafety: 'readback-required',
+        });
+        expect((error as OrcaAdapterError).recovery).toContain('do not retry the mutation automatically');
+      }
+      expect(verbs).toEqual(['run-use', 'run-current']);
+    }
+  });
+
   test('returns receipt-only proofs for send/reply and supported check --ack', async () => {
     for (const input of [
       { operation: 'send', subject: 'hello' },

--- a/src/lib/orca-orchestration-adapter.test.ts
+++ b/src/lib/orca-orchestration-adapter.test.ts
@@ -229,4 +229,164 @@ describe('runtime and executor boundary', () => {
       expect((error as OrcaAdapterError).retrySafety).toBe('unrecoverably-ambiguous');
     }
   });
+
+  test('classifies every mutation timeout as ambiguous and does not retry', async () => {
+    let calls = 0;
+    const adapter = createOrcaOrchestrationAdapter({
+      executable: 'orca-test',
+      executor: async () => {
+        calls += 1;
+        return { exitCode: null, stdout: '', stderr: '', timedOut: true };
+      },
+    });
+    try {
+      await adapter.execute({ operation: 'send', subject: 'once' });
+      throw new Error('expected failure');
+    } catch (error) {
+      expect((error as OrcaAdapterError).code).toBe('ambiguous_after_possible_commit');
+      expect((error as OrcaAdapterError).retrySafety).toBe('unrecoverably-ambiguous');
+    }
+    expect(calls).toBe(1);
+  });
+
+  test('rejects verb-specific malformed and identifier-free mutation JSON without retry', async () => {
+    for (const [stdout, code] of [
+      ['not-json', 'malformed_json'],
+      ['{"id":"request_a","ok":true,"result":{"released":true}}', 'missing_receipt'],
+    ] as const) {
+      let calls = 0;
+      const adapter = createOrcaOrchestrationAdapter({
+        executable: 'orca-test',
+        executor: async () => {
+          calls += 1;
+          return { exitCode: 0, stdout, stderr: '' };
+        },
+      });
+      try {
+        await adapter.execute({ operation: 'worker-release', dispatch: 'dispatch_a' });
+        throw new Error('expected failure');
+      } catch (error) {
+        expect(error).toBeInstanceOf(OrcaAdapterError);
+        expect((error as OrcaAdapterError).code).toBe(code);
+        expect((error as OrcaAdapterError).retrySafety).toBe('readback-required');
+      }
+      expect(calls).toBe(1);
+    }
+  });
+
+  test('normalizes run-use identifiers, runtime metadata, timestamps, and run-current proof', async () => {
+    const requests: string[][] = [];
+    const instants = [new Date('2026-08-29T00:00:00.000Z'), new Date('2026-08-29T00:00:01.000Z')];
+    const adapter = createOrcaOrchestrationAdapter({
+      executable: 'orca-test',
+      now: () => instants.shift() as Date,
+      executor: async (request) => {
+        requests.push([...request.argv]);
+        const result = request.argv[1] === 'run-use' ? { runId: 'run_a' } : { run: { id: 'run_a' } };
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            id: 'request_a',
+            ok: true,
+            result,
+            _meta: { runtimeId: 'runtime_a', runtimeVersion: '1.2.3' },
+          }),
+          stderr: '',
+        };
+      },
+    });
+    const response = await adapter.execute({ operation: 'run-use', id: 'run_a' });
+    expect(requests.map((argv) => argv[1])).toEqual(['run-use', 'run-current']);
+    expect(response.receipt).toEqual({
+      verb: 'run-use',
+      ids: { runId: 'run_a' },
+      runtimeId: 'runtime_a',
+      runtimeVersion: '1.2.3',
+      startedAt: '2026-08-29T00:00:00.000Z',
+      completedAt: '2026-08-29T00:00:01.000Z',
+      readbackVerb: 'run-current',
+    });
+  });
+
+  test('verifies gate task context and worker release through their required public readbacks', async () => {
+    const run = async (input: OrcaOperation, results: Record<string, object>) => {
+      const verbs: string[] = [];
+      const adapter = createOrcaOrchestrationAdapter({
+        executable: 'orca-test',
+        executor: async (request) => {
+          const verb = request.argv[1] as string;
+          verbs.push(verb);
+          return {
+            exitCode: 0,
+            stdout: JSON.stringify({ id: `request_${verb}`, ok: true, result: results[verb] }),
+            stderr: '',
+          };
+        },
+      });
+      const response = await adapter.execute(input);
+      return { verbs, response };
+    };
+    const gate = await run(
+      { operation: 'gate-resolve', id: 'gate_a', resolution: 'yes', task: 'task_a' },
+      {
+        'gate-resolve': { gateId: 'gate_a', taskId: 'task_a' },
+        'gate-list': { gates: [{ id: 'gate_a', taskId: 'task_a', status: 'resolved', resolution: 'yes' }] },
+      },
+    );
+    expect(gate.verbs).toEqual(['gate-resolve', 'gate-list']);
+    expect(gate.response.receipt?.ids).toEqual({ gateId: 'gate_a', taskId: 'task_a' });
+
+    const worker = await run(
+      { operation: 'worker-release', dispatch: 'dispatch_a' },
+      {
+        'worker-release': { dispatchId: 'dispatch_a', released: true },
+        'worker-show': { dispatch: { id: 'dispatch_a', state: 'released' } },
+      },
+    );
+    expect(worker.verbs).toEqual(['worker-release', 'worker-show']);
+    expect(worker.response.receipt?.readbackVerb).toBe('worker-show');
+  });
+
+  test('fails on readback disagreement and never retries either call', async () => {
+    const verbs: string[] = [];
+    const adapter = createOrcaOrchestrationAdapter({
+      executable: 'orca-test',
+      executor: async (request) => {
+        const verb = request.argv[1] as string;
+        verbs.push(verb);
+        const result = verb === 'run-use' ? { runId: 'run_a' } : { run: { id: 'run_other' } };
+        return { exitCode: 0, stdout: JSON.stringify({ id: 'request_a', ok: true, result }), stderr: '' };
+      },
+    });
+    try {
+      await adapter.execute({ operation: 'run-use', id: 'run_a' });
+      throw new Error('expected failure');
+    } catch (error) {
+      expect((error as OrcaAdapterError).code).toBe('readback_mismatch');
+    }
+    expect(verbs).toEqual(['run-use', 'run-current']);
+  });
+
+  test('returns receipt-only proofs for send/reply and supported check --ack', async () => {
+    for (const input of [
+      { operation: 'send', subject: 'hello' },
+      { operation: 'reply', id: 'message_a', body: 'yes' },
+      { operation: 'check', ack: 'delivery_a' },
+    ] satisfies OrcaOperation[]) {
+      let calls = 0;
+      const adapter = createOrcaOrchestrationAdapter({
+        executable: 'orca-test',
+        executor: async (request) => {
+          calls += 1;
+          const result =
+            request.argv[1] === 'check' ? { deliveryId: 'delivery_a', messages: [] } : { messageId: 'message_a' };
+          return { exitCode: 0, stdout: JSON.stringify({ id: 'request_a', ok: true, result }), stderr: '' };
+        },
+      });
+      const response = await adapter.execute(input);
+      expect(response.receipt?.verb).toBe(input.operation);
+      expect(response.receipt?.readbackVerb).toBeNull();
+      expect(calls).toBe(1);
+    }
+  });
 });

--- a/src/lib/orca-orchestration-adapter.test.ts
+++ b/src/lib/orca-orchestration-adapter.test.ts
@@ -5,6 +5,7 @@ import {
   OrcaAdapterError,
   type OrcaOperation,
   type OrcaProcessExecutor,
+  __orcaAdapterTestOnly,
   buildOrcaOrchestrationArgv,
   createOrcaOrchestrationAdapter,
   resolveOrcaExecutable,
@@ -167,22 +168,18 @@ describe('closed Orca orchestration argv grammar', () => {
 
 describe('runtime and executor boundary', () => {
   test('resolves one deterministic executable without fallback', () => {
-    expect(resolveOrcaExecutable({ platform: 'win32', env: {} })).toBe('orca.exe');
-    expect(resolveOrcaExecutable({ platform: 'darwin', env: {} })).toBe('orca');
-    expect(resolveOrcaExecutable({ platform: 'linux', env: {}, managedTerminal: false })).toBe('orca-ide');
-    expect(resolveOrcaExecutable({ platform: 'linux', env: {}, managedTerminal: true })).toBe('orca');
-    expect(resolveOrcaExecutable({ platform: 'linux', env: { ORCA_CLI_COMMAND: '/opt/orca/bin/orca' } })).toBe(
-      '/opt/orca/bin/orca',
-    );
-    expect(() => resolveOrcaExecutable({ platform: 'linux', env: { ORCA_CLI_COMMAND: 'wrapper --flag' } })).toThrow(
-      OrcaAdapterError,
+    expect(resolveOrcaExecutable({ platform: 'win32' })).toBe('orca.exe');
+    expect(resolveOrcaExecutable({ platform: 'darwin' })).toBe('orca');
+    expect(resolveOrcaExecutable({ platform: 'linux', managedTerminal: false })).toBe('orca-ide');
+    expect(resolveOrcaExecutable({ platform: 'linux', managedTerminal: true })).toBe('orca');
+    expect(createOrcaOrchestrationAdapter().executable).toBe(
+      resolveOrcaExecutable({ managedTerminal: process.env.TERM_PROGRAM === 'Orca' }),
     );
   });
 
   test('does not spawn on invalid input and owns all process controls', async () => {
     const requests: Parameters<OrcaProcessExecutor>[0][] = [];
-    const adapter = createOrcaOrchestrationAdapter({
-      executable: 'orca-test',
+    const adapter = __orcaAdapterTestOnly.createAdapter({
       env: { SAFE: 'yes' },
       executor: async (request) => {
         requests.push(request);
@@ -194,7 +191,7 @@ describe('runtime and executor boundary', () => {
     await adapter.execute({ operation: 'run-list' });
     expect(requests).toEqual([
       {
-        executable: 'orca-test',
+        executable: 'orca-ide',
         argv: ['orchestration', 'run-list', '--json'],
         shell: false,
         timeoutMs: 30_000,
@@ -207,8 +204,7 @@ describe('runtime and executor boundary', () => {
 
   test('requires one strict success envelope', async () => {
     for (const stdout of ['', '{}', '{"id":"x","ok":true}', '{"id":"x","ok":true,"result":{},"extra":1}', '{}\n{}']) {
-      const adapter = createOrcaOrchestrationAdapter({
-        executable: 'orca-test',
+      const adapter = __orcaAdapterTestOnly.createAdapter({
         executor: async () => ({ exitCode: 0, stdout, stderr: '' }),
       });
       await expect(adapter.execute({ operation: 'run-list' })).rejects.toBeInstanceOf(OrcaAdapterError);
@@ -216,8 +212,7 @@ describe('runtime and executor boundary', () => {
   });
 
   test('classifies an acknowledgement timeout as unrecoverably ambiguous', async () => {
-    const adapter = createOrcaOrchestrationAdapter({
-      executable: 'orca-test',
+    const adapter = __orcaAdapterTestOnly.createAdapter({
       executor: async () => ({ exitCode: null, stdout: '', stderr: '', timedOut: true }),
     });
     try {
@@ -232,8 +227,7 @@ describe('runtime and executor boundary', () => {
 
   test('classifies every mutation timeout as ambiguous and does not retry', async () => {
     let calls = 0;
-    const adapter = createOrcaOrchestrationAdapter({
-      executable: 'orca-test',
+    const adapter = __orcaAdapterTestOnly.createAdapter({
       executor: async () => {
         calls += 1;
         return { exitCode: null, stdout: '', stderr: '', timedOut: true };
@@ -250,13 +244,9 @@ describe('runtime and executor boundary', () => {
   });
 
   test('rejects verb-specific malformed and identifier-free mutation JSON without retry', async () => {
-    for (const [stdout, code] of [
-      ['not-json', 'malformed_json'],
-      ['{"id":"request_a","ok":true,"result":{"released":true}}', 'missing_receipt'],
-    ] as const) {
+    for (const stdout of ['not-json', '{"id":"request_a","ok":true,"result":{"released":true}}']) {
       let calls = 0;
-      const adapter = createOrcaOrchestrationAdapter({
-        executable: 'orca-test',
+      const adapter = __orcaAdapterTestOnly.createAdapter({
         executor: async () => {
           calls += 1;
           return { exitCode: 0, stdout, stderr: '' };
@@ -267,8 +257,8 @@ describe('runtime and executor boundary', () => {
         throw new Error('expected failure');
       } catch (error) {
         expect(error).toBeInstanceOf(OrcaAdapterError);
-        expect((error as OrcaAdapterError).code).toBe(code);
-        expect((error as OrcaAdapterError).retrySafety).toBe('readback-required');
+        expect((error as OrcaAdapterError).code).toBe('ambiguous_after_possible_commit');
+        expect((error as OrcaAdapterError).retrySafety).toBe('unrecoverably-ambiguous');
       }
       expect(calls).toBe(1);
     }
@@ -277,8 +267,7 @@ describe('runtime and executor boundary', () => {
   test('normalizes run-use identifiers, runtime metadata, timestamps, and run-current proof', async () => {
     const requests: string[][] = [];
     const instants = [new Date('2026-08-29T00:00:00.000Z'), new Date('2026-08-29T00:00:01.000Z')];
-    const adapter = createOrcaOrchestrationAdapter({
-      executable: 'orca-test',
+    const adapter = __orcaAdapterTestOnly.createAdapter({
       now: () => instants.shift() as Date,
       executor: async (request) => {
         requests.push([...request.argv]);
@@ -314,8 +303,7 @@ describe('runtime and executor boundary', () => {
   test('verifies gate task context and worker release through their required public readbacks', async () => {
     const run = async (input: OrcaOperation, results: Record<string, object>) => {
       const verbs: string[] = [];
-      const adapter = createOrcaOrchestrationAdapter({
-        executable: 'orca-test',
+      const adapter = __orcaAdapterTestOnly.createAdapter({
         executor: async (request) => {
           const verb = request.argv[1] as string;
           verbs.push(verb);
@@ -361,8 +349,7 @@ describe('runtime and executor boundary', () => {
 
   test('fails on readback disagreement and never retries either call', async () => {
     const verbs: string[] = [];
-    const adapter = createOrcaOrchestrationAdapter({
-      executable: 'orca-test',
+    const adapter = __orcaAdapterTestOnly.createAdapter({
       executor: async (request) => {
         const verb = request.argv[1] as string;
         verbs.push(verb);
@@ -398,8 +385,7 @@ describe('runtime and executor boundary', () => {
       { operation: 'check', ack: 'delivery_a' },
     ] satisfies OrcaOperation[]) {
       let calls = 0;
-      const adapter = createOrcaOrchestrationAdapter({
-        executable: 'orca-test',
+      const adapter = __orcaAdapterTestOnly.createAdapter({
         executor: async (request) => {
           calls += 1;
           const result =
@@ -431,8 +417,7 @@ describe('runtime and executor boundary', () => {
       '{"id":"request_a","ok":true,"result":{"nested":{"runId":"run_a"}}}',
     ]) {
       let calls = 0;
-      const adapter = createOrcaOrchestrationAdapter({
-        executable: 'orca-test',
+      const adapter = __orcaAdapterTestOnly.createAdapter({
         executor: async () => {
           calls += 1;
           return { exitCode: 0, stdout, stderr: '' };
@@ -446,8 +431,7 @@ describe('runtime and executor boundary', () => {
   });
 
   test('requires exact acknowledgement state and runtime-attested terminal binding', async () => {
-    const ack = createOrcaOrchestrationAdapter({
-      executable: 'orca-test',
+    const ack = __orcaAdapterTestOnly.createAdapter({
       executor: async () => ({
         exitCode: 0,
         stdout:
@@ -456,11 +440,10 @@ describe('runtime and executor boundary', () => {
       }),
     });
     await expect(ack.execute({ operation: 'check', ack: 'delivery_a' })).rejects.toMatchObject({
-      code: 'missing_receipt',
+      code: 'ambiguous_after_possible_commit',
     });
 
-    const terminal = createOrcaOrchestrationAdapter({
-      executable: 'orca-test',
+    const terminal = __orcaAdapterTestOnly.createAdapter({
       executor: async () => ({
         exitCode: 0,
         stdout: JSON.stringify({
@@ -479,8 +462,7 @@ describe('runtime and executor boundary', () => {
 
   test('accepts the public retained worker disposition', async () => {
     const verbs: string[] = [];
-    const adapter = createOrcaOrchestrationAdapter({
-      executable: 'orca-test',
+    const adapter = __orcaAdapterTestOnly.createAdapter({
       executor: async (request) => {
         const verb = request.argv[1] as string;
         verbs.push(verb);
@@ -510,8 +492,7 @@ describe('runtime and executor boundary', () => {
       { exitCode: null, stdout: '', stderr: '', transportLost: true },
     ]) {
       let calls = 0;
-      const adapter = createOrcaOrchestrationAdapter({
-        executable: 'orca-test',
+      const adapter = __orcaAdapterTestOnly.createAdapter({
         executor: async () => {
           calls += 1;
           return result;
@@ -522,6 +503,169 @@ describe('runtime and executor boundary', () => {
         retrySafety: 'unrecoverably-ambiguous',
       });
       expect(calls).toBe(1);
+    }
+  });
+
+  test('classifies every verb failure by whether the invocation could mutate', async () => {
+    const mutation = new Set([
+      'run-create',
+      'run-use',
+      'task-create',
+      'task-update',
+      'worker-start',
+      'worker-release',
+      'send',
+      'check',
+      'reply',
+      'ask',
+      'gate-create',
+      'gate-resolve',
+    ]);
+    const failures = [
+      { exitCode: 7, stdout: '', stderr: 'failed' },
+      { exitCode: 0, stdout: 'not-json', stderr: '' },
+      { exitCode: 0, stdout: '{"id":"r","ok":true,"result":{}}', stderr: '' },
+      { exitCode: null, stdout: '', stderr: '', timedOut: true },
+      { exitCode: null, stdout: '', stderr: '', outputLimited: true },
+      {
+        exitCode: 0,
+        stdout: '{"id":"r","ok":false,"error":{"code":"nope","message":"failed"}}',
+        stderr: '',
+      },
+    ];
+    for (const [, input] of cases) {
+      for (const failure of failures) {
+        const adapter = __orcaAdapterTestOnly.createAdapter({ executor: async () => failure });
+        try {
+          await adapter.execute(input);
+          throw new Error('expected adapter failure');
+        } catch (error) {
+          expect(error).toBeInstanceOf(OrcaAdapterError);
+          if (mutation.has(input.operation)) {
+            expect((error as OrcaAdapterError).code).toBe('ambiguous_after_possible_commit');
+            expect((error as OrcaAdapterError).retrySafety).toBe('unrecoverably-ambiguous');
+          } else {
+            expect((error as OrcaAdapterError).retrySafety).toBe('safe');
+          }
+        }
+      }
+    }
+  });
+
+  test('treats executor rejection as safe pre-spawn executable unavailability', async () => {
+    const adapter = __orcaAdapterTestOnly.createAdapter({
+      executor: async () => {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      },
+    });
+    await expect(adapter.execute({ operation: 'send', subject: 'once' })).rejects.toMatchObject({
+      code: 'executable_unavailable',
+      phase: 'resolve',
+      retrySafety: 'safe',
+    });
+  });
+
+  test('bounds timeout termination through the kill escalation path', async () => {
+    const started = Date.now();
+    const result = await __orcaAdapterTestOnly.spawnOrcaProcess({
+      executable: process.execPath,
+      argv: ['-e', "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)"],
+      shell: false,
+      timeoutMs: 20,
+      maxStdoutBytes: MAX_ORCA_STDOUT_BYTES,
+      maxStderrBytes: MAX_ORCA_STDERR_BYTES,
+      env: process.env,
+    });
+    expect(result.timedOut).toBeTrue();
+    expect(result.signal).toBe('SIGKILL');
+    expect(Date.now() - started).toBeLessThan(2500);
+  });
+
+  test('redacts secrets and request values, strips controls, and truncates stderr', async () => {
+    const secret = 'super-secret-token';
+    const body = 'private request body';
+    const adapter = __orcaAdapterTestOnly.createAdapter({
+      env: { API_TOKEN: secret },
+      executor: async () => ({
+        exitCode: 2,
+        stdout: '',
+        stderr: `${'x'.repeat(5000)}\u0001 ${secret} ${body}`,
+      }),
+    });
+    try {
+      await adapter.execute({ operation: 'send', subject: 'subject', body });
+      throw new Error('expected failure');
+    } catch (error) {
+      const stderr = (error as OrcaAdapterError).stderr ?? '';
+      expect(Buffer.byteLength(stderr)).toBeLessThanOrEqual(4096);
+      expect(stderr).not.toContain(secret);
+      expect(stderr).not.toContain(body);
+      expect(stderr).not.toContain('\u0001');
+      expect(stderr).toContain('[REDACTED]');
+    }
+  });
+
+  test('rejects non-finite ask states and mixed success/error envelopes', async () => {
+    for (const stdout of [
+      '{"id":"r","ok":true,"result":{"messageId":"message_a","state":"pending","answer":"no"},"_meta":{"runtimeId":"runtime_a","runtimeVersion":"1"}}',
+      '{"id":"r","ok":true,"result":{"messageId":"message_a","state":"answered"},"_meta":{"runtimeId":"runtime_a","runtimeVersion":"1"}}',
+      '{"id":"r","ok":true,"result":{"messageId":"message_a","state":"other"},"_meta":{"runtimeId":"runtime_a","runtimeVersion":"1"}}',
+      '{"id":"r","ok":false,"result":{},"error":{"code":"x","message":"x"}}',
+      '{"id":"r","ok":false,"error":{"code":"x","message":"x","extra":true}}',
+    ]) {
+      const adapter = __orcaAdapterTestOnly.createAdapter({
+        executor: async () => ({ exitCode: 0, stdout, stderr: '' }),
+      });
+      await expect(adapter.execute({ operation: 'ask', question: 'q' })).rejects.toMatchObject({
+        code: 'ambiguous_after_possible_commit',
+      });
+    }
+  });
+
+  test('rejects mismatched receipt identities and duplicate readback rows', async () => {
+    const scenarios: Array<{ input: OrcaOperation; mutationResult: object; readResult?: object }> = [
+      {
+        input: { operation: 'task-update', id: 'task_a', status: 'completed' },
+        mutationResult: { taskId: 'task_other' },
+      },
+      {
+        input: { operation: 'worker-start', task: 'task_a', agent: 'codex' },
+        mutationResult: { dispatchId: 'dispatch_a', taskId: 'task_other' },
+      },
+      {
+        input: { operation: 'gate-create', task: 'task_a', question: 'q' },
+        mutationResult: { gateId: 'gate_a', taskId: 'task_other' },
+      },
+      {
+        input: { operation: 'reply', id: 'message_a', body: 'yes' },
+        mutationResult: { messageId: 'message_other' },
+      },
+      {
+        input: { operation: 'task-create', spec: 'spec' },
+        mutationResult: { taskId: 'task_a' },
+        readResult: {
+          tasks: [
+            { id: 'task_a', spec: 'spec', status: 'ready' },
+            { id: 'task_a', spec: 'spec', status: 'ready' },
+          ],
+        },
+      },
+    ];
+    for (const scenario of scenarios) {
+      let call = 0;
+      const adapter = __orcaAdapterTestOnly.createAdapter({
+        executor: async () => ({
+          exitCode: 0,
+          stdout: JSON.stringify({
+            id: 'request_a',
+            ok: true,
+            result: call++ === 0 ? scenario.mutationResult : scenario.readResult,
+            _meta: { runtimeId: 'runtime_a', runtimeVersion: '1' },
+          }),
+          stderr: '',
+        }),
+      });
+      await expect(adapter.execute(scenario.input)).rejects.toMatchObject({ code: 'readback_mismatch' });
     }
   });
 });

--- a/src/lib/orca-orchestration-adapter.ts
+++ b/src/lib/orca-orchestration-adapter.ts
@@ -1181,7 +1181,10 @@ function sanitizeDiagnosticText(
       ([key, value]) => value !== undefined && /(?:TOKEN|SECRET|PASSWORD|PASS|KEY|CREDENTIAL|AUTH|COOKIE)/i.test(key),
     )
     .map(([, value]) => value as string);
-  for (const value of [...requestValues, ...secrets]
+  const connectionCredentials = Object.values(env).flatMap((value) =>
+    value === undefined ? [] : credentialValuesFromUrl(value),
+  );
+  for (const value of [...requestValues, ...secrets, ...connectionCredentials]
     .filter((candidate) => candidate.length >= 3)
     .sort((a, b) => b.length - a.length)) {
     safe = safe.split(value).join('[REDACTED]');
@@ -1190,6 +1193,20 @@ function sanitizeDiagnosticText(
   return bytes.length <= 4096
     ? safe
     : Buffer.concat([Buffer.from('[truncated] '), bytes.subarray(bytes.length - 4084)]).toString('utf8');
+}
+
+function credentialValuesFromUrl(value: string): string[] {
+  try {
+    const url = new URL(value);
+    if (url.password.length === 0) return [];
+    try {
+      return [url.password, decodeURIComponent(url.password)];
+    } catch {
+      return [url.password];
+    }
+  } catch {
+    return [];
+  }
 }
 
 function collectStringValues(value: unknown): string[] {

--- a/src/lib/orca-orchestration-adapter.ts
+++ b/src/lib/orca-orchestration-adapter.ts
@@ -1,0 +1,637 @@
+import { spawn } from 'node:child_process';
+import { z } from 'zod';
+
+export const ORCA_ORCHESTRATION_VERBS = [
+  'run-create',
+  'run-list',
+  'run-show',
+  'run-current',
+  'run-use',
+  'task-create',
+  'task-list',
+  'task-update',
+  'worker-start',
+  'worker-show',
+  'worker-read',
+  'worker-release',
+  'send',
+  'check',
+  'reply',
+  'ask',
+  'gate-create',
+  'gate-list',
+  'gate-resolve',
+] as const;
+
+export type OrcaOrchestrationVerb = (typeof ORCA_ORCHESTRATION_VERBS)[number];
+
+export type OrcaAdapterErrorCode =
+  | 'unsupported_platform'
+  | 'unsupported_environment'
+  | 'executable_unavailable'
+  | 'incompatible_cli_version'
+  | 'invalid_operation'
+  | 'invalid_argument'
+  | 'timeout'
+  | 'output_limit'
+  | 'ambiguous_after_possible_commit'
+  | 'process_exit'
+  | 'malformed_json'
+  | 'unexpected_response'
+  | 'missing_receipt'
+  | 'readback_mismatch'
+  | 'local_lifecycle_disabled_in_orca_mode';
+
+export type RetrySafety = 'safe' | 'unsafe' | 'readback-required' | 'unrecoverably-ambiguous';
+
+export class OrcaAdapterError extends Error {
+  readonly name = 'OrcaAdapterError';
+
+  constructor(
+    readonly code: OrcaAdapterErrorCode,
+    readonly operation: OrcaOrchestrationVerb | 'runtime',
+    readonly phase: 'validate' | 'resolve' | 'execute' | 'decode' | 'receipt' | 'readback',
+    readonly retrySafety: RetrySafety,
+    readonly recovery: string,
+    message: string,
+    readonly stderr?: string,
+  ) {
+    super(message);
+  }
+}
+
+const id = z.string().regex(/^[A-Za-z][A-Za-z0-9_-]{0,127}$/);
+const utf8 = (max: number) =>
+  z
+    .string()
+    .refine((value) => value === value.normalize('NFC'), 'must be NFC-normalized')
+    .refine((value) => !value.includes('\0') && !/[\uD800-\uDFFF]/u.test(value), 'contains an invalid code point')
+    .refine((value) => Buffer.byteLength(value, 'utf8') >= 1 && Buffer.byteLength(value, 'utf8') <= max);
+const longText = utf8(16_384);
+const shortText = utf8(512);
+const itemText = utf8(256);
+const cursor = z
+  .string()
+  .min(1)
+  .max(512)
+  .regex(/^[\x21-\x7E]+$/)
+  .refine((value) => !value.startsWith('-') && !/[;&|`$<>\\(){}\[\]*?!'\"]/.test(value));
+const model = cursor.refine((value) => Buffer.byteLength(value, 'utf8') <= 128);
+const limit = z.number().int().min(1).max(100);
+const timeout = z.number().int().min(250).max(600_000);
+const taskStatus = z.enum(['pending', 'ready', 'dispatched', 'completed', 'failed', 'blocked']);
+const gateStatus = z.enum(['pending', 'resolved']);
+const messageType = z.enum([
+  'status',
+  'dispatch',
+  'worker_done',
+  'merge_ready',
+  'escalation',
+  'handoff',
+  'question',
+  'decision_gate',
+  'heartbeat',
+]);
+const priority = z.enum(['low', 'normal', 'high', 'urgent']);
+const workerSource = z.enum(['auto', 'transcript', 'terminal']);
+const agent = z.enum(['claude', 'codex', 'cursor', 'droid', 'gemini', 'grok', 'opencode']);
+const effort = z.enum(['low', 'medium', 'high', 'xhigh']);
+const uniqueArray = <T extends z.ZodTypeAny>(member: T, maximum: number, minimum = 0) =>
+  z
+    .array(member)
+    .min(minimum)
+    .max(maximum)
+    .refine((values) => new Set(values as unknown[]).size === values.length, 'items must be unique');
+const result = z
+  .object({ summary: longText, artifacts: uniqueArray(itemText, 32).optional() })
+  .strict()
+  .refine((value) => Buffer.byteLength(JSON.stringify(value)) <= 32_768);
+const sendPayload = z
+  .object({
+    taskId: id.optional(),
+    dispatchId: id.optional(),
+    phase: itemText.optional(),
+    outcome: z.enum(['succeeded', 'failed']).optional(),
+    filesModified: uniqueArray(itemText, 128).optional(),
+    reportPath: itemText.optional(),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, 'payload must not be empty')
+  .refine((value) => Buffer.byteLength(JSON.stringify(value)) <= 32_768);
+const base = <V extends OrcaOrchestrationVerb, T extends z.ZodRawShape>(verb: V, shape: T) =>
+  z.object({ operation: z.literal(verb), ...shape }).strict();
+
+export const orcaOperationSchema = z.union([
+  base('run-create', { objective: longText }),
+  base('run-list', { limit: limit.optional(), cursor: cursor.optional() }),
+  base('run-show', { id }),
+  base('run-current', {}),
+  base('run-use', { id }),
+  base('task-create', {
+    spec: longText,
+    title: shortText.optional(),
+    deps: uniqueArray(id, 64).optional(),
+    parent: id.optional(),
+  }),
+  base('task-list', {
+    status: taskStatus.optional(),
+    ready: z.boolean().optional(),
+    brief: z.boolean().optional(),
+  }),
+  base('task-update', { id, status: taskStatus, result: result.optional() }),
+  base('worker-start', {
+    task: id,
+    agent,
+    model: model.optional(),
+    effort: effort.optional(),
+    timeoutMs: timeout.optional(),
+  }).refine((value) => value.effort === undefined || value.model !== undefined, {
+    message: 'effort requires model',
+  }),
+  base('worker-show', { dispatch: id }),
+  base('worker-read', {
+    dispatch: id,
+    source: workerSource.optional(),
+    cursor: cursor.optional(),
+    limit: limit.optional(),
+  }),
+  base('worker-release', { dispatch: id }),
+  base('send', {
+    subject: shortText,
+    body: longText.optional(),
+    type: messageType.optional(),
+    priority: priority.optional(),
+    threadId: id.optional(),
+    payload: sendPayload.optional(),
+  }),
+  base('check', {
+    ack: id.optional(),
+    unread: z.boolean().optional(),
+    peek: z.boolean().optional(),
+    all: z.boolean().optional(),
+    types: uniqueArray(messageType, messageType.options.length, 1).optional(),
+    wait: z.boolean().optional(),
+    timeoutMs: timeout.optional(),
+  })
+    .refine((value) => [value.unread, value.peek, value.all].filter((entry) => entry === true).length <= 1, {
+      message: 'unread, peek, and all are mutually exclusive',
+    })
+    .refine((value) => value.timeoutMs === undefined || value.wait === true, { message: 'timeoutMs requires wait' }),
+  base('reply', { id, body: longText }),
+  base('ask', {
+    question: shortText.optional(),
+    resume: id.optional(),
+    options: uniqueArray(itemText, 10, 1).optional(),
+    timeoutMs: timeout.optional(),
+  })
+    .refine((value) => (value.question === undefined) !== (value.resume === undefined), {
+      message: 'exactly one of question or resume is required',
+    })
+    .refine((value) => value.options === undefined || value.question !== undefined, {
+      message: 'options require question',
+    })
+    .refine((value) => value.options?.every((option) => !/[,\r\n]/.test(option)) ?? true, {
+      message: 'ask options cannot contain comma, CR, or LF',
+    }),
+  base('gate-create', {
+    task: id,
+    question: shortText,
+    options: uniqueArray(itemText, 10, 1).optional(),
+  }),
+  base('gate-list', { task: id.optional(), status: gateStatus.optional() }),
+  base('gate-resolve', { id, resolution: longText, task: id }),
+]);
+
+export type OrcaOperation = z.input<typeof orcaOperationSchema>;
+export type ValidatedOrcaOperation = z.output<typeof orcaOperationSchema>;
+
+function flagValue(flag: string, value: string): string[] {
+  if (value.length > 0 && value[0] === '-') {
+    throw new OrcaAdapterError(
+      'invalid_argument',
+      'runtime',
+      'validate',
+      'safe',
+      'Correct the rejected semantic value and retry.',
+      `${flag} has a flag-shaped value`,
+    );
+  }
+  return [flag, value];
+}
+
+function optionalFlag(flag: string, value: string | number | undefined): string[] {
+  return value === undefined ? [] : flagValue(flag, String(value));
+}
+
+function boolFlag(flag: string, value: boolean | undefined): string[] {
+  return value === true ? [flag] : [];
+}
+
+export function buildOrcaOrchestrationArgv(input: unknown): readonly string[] {
+  const parsed = orcaOperationSchema.safeParse(input);
+  if (!parsed.success) {
+    const operation = readOperation(input);
+    throw new OrcaAdapterError(
+      operation === undefined ? 'invalid_operation' : 'invalid_argument',
+      operation ?? 'runtime',
+      'validate',
+      'safe',
+      'Correct the semantic input and retry.',
+      parsed.error.issues.map((issue) => issue.message).join('; '),
+    );
+  }
+  const operation = parsed.data;
+  const args = buildArguments(operation);
+  return Object.freeze(['orchestration', operation.operation, ...args, '--json']);
+}
+
+function readOperation(input: unknown): OrcaOrchestrationVerb | undefined {
+  if (typeof input !== 'object' || input === null || !('operation' in input)) return undefined;
+  const operation = (input as { operation?: unknown }).operation;
+  return ORCA_ORCHESTRATION_VERBS.find((candidate) => candidate === operation);
+}
+
+function buildArguments(operation: ValidatedOrcaOperation): string[] {
+  switch (operation.operation) {
+    case 'run-create':
+      return flagValue('--objective', operation.objective);
+    case 'run-list':
+      return [...optionalFlag('--limit', operation.limit), ...optionalFlag('--cursor', operation.cursor)];
+    case 'run-show':
+    case 'run-use':
+      return flagValue('--id', operation.id);
+    case 'run-current':
+      return [];
+    case 'task-create':
+      return [
+        ...flagValue('--spec', operation.spec),
+        ...optionalFlag('--task-title', operation.title),
+        ...(operation.deps === undefined ? [] : flagValue('--deps', JSON.stringify(operation.deps))),
+        ...optionalFlag('--parent', operation.parent),
+      ];
+    case 'task-list':
+      return [
+        ...optionalFlag('--status', operation.status),
+        ...boolFlag('--ready', operation.ready),
+        ...boolFlag('--brief', operation.brief),
+      ];
+    case 'task-update':
+      return [
+        ...flagValue('--id', operation.id),
+        ...flagValue('--status', operation.status),
+        ...(operation.result === undefined ? [] : flagValue('--result', JSON.stringify(operation.result))),
+      ];
+    case 'worker-start':
+      return [
+        ...flagValue('--task', operation.task),
+        '--worktree',
+        'current',
+        ...flagValue('--agent', operation.agent),
+        ...optionalFlag('--model', operation.model),
+        ...optionalFlag('--effort', operation.effort),
+        ...optionalFlag('--timeout-ms', operation.timeoutMs),
+      ];
+    case 'worker-show':
+    case 'worker-release':
+      return flagValue('--dispatch', operation.dispatch);
+    case 'worker-read':
+      return [
+        ...flagValue('--dispatch', operation.dispatch),
+        ...optionalFlag('--source', operation.source),
+        ...optionalFlag('--cursor', operation.cursor),
+        ...optionalFlag('--limit', operation.limit),
+      ];
+    case 'send':
+      return [
+        ...flagValue('--subject', operation.subject),
+        ...optionalFlag('--body', operation.body),
+        ...optionalFlag('--type', operation.type),
+        ...optionalFlag('--priority', operation.priority),
+        ...optionalFlag('--thread-id', operation.threadId),
+        ...(operation.payload === undefined ? [] : flagValue('--payload', JSON.stringify(operation.payload))),
+      ];
+    case 'check':
+      return [
+        ...optionalFlag('--ack', operation.ack),
+        ...boolFlag('--unread', operation.unread),
+        ...boolFlag('--peek', operation.peek),
+        ...boolFlag('--all', operation.all),
+        ...(operation.types === undefined ? [] : flagValue('--types', operation.types.join(','))),
+        ...boolFlag('--wait', operation.wait),
+        ...optionalFlag('--timeout-ms', operation.timeoutMs),
+      ];
+    case 'reply':
+      return [...flagValue('--id', operation.id), ...flagValue('--body', operation.body)];
+    case 'ask':
+      return [
+        ...(operation.question === undefined
+          ? flagValue('--resume', operation.resume as string)
+          : flagValue('--question', operation.question)),
+        ...(operation.options === undefined ? [] : flagValue('--options', operation.options.join(','))),
+        ...optionalFlag('--timeout-ms', operation.timeoutMs),
+      ];
+    case 'gate-create':
+      return [
+        ...flagValue('--task', operation.task),
+        ...flagValue('--question', operation.question),
+        ...(operation.options === undefined ? [] : flagValue('--options', JSON.stringify(operation.options))),
+      ];
+    case 'gate-list':
+      return [...optionalFlag('--task', operation.task), ...optionalFlag('--status', operation.status)];
+    case 'gate-resolve':
+      return [...flagValue('--id', operation.id), ...flagValue('--resolution', operation.resolution)];
+  }
+}
+
+const executableToken = z
+  .string()
+  .min(1)
+  .max(1024)
+  .refine((value) => !/[\s;&|`$<>\r\n\0]/.test(value))
+  .refine((value) => !value.includes('..'));
+
+export function resolveOrcaExecutable(
+  options: {
+    platform?: NodeJS.Platform;
+    env?: Readonly<Record<string, string | undefined>>;
+    managedTerminal?: boolean;
+  } = {},
+): string {
+  const platform = options.platform ?? process.platform;
+  const env = options.env ?? process.env;
+  if (env.ORCA_CLI_COMMAND !== undefined) {
+    const parsed = executableToken.safeParse(env.ORCA_CLI_COMMAND);
+    if (!parsed.success) {
+      throw new OrcaAdapterError(
+        'unsupported_environment',
+        'runtime',
+        'resolve',
+        'safe',
+        'Provide ORCA_CLI_COMMAND as one executable token without flags.',
+        'ORCA_CLI_COMMAND is not a safe executable token',
+      );
+    }
+    return parsed.data;
+  }
+  if (platform === 'win32') return 'orca.exe';
+  if (platform === 'darwin') return 'orca';
+  if (platform === 'linux') return options.managedTerminal === true ? 'orca' : 'orca-ide';
+  throw new OrcaAdapterError(
+    'unsupported_platform',
+    'runtime',
+    'resolve',
+    'safe',
+    'Run the adapter on a supported Orca host.',
+    `unsupported platform: ${platform}`,
+  );
+}
+
+export interface OrcaProcessRequest {
+  executable: string;
+  argv: readonly string[];
+  shell: false;
+  timeoutMs: number;
+  maxStdoutBytes: number;
+  maxStderrBytes: number;
+  env: Readonly<Record<string, string | undefined>>;
+}
+
+export interface OrcaProcessResult {
+  exitCode: number | null;
+  signal?: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  timedOut?: boolean;
+  outputLimited?: boolean;
+}
+
+export type OrcaProcessExecutor = (request: OrcaProcessRequest) => Promise<OrcaProcessResult>;
+
+export const DEFAULT_ORCA_TIMEOUT_MS = 30_000;
+export const MAX_ORCA_STDOUT_BYTES = 1_048_576;
+export const MAX_ORCA_STDERR_BYTES = 65_536;
+
+export const spawnOrcaProcess: OrcaProcessExecutor = async (request) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(request.executable, [...request.argv], {
+      shell: request.shell,
+      env: request.env as NodeJS.ProcessEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let settled = false;
+    let timedOut = false;
+    let outputLimited = false;
+    const stop = () => child.kill('SIGTERM');
+    const timer = setTimeout(() => {
+      timedOut = true;
+      stop();
+    }, request.timeoutMs);
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdoutBytes += chunk.length;
+      if (stdoutBytes > request.maxStdoutBytes) {
+        outputLimited = true;
+        stop();
+      } else stdout.push(chunk);
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderrBytes += chunk.length;
+      if (stderrBytes > request.maxStderrBytes) {
+        outputLimited = true;
+        stop();
+      } else stderr.push(chunk);
+    });
+    child.once('error', (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once('close', (exitCode, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({
+        exitCode,
+        signal,
+        stdout: Buffer.concat(stdout).toString('utf8'),
+        stderr: Buffer.concat(stderr).toString('utf8'),
+        timedOut,
+        outputLimited,
+      });
+    });
+  });
+
+const envelopeSchema = z
+  .object({
+    id: z.string().min(1).max(256),
+    ok: z.boolean(),
+    result: z.unknown().optional(),
+    error: z
+      .object({ code: z.string().min(1).max(128), message: z.string().min(1).max(4096) })
+      .passthrough()
+      .optional(),
+    _meta: z.record(z.unknown()).optional(),
+  })
+  .strict()
+  .refine((value) => (value.ok ? value.result !== undefined && value.error === undefined : value.error !== undefined));
+
+export type OrcaJsonEnvelope = z.infer<typeof envelopeSchema>;
+
+function parseEnvelope(operation: OrcaOrchestrationVerb, stdout: string): OrcaJsonEnvelope {
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(stdout);
+  } catch {
+    throw new OrcaAdapterError(
+      'malformed_json',
+      operation,
+      'decode',
+      'safe',
+      'Inspect Orca health and retry this read-only operation when safe.',
+      'stdout was not one JSON document',
+    );
+  }
+  const parsed = envelopeSchema.safeParse(decoded);
+  if (!parsed.success) {
+    throw new OrcaAdapterError(
+      'unexpected_response',
+      operation,
+      'decode',
+      'safe',
+      'Use a compatible Orca CLI version.',
+      'stdout did not match the Orca envelope contract',
+    );
+  }
+  return parsed.data;
+}
+
+export interface OrcaAdapterOptions {
+  executor?: OrcaProcessExecutor;
+  executable?: string;
+  env?: Readonly<Record<string, string | undefined>>;
+  managedTerminal?: boolean;
+  timeoutMs?: number;
+}
+
+export interface OrcaOrchestrationAdapter {
+  readonly executable: string;
+  execute(input: unknown): Promise<OrcaJsonEnvelope>;
+}
+
+const mutationVerbs = new Set<OrcaOrchestrationVerb>([
+  'run-create',
+  'run-use',
+  'task-create',
+  'task-update',
+  'worker-start',
+  'worker-release',
+  'send',
+  'reply',
+  'ask',
+  'gate-create',
+  'gate-resolve',
+]);
+
+function hasAcknowledgement(operation: OrcaOrchestrationVerb, input: unknown): boolean {
+  return operation === 'check' && typeof input === 'object' && input !== null && 'ack' in input;
+}
+
+function processFailure(
+  operation: OrcaOrchestrationVerb,
+  input: unknown,
+  result: OrcaProcessResult,
+): OrcaAdapterError | undefined {
+  const acknowledgement = hasAcknowledgement(operation, input);
+  const mutation = mutationVerbs.has(operation) || acknowledgement;
+  if (result.outputLimited) {
+    return new OrcaAdapterError(
+      'output_limit',
+      operation,
+      'execute',
+      mutation ? 'readback-required' : 'safe',
+      'Inspect state with the documented read operation before retrying.',
+      'Orca output exceeded the adapter limit',
+    );
+  }
+  if (result.timedOut) {
+    return new OrcaAdapterError(
+      acknowledgement ? 'ambiguous_after_possible_commit' : 'timeout',
+      operation,
+      'execute',
+      acknowledgement ? 'unrecoverably-ambiguous' : mutation ? 'readback-required' : 'safe',
+      acknowledgement
+        ? 'Do not acknowledge again automatically; only external confirmation can establish whether it committed.'
+        : 'Use the documented public readback before retrying a mutation.',
+      'Orca did not finish before the deadline',
+    );
+  }
+  if (result.exitCode !== 0) {
+    return new OrcaAdapterError(
+      'process_exit',
+      operation,
+      'execute',
+      mutation ? 'readback-required' : 'safe',
+      'Inspect Orca state and use the documented recovery operation.',
+      `Orca exited with status ${result.exitCode ?? 'signal'}`,
+      result.stderr.slice(-4096),
+    );
+  }
+  return undefined;
+}
+
+export function createOrcaOrchestrationAdapter(options: OrcaAdapterOptions = {}): OrcaOrchestrationAdapter {
+  const env = Object.freeze({ ...(options.env ?? process.env) });
+  const executable =
+    options.executable ??
+    resolveOrcaExecutable({ env, managedTerminal: options.managedTerminal ?? env.TERM_PROGRAM === 'Orca' });
+  const executor = options.executor ?? spawnOrcaProcess;
+  const defaultTimeout = options.timeoutMs ?? DEFAULT_ORCA_TIMEOUT_MS;
+  return Object.freeze({
+    executable,
+    async execute(input: unknown): Promise<OrcaJsonEnvelope> {
+      const argv = buildOrcaOrchestrationArgv(input);
+      const operation = argv[1] as OrcaOrchestrationVerb;
+      let result: OrcaProcessResult;
+      try {
+        result = await executor({
+          executable,
+          argv,
+          shell: false,
+          timeoutMs: defaultTimeout,
+          maxStdoutBytes: MAX_ORCA_STDOUT_BYTES,
+          maxStderrBytes: MAX_ORCA_STDERR_BYTES,
+          env,
+        });
+      } catch (error) {
+        throw new OrcaAdapterError(
+          'executable_unavailable',
+          operation,
+          'execute',
+          'safe',
+          `Verify that ${executable} is installed and available to the plugin host.`,
+          error instanceof Error ? error.message : 'failed to launch Orca',
+        );
+      }
+      const failure = processFailure(operation, input, result);
+      if (failure !== undefined) throw failure;
+      const envelope = parseEnvelope(operation, result.stdout);
+      if (!envelope.ok) {
+        const isMutation = mutationVerbs.has(operation) || hasAcknowledgement(operation, input);
+        throw new OrcaAdapterError(
+          'unexpected_response',
+          operation,
+          'decode',
+          isMutation ? 'readback-required' : 'safe',
+          'Follow the public Orca diagnostic and inspect state before retrying.',
+          envelope.error?.message ?? 'Orca returned an error envelope',
+        );
+      }
+      return envelope;
+    },
+  });
+}

--- a/src/lib/orca-orchestration-adapter.ts
+++ b/src/lib/orca-orchestration-adapter.ts
@@ -1024,7 +1024,12 @@ async function finalizeMutation(
   validateMutationReceipt(operation, envelope);
   const plan = readbackPlan(operation, envelope.result);
   if (plan !== undefined) {
-    const readback = await invoke(plan.operation);
+    let readback: OrcaJsonEnvelope;
+    try {
+      readback = await invoke(plan.operation);
+    } catch (error) {
+      throw mapReadbackFailure(operation.operation, plan.operation.operation, error);
+    }
     if (!plan.matches(readback.result)) {
       throw new OrcaAdapterError(
         'readback_mismatch',
@@ -1047,6 +1052,32 @@ async function finalizeMutation(
     readbackVerb: plan?.operation.operation ?? null,
   });
   return Object.freeze({ ...envelope, receipt });
+}
+
+function mapReadbackFailure(
+  mutation: OrcaOrchestrationVerb,
+  readback: OrcaOrchestrationVerb,
+  error: unknown,
+): OrcaAdapterError {
+  if (!(error instanceof OrcaAdapterError)) {
+    return new OrcaAdapterError(
+      'unexpected_response',
+      mutation,
+      'readback',
+      'unrecoverably-ambiguous',
+      `Inspect state with orchestration ${readback}; do not retry the mutation automatically.`,
+      `${readback} failed after Orca returned a valid mutation receipt`,
+    );
+  }
+  return new OrcaAdapterError(
+    error.code,
+    mutation,
+    'readback',
+    'readback-required',
+    `Repeat or inspect orchestration ${readback}; do not retry the mutation automatically.`,
+    `${readback} failed after Orca returned a valid mutation receipt: ${error.message}`,
+    error.stderr,
+  );
 }
 
 function validateMutationReceipt(operation: ValidatedOrcaOperation, envelope: OrcaJsonEnvelope): void {

--- a/src/lib/orca-orchestration-adapter.ts
+++ b/src/lib/orca-orchestration-adapter.ts
@@ -343,36 +343,13 @@ function buildArguments(operation: ValidatedOrcaOperation): string[] {
   }
 }
 
-const executableToken = z
-  .string()
-  .min(1)
-  .max(1024)
-  .refine((value) => !/[\s;&|`$<>\r\n\0]/.test(value))
-  .refine((value) => !value.includes('..'));
-
 export function resolveOrcaExecutable(
   options: {
     platform?: NodeJS.Platform;
-    env?: Readonly<Record<string, string | undefined>>;
     managedTerminal?: boolean;
   } = {},
 ): string {
   const platform = options.platform ?? process.platform;
-  const env = options.env ?? process.env;
-  if (env.ORCA_CLI_COMMAND !== undefined) {
-    const parsed = executableToken.safeParse(env.ORCA_CLI_COMMAND);
-    if (!parsed.success) {
-      throw new OrcaAdapterError(
-        'unsupported_environment',
-        'runtime',
-        'resolve',
-        'safe',
-        'Provide ORCA_CLI_COMMAND as one executable token without flags.',
-        'ORCA_CLI_COMMAND is not a safe executable token',
-      );
-    }
-    return parsed.data;
-  }
   if (platform === 'win32') return 'orca.exe';
   if (platform === 'darwin') return 'orca';
   if (platform === 'linux') return options.managedTerminal === true ? 'orca' : 'orca-ide';
@@ -412,8 +389,9 @@ export const DEFAULT_ORCA_TIMEOUT_MS = 30_000;
 export const MAX_ORCA_STDOUT_BYTES = 1_048_576;
 export const MAX_ORCA_STDERR_BYTES = 65_536;
 const ORCA_KILL_GRACE_MS = 1_000;
+const ORCA_CLOSE_GRACE_MS = 1_000;
 
-export const spawnOrcaProcess: OrcaProcessExecutor = async (request) =>
+const spawnOrcaProcess: OrcaProcessExecutor = async (request) =>
   new Promise((resolve, reject) => {
     const child = spawn(request.executable, [...request.argv], {
       shell: request.shell,
@@ -428,10 +406,35 @@ export const spawnOrcaProcess: OrcaProcessExecutor = async (request) =>
     let settled = false;
     let timedOut = false;
     let outputLimited = false;
+    let spawned = false;
     let killTimer: ReturnType<typeof setTimeout> | undefined;
+    let closeTimer: ReturnType<typeof setTimeout> | undefined;
+    const finish = (result: OrcaProcessResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (killTimer !== undefined) clearTimeout(killTimer);
+      if (closeTimer !== undefined) clearTimeout(closeTimer);
+      resolve(result);
+    };
     const stop = () => {
       child.kill('SIGTERM');
-      killTimer ??= setTimeout(() => child.kill('SIGKILL'), ORCA_KILL_GRACE_MS);
+      killTimer ??= setTimeout(() => {
+        child.kill('SIGKILL');
+        closeTimer ??= setTimeout(
+          () =>
+            finish({
+              exitCode: null,
+              signal: 'SIGKILL',
+              stdout: Buffer.concat(stdout).toString('utf8'),
+              stderr: Buffer.concat(stderr).toString('utf8'),
+              timedOut,
+              outputLimited,
+              transportLost: true,
+            }),
+          ORCA_CLOSE_GRACE_MS,
+        );
+      }, ORCA_KILL_GRACE_MS);
     };
     const timer = setTimeout(() => {
       timedOut = true;
@@ -451,19 +454,31 @@ export const spawnOrcaProcess: OrcaProcessExecutor = async (request) =>
         stop();
       } else stderr.push(chunk);
     });
+    child.once('spawn', () => {
+      spawned = true;
+    });
     child.once('error', (error) => {
       if (settled) return;
+      if (spawned) {
+        finish({
+          exitCode: null,
+          stdout: Buffer.concat(stdout).toString('utf8'),
+          stderr: `${Buffer.concat(stderr).toString('utf8')}\nprocess transport error: ${error.message}`,
+          timedOut,
+          outputLimited,
+          transportLost: true,
+        });
+        return;
+      }
       settled = true;
       clearTimeout(timer);
       if (killTimer !== undefined) clearTimeout(killTimer);
+      if (closeTimer !== undefined) clearTimeout(closeTimer);
       reject(error);
     });
     child.once('close', (exitCode, signal) => {
       if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      if (killTimer !== undefined) clearTimeout(killTimer);
-      resolve({
+      finish({
         exitCode,
         signal,
         stdout: Buffer.concat(stdout).toString('utf8'),
@@ -504,7 +519,10 @@ const gateEntity = receipt({
   resolution: longText.optional(),
 });
 const messageReceipt = receipt({ messageId: id });
-const askReceipt = receipt({ messageId: id, state: z.enum(['answered', 'pending']), answer: longText.optional() });
+const askReceipt = z.union([
+  receipt({ messageId: id, state: z.literal('answered'), answer: longText }),
+  receipt({ messageId: id, state: z.literal('pending') }),
+]);
 const checkResult = receipt({
   deliveryId: id.optional(),
   acknowledged: z.boolean().optional(),
@@ -543,7 +561,7 @@ const envelopeSchema = z
     result: z.unknown().optional(),
     error: z
       .object({ code: z.string().min(1).max(128), message: z.string().min(1).max(4096) })
-      .passthrough()
+      .strict()
       .optional(),
     _meta: z
       .object({
@@ -556,7 +574,11 @@ const envelopeSchema = z
       .optional(),
   })
   .strict()
-  .refine((value) => (value.ok ? value.result !== undefined && value.error === undefined : value.error !== undefined));
+  .refine((value) =>
+    value.ok
+      ? value.result !== undefined && value.error === undefined
+      : value.result === undefined && value.error !== undefined,
+  );
 
 export type OrcaJsonEnvelope = z.infer<typeof envelopeSchema>;
 
@@ -572,30 +594,44 @@ export interface OrcaMutationReceipt {
 
 export type OrcaAdapterResponse = OrcaJsonEnvelope & { readonly receipt?: OrcaMutationReceipt };
 
-function parseEnvelope(operation: OrcaOrchestrationVerb, stdout: string): OrcaJsonEnvelope {
-  const mutation = mutationVerbs.has(operation);
+function ambiguousMutationError(
+  operation: OrcaOrchestrationVerb,
+  phase: 'execute' | 'decode' | 'receipt',
+  message: string,
+): OrcaAdapterError {
+  return new OrcaAdapterError(
+    'ambiguous_after_possible_commit',
+    operation,
+    phase,
+    'unrecoverably-ambiguous',
+    'Do not retry automatically; inspect the documented public read operation before choosing another mutation.',
+    message,
+  );
+}
+
+function parseEnvelope(operation: OrcaOrchestrationVerb, stdout: string, mutation: boolean): OrcaJsonEnvelope {
   let decoded: unknown;
   try {
     decoded = parseJsonRejectingDuplicateKeys(stdout);
   } catch {
+    if (mutation) throw ambiguousMutationError(operation, 'decode', 'stdout was not one JSON document');
     throw new OrcaAdapterError(
       'malformed_json',
       operation,
       'decode',
-      mutation ? 'readback-required' : 'safe',
-      mutation
-        ? 'Inspect state with the documented public read operation; do not retry the mutation automatically.'
-        : 'Inspect Orca health and retry this read-only operation when safe.',
+      'safe',
+      'Inspect Orca health and retry this read-only operation when safe.',
       'stdout was not one JSON document',
     );
   }
   const parsed = envelopeSchema.safeParse(decoded);
   if (!parsed.success) {
+    if (mutation) throw ambiguousMutationError(operation, 'decode', 'stdout did not match the Orca envelope contract');
     throw new OrcaAdapterError(
       'unexpected_response',
       operation,
       'decode',
-      mutation ? 'readback-required' : 'safe',
+      'safe',
       'Use a compatible Orca CLI version.',
       'stdout did not match the Orca envelope contract',
     );
@@ -603,11 +639,17 @@ function parseEnvelope(operation: OrcaOrchestrationVerb, stdout: string): OrcaJs
   if (parsed.data.ok) {
     const result = responseSchemas[operation].safeParse(parsed.data.result);
     if (!result.success) {
+      if (mutation)
+        throw ambiguousMutationError(
+          operation,
+          'receipt',
+          `success result did not match the finite ${operation} response contract`,
+        );
       throw new OrcaAdapterError(
-        mutationVerbs.has(operation) ? 'missing_receipt' : 'unexpected_response',
+        'unexpected_response',
         operation,
-        mutationVerbs.has(operation) ? 'receipt' : 'decode',
-        mutationVerbs.has(operation) ? 'readback-required' : 'safe',
+        'decode',
+        'safe',
         'Use a compatible Orca CLI version and inspect the public operation result.',
         `success result did not match the finite ${operation} response contract`,
       );
@@ -650,11 +692,11 @@ function parseJsonRejectingDuplicateKeys(text: string): unknown {
   return JSON.parse(text);
 }
 
-export interface OrcaAdapterOptions {
+interface OrcaAdapterTestOptions {
   executor?: OrcaProcessExecutor;
-  executable?: string;
   env?: Readonly<Record<string, string | undefined>>;
   managedTerminal?: boolean;
+  platform?: NodeJS.Platform;
   timeoutMs?: number;
   now?: () => Date;
 }
@@ -734,17 +776,13 @@ function readbackPlan(operation: ValidatedOrcaOperation, result: unknown): Readb
       matches: (readback) => {
         if (mutation.gateId !== operation.id || mutation.taskId !== operation.task) return false;
         const gates = recordOf(readback).gates;
+        if (!Array.isArray(gates)) return false;
+        const matching = gates.map(recordOf).filter((gate) => gate.id === operation.id);
         return (
-          Array.isArray(gates) &&
-          gates.some((value) => {
-            const gate = recordOf(value);
-            return (
-              gate.id === operation.id &&
-              gate.taskId === operation.task &&
-              gate.status === 'resolved' &&
-              gate.resolution === operation.resolution
-            );
-          })
+          matching.length === 1 &&
+          matching[0].taskId === operation.task &&
+          matching[0].status === 'resolved' &&
+          matching[0].resolution === operation.resolution
         );
       },
     };
@@ -774,14 +812,17 @@ function readbackPlan(operation: ValidatedOrcaOperation, result: unknown): Readb
     };
   }
   if (operation.operation === 'task-create' || operation.operation === 'task-update') {
-    const taskId = operation.operation === 'task-create' ? recordOf(result).taskId : operation.id;
+    const mutation = recordOf(result);
+    const taskId = operation.operation === 'task-create' ? mutation.taskId : operation.id;
     return {
       operation: { operation: 'task-list' },
       matches: (readback) => {
+        if (mutation.taskId !== taskId) return false;
         const tasks = recordOf(readback).tasks;
         if (!Array.isArray(tasks)) return false;
-        const task = tasks.map(recordOf).find((candidate) => candidate.id === taskId);
-        if (task === undefined) return false;
+        const matching = tasks.map(recordOf).filter((candidate) => candidate.id === taskId);
+        if (matching.length !== 1) return false;
+        const task = matching[0];
         return operation.operation === 'task-create'
           ? task.spec === operation.spec &&
               task.title === operation.title &&
@@ -792,12 +833,14 @@ function readbackPlan(operation: ValidatedOrcaOperation, result: unknown): Readb
     };
   }
   if (operation.operation === 'worker-start') {
-    const dispatchId = recordOf(result).dispatchId;
+    const mutation = recordOf(result);
+    const dispatchId = mutation.dispatchId;
     return {
       operation: { operation: 'worker-show', dispatch: String(dispatchId) },
       matches: (readback) => {
         const worker = recordOf(recordOf(readback).dispatch);
         return (
+          mutation.taskId === operation.task &&
           worker.id === dispatchId &&
           worker.taskId === operation.task &&
           worker.agent === operation.agent &&
@@ -808,13 +851,17 @@ function readbackPlan(operation: ValidatedOrcaOperation, result: unknown): Readb
     };
   }
   if (operation.operation === 'gate-create') {
-    const gateId = recordOf(result).gateId;
+    const mutation = recordOf(result);
+    const gateId = mutation.gateId;
     return {
       operation: { operation: 'gate-list', task: operation.task },
       matches: (readback) => {
         const gates = recordOf(readback).gates;
         if (!Array.isArray(gates)) return false;
-        const gate = gates.map(recordOf).find((candidate) => candidate.id === gateId);
+        if (mutation.taskId !== operation.task) return false;
+        const matching = gates.map(recordOf).filter((candidate) => candidate.id === gateId);
+        if (matching.length !== 1) return false;
+        const gate = matching[0];
         return (
           gate?.taskId === operation.task &&
           gate.question === operation.question &&
@@ -834,32 +881,36 @@ function processFailure(
   const acknowledgement = hasAcknowledgement(operation, input);
   const mutation = mutationVerbs.has(operation) || acknowledgement;
   if (result.outputLimited || result.transportLost) {
-    return new OrcaAdapterError(
-      mutation ? 'ambiguous_after_possible_commit' : result.outputLimited ? 'output_limit' : 'process_exit',
+    if (mutation)
+      return ambiguousMutationError(
+        operation,
+        'execute',
+        result.outputLimited
+          ? 'Orca output exceeded the adapter limit'
+          : 'Orca transport closed before a valid response',
+      );
+    return safeProcessError(
       operation,
-      'execute',
-      mutation ? 'unrecoverably-ambiguous' : 'safe',
-      mutation
-        ? 'Do not retry automatically; inspect the documented public read before choosing another mutation.'
-        : 'Retry the read-only operation when Orca is healthy.',
+      result.outputLimited ? 'output_limit' : 'process_exit',
       result.outputLimited ? 'Orca output exceeded the adapter limit' : 'Orca transport closed before a valid response',
     );
   }
   if (result.timedOut) {
-    return new OrcaAdapterError(
-      mutation ? 'ambiguous_after_possible_commit' : 'timeout',
-      operation,
-      'execute',
-      mutation ? 'unrecoverably-ambiguous' : 'safe',
-      mutation
-        ? acknowledgement
-          ? 'Do not acknowledge again automatically; only external confirmation can establish whether it committed.'
-          : 'Do not retry automatically; use the documented public readback before choosing another mutation.'
-        : 'Retry the read-only operation when Orca is healthy.',
-      'Orca did not finish before the deadline',
-    );
+    return mutation
+      ? ambiguousMutationError(operation, 'execute', 'Orca did not finish before the deadline')
+      : safeProcessError(operation, 'timeout', 'Orca did not finish before the deadline');
   }
   if (result.exitCode !== 0) {
+    if (mutation)
+      return new OrcaAdapterError(
+        'ambiguous_after_possible_commit',
+        operation,
+        'execute',
+        'unrecoverably-ambiguous',
+        'Do not retry automatically; inspect the documented public read operation before choosing another mutation.',
+        `Orca exited with status ${result.exitCode ?? 'signal'}`,
+        result.stderr,
+      );
     return new OrcaAdapterError(
       'process_exit',
       operation,
@@ -873,11 +924,27 @@ function processFailure(
   return undefined;
 }
 
-export function createOrcaOrchestrationAdapter(options: OrcaAdapterOptions = {}): OrcaOrchestrationAdapter {
+function safeProcessError(
+  operation: OrcaOrchestrationVerb,
+  code: 'timeout' | 'output_limit' | 'process_exit',
+  message: string,
+): OrcaAdapterError {
+  return new OrcaAdapterError(
+    code,
+    operation,
+    'execute',
+    'safe',
+    'Retry the read-only operation when Orca is healthy.',
+    message,
+  );
+}
+
+function createAdapter(options: OrcaAdapterTestOptions = {}): OrcaOrchestrationAdapter {
   const env = Object.freeze({ ...(options.env ?? process.env) });
-  const executable =
-    options.executable ??
-    resolveOrcaExecutable({ env, managedTerminal: options.managedTerminal ?? env.TERM_PROGRAM === 'Orca' });
+  const executable = resolveOrcaExecutable({
+    platform: options.platform,
+    managedTerminal: options.managedTerminal ?? env.TERM_PROGRAM === 'Orca',
+  });
   const executor = options.executor ?? spawnOrcaProcess;
   const defaultTimeout = options.timeoutMs ?? DEFAULT_ORCA_TIMEOUT_MS;
   const now = options.now ?? (() => new Date());
@@ -896,25 +963,28 @@ export function createOrcaOrchestrationAdapter(options: OrcaAdapterOptions = {})
       });
     } catch (error) {
       throw new OrcaAdapterError(
-        mutationVerbs.has(operation.operation) || hasAcknowledgement(operation.operation, operation)
-          ? 'ambiguous_after_possible_commit'
-          : 'executable_unavailable',
+        'executable_unavailable',
         operation.operation,
-        'execute',
-        mutationVerbs.has(operation.operation) || hasAcknowledgement(operation.operation, operation)
-          ? 'unrecoverably-ambiguous'
-          : 'safe',
-        'Verify that the selected Orca executable is available; do not retry a mutation without public state proof.',
+        'resolve',
+        'safe',
+        'Verify that the deterministic Orca executable is installed and available, then retry.',
         error instanceof Error && 'code' in error
           ? `Orca execution failed (${String(error.code)})`
           : 'Orca execution failed',
       );
     }
+    result = { ...result, stderr: sanitizeStderr(result.stderr, operation, env) };
+    const isMutation = mutationVerbs.has(operation.operation) || hasAcknowledgement(operation.operation, operation);
     const failure = processFailure(operation.operation, operation, result);
     if (failure !== undefined) throw failure;
-    const envelope = parseEnvelope(operation.operation, result.stdout);
+    const envelope = parseEnvelope(operation.operation, result.stdout, isMutation);
     if (!envelope.ok) {
-      const isMutation = mutationVerbs.has(operation.operation) || hasAcknowledgement(operation.operation, operation);
+      if (isMutation)
+        throw ambiguousMutationError(
+          operation.operation,
+          'decode',
+          envelope.error?.message ?? 'Orca returned an error envelope',
+        );
       throw new OrcaAdapterError(
         'unexpected_response',
         operation.operation,
@@ -939,76 +1009,154 @@ export function createOrcaOrchestrationAdapter(options: OrcaAdapterOptions = {})
       const envelope = await invoke(operation);
       if (!mutationVerbs.has(operation.operation) && !hasAcknowledgement(operation.operation, operation))
         return envelope;
-
-      if (envelope._meta?.runtimeId === undefined || envelope._meta.runtimeVersion === undefined) {
-        throw new OrcaAdapterError(
-          'missing_receipt',
-          operation.operation,
-          'receipt',
-          'readback-required',
-          'Use a compatible Orca CLI version and inspect the documented public state before retrying.',
-          'mutation receipt omitted bounded runtime identity/version metadata',
-        );
-      }
-
-      if (
-        operation.operation === 'check' &&
-        operation.ack !== undefined &&
-        (recordOf(envelope.result).deliveryId !== operation.ack || recordOf(envelope.result).acknowledged !== true)
-      ) {
-        throw new OrcaAdapterError(
-          'missing_receipt',
-          operation.operation,
-          'receipt',
-          'unrecoverably-ambiguous',
-          'Do not acknowledge again automatically; only external confirmation can establish whether it committed.',
-          'check --ack success did not contain its matching delivery identifier',
-        );
-      }
-
-      const plan = readbackPlan(operation, envelope.result);
-      if (operation.operation === 'run-use') {
-        const meta = envelope._meta as Record<string, unknown> | undefined;
-        if (recordOf(envelope.result).coordinatorTerminalHandle !== meta?.invokingTerminal) {
-          throw new OrcaAdapterError(
-            'readback_mismatch',
-            operation.operation,
-            'readback',
-            'unsafe',
-            'Inspect orchestration run-current; do not retry run-use automatically.',
-            'run-use terminal binding was not runtime-attested',
-          );
-        }
-      }
-      if (plan !== undefined) {
-        const readback = await invoke(plan.operation);
-        if (!plan.matches(readback.result)) {
-          throw new OrcaAdapterError(
-            'readback_mismatch',
-            operation.operation,
-            'readback',
-            'unsafe',
-            `Inspect state with orchestration ${plan.operation.operation}; do not retry the mutation automatically.`,
-            `${plan.operation.operation} disagreed with the mutation receipt`,
-          );
-        }
-      }
-      const meta = envelope._meta as Record<string, unknown> | undefined;
-      const receipt: OrcaMutationReceipt = Object.freeze({
-        verb: operation.operation,
-        ids: receiptIds(operation.operation, envelope.result),
-        runtimeId: typeof meta?.runtimeId === 'string' ? meta.runtimeId : null,
-        runtimeVersion:
-          typeof meta?.runtimeVersion === 'string'
-            ? meta.runtimeVersion
-            : typeof meta?.version === 'string'
-              ? meta.version
-              : null,
-        startedAt,
-        completedAt: now().toISOString(),
-        readbackVerb: plan?.operation.operation ?? null,
-      });
-      return Object.freeze({ ...envelope, receipt });
+      return finalizeMutation(operation, envelope, startedAt, invoke, now);
     },
   });
 }
+
+async function finalizeMutation(
+  operation: ValidatedOrcaOperation,
+  envelope: OrcaJsonEnvelope,
+  startedAt: string,
+  invoke: (operation: ValidatedOrcaOperation) => Promise<OrcaJsonEnvelope>,
+  now: () => Date,
+): Promise<OrcaAdapterResponse> {
+  validateMutationReceipt(operation, envelope);
+  const plan = readbackPlan(operation, envelope.result);
+  if (plan !== undefined) {
+    const readback = await invoke(plan.operation);
+    if (!plan.matches(readback.result)) {
+      throw new OrcaAdapterError(
+        'readback_mismatch',
+        operation.operation,
+        'readback',
+        'unsafe',
+        `Inspect state with orchestration ${plan.operation.operation}; do not retry the mutation automatically.`,
+        `${plan.operation.operation} disagreed with the mutation receipt`,
+      );
+    }
+  }
+  const meta = envelope._meta as Record<string, unknown>;
+  const receipt: OrcaMutationReceipt = Object.freeze({
+    verb: operation.operation,
+    ids: receiptIds(operation.operation, envelope.result),
+    runtimeId: meta.runtimeId as string,
+    runtimeVersion: meta.runtimeVersion as string,
+    startedAt,
+    completedAt: now().toISOString(),
+    readbackVerb: plan?.operation.operation ?? null,
+  });
+  return Object.freeze({ ...envelope, receipt });
+}
+
+function validateMutationReceipt(operation: ValidatedOrcaOperation, envelope: OrcaJsonEnvelope): void {
+  if (envelope._meta?.runtimeId === undefined || envelope._meta.runtimeVersion === undefined) {
+    throw ambiguousMutationError(
+      operation.operation,
+      'receipt',
+      'mutation receipt omitted bounded runtime identity/version metadata',
+    );
+  }
+  if (!receiptMatchesRequest(operation, envelope.result)) {
+    throw new OrcaAdapterError(
+      'readback_mismatch',
+      operation.operation,
+      'receipt',
+      'unsafe',
+      'Inspect the requested entity with its documented public read operation; do not retry automatically.',
+      'mutation receipt identity disagreed with the requested entity',
+    );
+  }
+  if (
+    operation.operation === 'check' &&
+    operation.ack !== undefined &&
+    recordOf(envelope.result).acknowledged !== true
+  ) {
+    throw ambiguousMutationError(
+      operation.operation,
+      'receipt',
+      'check --ack success did not contain its matching delivery identifier',
+    );
+  }
+  if (
+    operation.operation === 'run-use' &&
+    recordOf(envelope.result).coordinatorTerminalHandle !== envelope._meta.invokingTerminal
+  ) {
+    throw new OrcaAdapterError(
+      'readback_mismatch',
+      operation.operation,
+      'readback',
+      'unsafe',
+      'Inspect orchestration run-current; do not retry run-use automatically.',
+      'run-use terminal binding was not runtime-attested',
+    );
+  }
+}
+
+function receiptMatchesRequest(operation: ValidatedOrcaOperation, result: unknown): boolean {
+  const value = recordOf(result);
+  switch (operation.operation) {
+    case 'run-use':
+      return value.runId === operation.id;
+    case 'task-update':
+      return value.taskId === operation.id;
+    case 'worker-start':
+      return value.taskId === operation.task;
+    case 'worker-release':
+      return value.dispatchId === operation.dispatch;
+    case 'reply':
+      return value.messageId === operation.id;
+    case 'ask':
+      return operation.resume === undefined || value.messageId === operation.resume;
+    case 'check':
+      return operation.ack === undefined || value.deliveryId === operation.ack;
+    case 'gate-create':
+      return value.taskId === operation.task;
+    case 'gate-resolve':
+      return value.gateId === operation.id && value.taskId === operation.task;
+    default:
+      return true;
+  }
+}
+
+function sanitizeStderr(
+  stderr: string,
+  operation: ValidatedOrcaOperation,
+  env: Readonly<Record<string, string | undefined>>,
+): string {
+  let safe = [...stderr]
+    .filter((character) => {
+      const code = character.charCodeAt(0);
+      return code === 9 || code === 10 || code === 13 || (code >= 32 && code !== 127 && code < 128) || code > 159;
+    })
+    .join('');
+  const requestValues = collectStringValues(operation);
+  const secrets = Object.entries(env)
+    .filter(
+      ([key, value]) => value !== undefined && /(?:TOKEN|SECRET|PASSWORD|PASS|KEY|CREDENTIAL|AUTH|COOKIE)/i.test(key),
+    )
+    .map(([, value]) => value as string);
+  for (const value of [...requestValues, ...secrets]
+    .filter((candidate) => candidate.length >= 3)
+    .sort((a, b) => b.length - a.length)) {
+    safe = safe.split(value).join('[REDACTED]');
+  }
+  const bytes = Buffer.from(safe, 'utf8');
+  return bytes.length <= 4096
+    ? safe
+    : Buffer.concat([Buffer.from('[truncated] '), bytes.subarray(bytes.length - 4084)]).toString('utf8');
+}
+
+function collectStringValues(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (Array.isArray(value)) return value.flatMap(collectStringValues);
+  if (typeof value === 'object' && value !== null) return Object.values(value).flatMap(collectStringValues);
+  return [];
+}
+
+export function createOrcaOrchestrationAdapter(): OrcaOrchestrationAdapter {
+  return createAdapter();
+}
+
+/** Test-only dependency seam. Production callers must use createOrcaOrchestrationAdapter. */
+export const __orcaAdapterTestOnly = Object.freeze({ createAdapter, spawnOrcaProcess });

--- a/src/lib/orca-orchestration-adapter.ts
+++ b/src/lib/orca-orchestration-adapter.ts
@@ -403,6 +403,7 @@ export interface OrcaProcessResult {
   stderr: string;
   timedOut?: boolean;
   outputLimited?: boolean;
+  transportLost?: boolean;
 }
 
 export type OrcaProcessExecutor = (request: OrcaProcessRequest) => Promise<OrcaProcessResult>;
@@ -410,6 +411,7 @@ export type OrcaProcessExecutor = (request: OrcaProcessRequest) => Promise<OrcaP
 export const DEFAULT_ORCA_TIMEOUT_MS = 30_000;
 export const MAX_ORCA_STDOUT_BYTES = 1_048_576;
 export const MAX_ORCA_STDERR_BYTES = 65_536;
+const ORCA_KILL_GRACE_MS = 1_000;
 
 export const spawnOrcaProcess: OrcaProcessExecutor = async (request) =>
   new Promise((resolve, reject) => {
@@ -426,7 +428,11 @@ export const spawnOrcaProcess: OrcaProcessExecutor = async (request) =>
     let settled = false;
     let timedOut = false;
     let outputLimited = false;
-    const stop = () => child.kill('SIGTERM');
+    let killTimer: ReturnType<typeof setTimeout> | undefined;
+    const stop = () => {
+      child.kill('SIGTERM');
+      killTimer ??= setTimeout(() => child.kill('SIGKILL'), ORCA_KILL_GRACE_MS);
+    };
     const timer = setTimeout(() => {
       timedOut = true;
       stop();
@@ -449,12 +455,14 @@ export const spawnOrcaProcess: OrcaProcessExecutor = async (request) =>
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      if (killTimer !== undefined) clearTimeout(killTimer);
       reject(error);
     });
     child.once('close', (exitCode, signal) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      if (killTimer !== undefined) clearTimeout(killTimer);
       resolve({
         exitCode,
         signal,
@@ -466,47 +474,66 @@ export const spawnOrcaProcess: OrcaProcessExecutor = async (request) =>
     });
   });
 
-const jsonScalar = z.union([z.string(), z.number().finite(), z.boolean(), z.null()]);
-type JsonValue = z.infer<typeof jsonScalar> | JsonValue[] | { [key: string]: JsonValue };
-const jsonValue: z.ZodType<JsonValue> = z.lazy(() =>
-  z.union([jsonScalar, z.array(jsonValue).max(10_000), z.record(jsonValue)]),
-);
-const boundedResult = z
-  .record(jsonValue)
-  .refine((value) => Buffer.byteLength(JSON.stringify(value)) <= MAX_ORCA_STDOUT_BYTES);
-
-/*
- * Orca deliberately evolves the fields inside its public result objects.  The
- * adapter still keeps a finite contract: every supported verb is named here,
- * every result is an object, and mutations must expose the identifiers needed
- * for their receipt/readback proof.  No verb falls through to `unknown`.
- */
-const responseSchemas: Readonly<Record<OrcaOrchestrationVerb, z.ZodType<Record<string, JsonValue>>>> = {
-  'run-create': boundedResult.refine((value) => findString(value, ['runId', 'id']) !== undefined),
-  'run-list': boundedResult,
-  'run-show': boundedResult,
-  'run-current': boundedResult,
-  'run-use': boundedResult.refine((value) => findString(value, ['runId', 'id']) !== undefined),
-  'task-create': boundedResult.refine((value) => findString(value, ['taskId', 'id']) !== undefined),
-  'task-list': boundedResult,
-  'task-update': boundedResult.refine((value) => findString(value, ['taskId', 'id']) !== undefined),
-  'worker-start': boundedResult.refine(
-    (value) => findString(value, ['dispatchId', 'id']) !== undefined && findString(value, ['taskId']) !== undefined,
-  ),
-  'worker-show': boundedResult,
-  'worker-read': boundedResult,
-  'worker-release': boundedResult.refine((value) => findString(value, ['dispatchId', 'id']) !== undefined),
-  send: boundedResult.refine((value) => findString(value, ['messageId', 'id']) !== undefined),
-  check: boundedResult,
-  reply: boundedResult.refine((value) => findString(value, ['messageId', 'id']) !== undefined),
-  ask: boundedResult.refine((value) => findString(value, ['messageId', 'id']) !== undefined),
-  'gate-create': boundedResult.refine(
-    (value) => findString(value, ['gateId', 'id']) !== undefined && findString(value, ['taskId']) !== undefined,
-  ),
-  'gate-list': boundedResult,
-  'gate-resolve': boundedResult.refine(
-    (value) => findString(value, ['gateId', 'id']) !== undefined && findString(value, ['taskId']) !== undefined,
-  ),
+const terminalId = id;
+const receipt = (shape: z.ZodRawShape) => z.object(shape).strict();
+const runEntity = receipt({ id, objective: longText.optional(), coordinatorTerminalHandle: terminalId.optional() });
+const taskEntity = receipt({
+  id,
+  spec: longText,
+  title: shortText.optional(),
+  deps: uniqueArray(id, 64).optional(),
+  parent: id.optional(),
+  status: taskStatus,
+  result: result.optional(),
+});
+const workerEntity = receipt({
+  id,
+  taskId: id,
+  agent: agent.optional(),
+  model: model.optional(),
+  effort: effort.optional(),
+  state: itemText.optional(),
+  terminalDisposition: z.enum(['released', 'retained']).optional(),
+});
+const gateEntity = receipt({
+  id,
+  taskId: id,
+  question: shortText,
+  options: uniqueArray(itemText, 10, 1).optional(),
+  status: gateStatus,
+  resolution: longText.optional(),
+});
+const messageReceipt = receipt({ messageId: id });
+const askReceipt = receipt({ messageId: id, state: z.enum(['answered', 'pending']), answer: longText.optional() });
+const checkResult = receipt({
+  deliveryId: id.optional(),
+  acknowledged: z.boolean().optional(),
+  messages: z
+    .array(receipt({ id, type: messageType, subject: shortText }))
+    .max(50)
+    .optional(),
+  count: z.number().int().min(0).max(50).optional(),
+});
+const responseSchemas: Readonly<Record<OrcaOrchestrationVerb, z.ZodTypeAny>> = {
+  'run-create': receipt({ runId: id }),
+  'run-list': receipt({ runs: z.array(runEntity).max(100), cursor: cursor.optional() }),
+  'run-show': receipt({ run: runEntity }),
+  'run-current': receipt({ run: runEntity, coordinatorTerminalHandle: terminalId }),
+  'run-use': receipt({ runId: id, coordinatorTerminalHandle: terminalId }),
+  'task-create': receipt({ taskId: id }),
+  'task-list': receipt({ tasks: z.array(taskEntity).max(100) }),
+  'task-update': receipt({ taskId: id }),
+  'worker-start': receipt({ dispatchId: id, taskId: id }),
+  'worker-show': receipt({ dispatch: workerEntity }),
+  'worker-read': receipt({ dispatchId: id, source: workerSource, output: longText, cursor: cursor.optional() }),
+  'worker-release': receipt({ dispatchId: id }),
+  send: messageReceipt,
+  check: checkResult,
+  reply: messageReceipt,
+  ask: askReceipt,
+  'gate-create': receipt({ gateId: id, taskId: id }),
+  'gate-list': receipt({ gates: z.array(gateEntity).max(100) }),
+  'gate-resolve': receipt({ gateId: id, taskId: id }),
 };
 
 const envelopeSchema = z
@@ -518,7 +545,15 @@ const envelopeSchema = z
       .object({ code: z.string().min(1).max(128), message: z.string().min(1).max(4096) })
       .passthrough()
       .optional(),
-    _meta: z.record(z.unknown()).optional(),
+    _meta: z
+      .object({
+        runtimeId: id,
+        runtimeVersion: shortText.optional(),
+        version: shortText.optional(),
+        invokingTerminal: terminalId.optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .refine((value) => (value.ok ? value.result !== undefined && value.error === undefined : value.error !== undefined));
@@ -541,7 +576,7 @@ function parseEnvelope(operation: OrcaOrchestrationVerb, stdout: string): OrcaJs
   const mutation = mutationVerbs.has(operation);
   let decoded: unknown;
   try {
-    decoded = JSON.parse(stdout);
+    decoded = parseJsonRejectingDuplicateKeys(stdout);
   } catch {
     throw new OrcaAdapterError(
       'malformed_json',
@@ -581,6 +616,40 @@ function parseEnvelope(operation: OrcaOrchestrationVerb, stdout: string): OrcaJs
   return parsed.data;
 }
 
+function parseJsonRejectingDuplicateKeys(text: string): unknown {
+  const stack: Array<Set<string> | null> = [];
+  let expectingKey = false;
+  let index = 0;
+  while (index < text.length) {
+    const char = text[index];
+    if (char === '"') {
+      const start = index;
+      index += 1;
+      while (index < text.length) {
+        if (text[index] === '\\') index += 2;
+        else if (text[index] === '"') break;
+        else index += 1;
+      }
+      if (index >= text.length) throw new Error('unterminated JSON string');
+      if (expectingKey) {
+        const key = JSON.parse(text.slice(start, index + 1)) as string;
+        const keys = stack.at(-1);
+        if (keys === null || keys === undefined || keys.has(key)) throw new Error('duplicate JSON key');
+        keys.add(key);
+        expectingKey = false;
+      }
+    } else if (char === '{') {
+      stack.push(new Set());
+      expectingKey = true;
+    } else if (char === '[') stack.push(null);
+    else if (char === '}') stack.pop();
+    else if (char === ']') stack.pop();
+    else if (char === ',' && stack.at(-1) instanceof Set) expectingKey = true;
+    index += 1;
+  }
+  return JSON.parse(text);
+}
+
 export interface OrcaAdapterOptions {
   executor?: OrcaProcessExecutor;
   executable?: string;
@@ -613,83 +682,145 @@ function hasAcknowledgement(operation: OrcaOrchestrationVerb, input: unknown): b
   return operation === 'check' && typeof input === 'object' && input !== null && 'ack' in input;
 }
 
-function findString(value: unknown, keys: readonly string[]): string | undefined {
-  if (typeof value !== 'object' || value === null) return undefined;
-  if (Array.isArray(value)) {
-    for (const member of value) {
-      const found = findString(member, keys);
-      if (found !== undefined) return found;
-    }
-    return undefined;
-  }
-  const record = value as Record<string, unknown>;
-  for (const key of keys) if (typeof record[key] === 'string') return record[key];
-  for (const member of Object.values(record)) {
-    const found = findString(member, keys);
-    if (found !== undefined) return found;
-  }
-  return undefined;
+function recordOf(value: unknown): Record<string, unknown> {
+  return value as Record<string, unknown>;
 }
 
-function collectIds(value: unknown): Readonly<Record<string, string>> {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) return Object.freeze({});
-  const ids: Record<string, string> = {};
-  const visit = (entry: unknown): void => {
-    if (typeof entry !== 'object' || entry === null) return;
-    if (Array.isArray(entry)) {
-      entry.forEach(visit);
-      return;
-    }
-    for (const [key, member] of Object.entries(entry)) {
-      if ((key === 'id' || key.endsWith('Id')) && typeof member === 'string' && id.safeParse(member).success)
-        ids[key] = member;
-      else visit(member);
-    }
+function receiptIds(operation: OrcaOrchestrationVerb, value: unknown): Readonly<Record<string, string>> {
+  const result = recordOf(value);
+  const fields: Partial<Record<OrcaOrchestrationVerb, readonly string[]>> = {
+    'run-create': ['runId'],
+    'run-use': ['runId'],
+    'task-create': ['taskId'],
+    'task-update': ['taskId'],
+    'worker-start': ['dispatchId', 'taskId'],
+    'worker-release': ['dispatchId'],
+    send: ['messageId'],
+    reply: ['messageId'],
+    ask: ['messageId'],
+    check: ['deliveryId'],
+    'gate-create': ['gateId', 'taskId'],
+    'gate-resolve': ['gateId', 'taskId'],
   };
-  visit(value);
-  return Object.freeze(ids);
+  return Object.freeze(
+    Object.fromEntries(
+      (fields[operation] ?? []).flatMap((key) => (typeof result[key] === 'string' ? [[key, result[key]]] : [])),
+    ),
+  );
 }
 
 type ReadbackPlan = { operation: ValidatedOrcaOperation; matches: (result: unknown) => boolean };
 
 function readbackPlan(operation: ValidatedOrcaOperation, result: unknown): ReadbackPlan | undefined {
   if (operation.operation === 'run-use') {
-    const runId = findString(result, ['runId', 'id']);
+    const receipt = recordOf(result);
     return {
       operation: { operation: 'run-current' },
-      matches: (readback) => runId === operation.id && findString(readback, ['runId', 'id']) === operation.id,
+      matches: (readback) => {
+        const current = recordOf(readback);
+        const run = recordOf(current.run);
+        return (
+          receipt.runId === operation.id &&
+          run.id === operation.id &&
+          receipt.coordinatorTerminalHandle === current.coordinatorTerminalHandle
+        );
+      },
     };
   }
   if (operation.operation === 'gate-resolve') {
-    const gateId = findString(result, ['gateId', 'id']);
-    const taskId = findString(result, ['taskId']);
+    const mutation = recordOf(result);
     return {
       operation: { operation: 'gate-list', task: operation.task },
       matches: (readback) => {
-        if (gateId !== operation.id || taskId !== operation.task) return false;
-        const gates =
-          typeof readback === 'object' && readback !== null ? (readback as Record<string, unknown>).gates : undefined;
+        if (mutation.gateId !== operation.id || mutation.taskId !== operation.task) return false;
+        const gates = recordOf(readback).gates;
         return (
           Array.isArray(gates) &&
-          gates.some(
-            (gate) =>
-              findString(gate, ['gateId', 'id']) === gateId &&
-              findString(gate, ['taskId']) === operation.task &&
-              findString(gate, ['status']) === 'resolved' &&
-              findString(gate, ['resolution']) === operation.resolution,
-          )
+          gates.some((value) => {
+            const gate = recordOf(value);
+            return (
+              gate.id === operation.id &&
+              gate.taskId === operation.task &&
+              gate.status === 'resolved' &&
+              gate.resolution === operation.resolution
+            );
+          })
         );
       },
     };
   }
   if (operation.operation === 'worker-release') {
-    const dispatchId = findString(result, ['dispatchId', 'id']);
+    const mutation = recordOf(result);
     return {
       operation: { operation: 'worker-show', dispatch: operation.dispatch },
-      matches: (readback) =>
-        dispatchId === operation.dispatch &&
-        findString(readback, ['dispatchId', 'id']) === operation.dispatch &&
-        findString(readback, ['releaseState', 'state', 'status']) === 'released',
+      matches: (readback) => {
+        const worker = recordOf(recordOf(readback).dispatch);
+        return (
+          mutation.dispatchId === operation.dispatch &&
+          worker.id === operation.dispatch &&
+          ['released', 'retained'].includes(String(worker.terminalDisposition))
+        );
+      },
+    };
+  }
+  if (operation.operation === 'run-create') {
+    const runId = recordOf(result).runId;
+    return {
+      operation: { operation: 'run-show', id: String(runId) },
+      matches: (readback) => {
+        const run = recordOf(recordOf(readback).run);
+        return run.id === runId && run.objective === operation.objective;
+      },
+    };
+  }
+  if (operation.operation === 'task-create' || operation.operation === 'task-update') {
+    const taskId = operation.operation === 'task-create' ? recordOf(result).taskId : operation.id;
+    return {
+      operation: { operation: 'task-list' },
+      matches: (readback) => {
+        const tasks = recordOf(readback).tasks;
+        if (!Array.isArray(tasks)) return false;
+        const task = tasks.map(recordOf).find((candidate) => candidate.id === taskId);
+        if (task === undefined) return false;
+        return operation.operation === 'task-create'
+          ? task.spec === operation.spec &&
+              task.title === operation.title &&
+              JSON.stringify(task.deps ?? []) === JSON.stringify(operation.deps ?? []) &&
+              task.parent === operation.parent
+          : task.status === operation.status && JSON.stringify(task.result) === JSON.stringify(operation.result);
+      },
+    };
+  }
+  if (operation.operation === 'worker-start') {
+    const dispatchId = recordOf(result).dispatchId;
+    return {
+      operation: { operation: 'worker-show', dispatch: String(dispatchId) },
+      matches: (readback) => {
+        const worker = recordOf(recordOf(readback).dispatch);
+        return (
+          worker.id === dispatchId &&
+          worker.taskId === operation.task &&
+          worker.agent === operation.agent &&
+          worker.model === operation.model &&
+          worker.effort === operation.effort
+        );
+      },
+    };
+  }
+  if (operation.operation === 'gate-create') {
+    const gateId = recordOf(result).gateId;
+    return {
+      operation: { operation: 'gate-list', task: operation.task },
+      matches: (readback) => {
+        const gates = recordOf(readback).gates;
+        if (!Array.isArray(gates)) return false;
+        const gate = gates.map(recordOf).find((candidate) => candidate.id === gateId);
+        return (
+          gate?.taskId === operation.task &&
+          gate.question === operation.question &&
+          JSON.stringify(gate.options) === JSON.stringify(operation.options)
+        );
+      },
     };
   }
   return undefined;
@@ -702,14 +833,16 @@ function processFailure(
 ): OrcaAdapterError | undefined {
   const acknowledgement = hasAcknowledgement(operation, input);
   const mutation = mutationVerbs.has(operation) || acknowledgement;
-  if (result.outputLimited) {
+  if (result.outputLimited || result.transportLost) {
     return new OrcaAdapterError(
-      'output_limit',
+      mutation ? 'ambiguous_after_possible_commit' : result.outputLimited ? 'output_limit' : 'process_exit',
       operation,
       'execute',
-      mutation ? 'readback-required' : 'safe',
-      'Inspect state with the documented read operation before retrying.',
-      'Orca output exceeded the adapter limit',
+      mutation ? 'unrecoverably-ambiguous' : 'safe',
+      mutation
+        ? 'Do not retry automatically; inspect the documented public read before choosing another mutation.'
+        : 'Retry the read-only operation when Orca is healthy.',
+      result.outputLimited ? 'Orca output exceeded the adapter limit' : 'Orca transport closed before a valid response',
     );
   }
   if (result.timedOut) {
@@ -763,12 +896,18 @@ export function createOrcaOrchestrationAdapter(options: OrcaAdapterOptions = {})
       });
     } catch (error) {
       throw new OrcaAdapterError(
-        'executable_unavailable',
+        mutationVerbs.has(operation.operation) || hasAcknowledgement(operation.operation, operation)
+          ? 'ambiguous_after_possible_commit'
+          : 'executable_unavailable',
         operation.operation,
         'execute',
-        'safe',
-        `Verify that ${executable} is installed and available to the plugin host.`,
-        error instanceof Error ? error.message : 'failed to launch Orca',
+        mutationVerbs.has(operation.operation) || hasAcknowledgement(operation.operation, operation)
+          ? 'unrecoverably-ambiguous'
+          : 'safe',
+        'Verify that the selected Orca executable is available; do not retry a mutation without public state proof.',
+        error instanceof Error && 'code' in error
+          ? `Orca execution failed (${String(error.code)})`
+          : 'Orca execution failed',
       );
     }
     const failure = processFailure(operation.operation, operation, result);
@@ -801,10 +940,21 @@ export function createOrcaOrchestrationAdapter(options: OrcaAdapterOptions = {})
       if (!mutationVerbs.has(operation.operation) && !hasAcknowledgement(operation.operation, operation))
         return envelope;
 
+      if (envelope._meta?.runtimeId === undefined || envelope._meta.runtimeVersion === undefined) {
+        throw new OrcaAdapterError(
+          'missing_receipt',
+          operation.operation,
+          'receipt',
+          'readback-required',
+          'Use a compatible Orca CLI version and inspect the documented public state before retrying.',
+          'mutation receipt omitted bounded runtime identity/version metadata',
+        );
+      }
+
       if (
         operation.operation === 'check' &&
         operation.ack !== undefined &&
-        findString(envelope.result, ['deliveryId', 'id']) !== operation.ack
+        (recordOf(envelope.result).deliveryId !== operation.ack || recordOf(envelope.result).acknowledged !== true)
       ) {
         throw new OrcaAdapterError(
           'missing_receipt',
@@ -817,6 +967,19 @@ export function createOrcaOrchestrationAdapter(options: OrcaAdapterOptions = {})
       }
 
       const plan = readbackPlan(operation, envelope.result);
+      if (operation.operation === 'run-use') {
+        const meta = envelope._meta as Record<string, unknown> | undefined;
+        if (recordOf(envelope.result).coordinatorTerminalHandle !== meta?.invokingTerminal) {
+          throw new OrcaAdapterError(
+            'readback_mismatch',
+            operation.operation,
+            'readback',
+            'unsafe',
+            'Inspect orchestration run-current; do not retry run-use automatically.',
+            'run-use terminal binding was not runtime-attested',
+          );
+        }
+      }
       if (plan !== undefined) {
         const readback = await invoke(plan.operation);
         if (!plan.matches(readback.result)) {
@@ -833,7 +996,7 @@ export function createOrcaOrchestrationAdapter(options: OrcaAdapterOptions = {})
       const meta = envelope._meta as Record<string, unknown> | undefined;
       const receipt: OrcaMutationReceipt = Object.freeze({
         verb: operation.operation,
-        ids: collectIds(envelope.result),
+        ids: receiptIds(operation.operation, envelope.result),
         runtimeId: typeof meta?.runtimeId === 'string' ? meta.runtimeId : null,
         runtimeVersion:
           typeof meta?.runtimeVersion === 'string'

--- a/src/lib/orca-orchestration-adapter.ts
+++ b/src/lib/orca-orchestration-adapter.ts
@@ -979,19 +979,19 @@ function createAdapter(options: OrcaAdapterTestOptions = {}): OrcaOrchestrationA
     if (failure !== undefined) throw failure;
     const envelope = parseEnvelope(operation.operation, result.stdout, isMutation);
     if (!envelope.ok) {
-      if (isMutation)
-        throw ambiguousMutationError(
-          operation.operation,
-          'decode',
-          envelope.error?.message ?? 'Orca returned an error envelope',
-        );
+      const message = sanitizeDiagnosticText(
+        envelope.error?.message ?? 'Orca returned an error envelope',
+        operation,
+        env,
+      );
+      if (isMutation) throw ambiguousMutationError(operation.operation, 'decode', message);
       throw new OrcaAdapterError(
         'unexpected_response',
         operation.operation,
         'decode',
         isMutation ? 'readback-required' : 'safe',
         'Follow the public Orca diagnostic and inspect state before retrying.',
-        envelope.error?.message ?? 'Orca returned an error envelope',
+        message,
       );
     }
     return envelope;
@@ -1009,7 +1009,7 @@ function createAdapter(options: OrcaAdapterTestOptions = {}): OrcaOrchestrationA
       const envelope = await invoke(operation);
       if (!mutationVerbs.has(operation.operation) && !hasAcknowledgement(operation.operation, operation))
         return envelope;
-      return finalizeMutation(operation, envelope, startedAt, invoke, now);
+      return finalizeMutation(operation, envelope, startedAt, invoke, now, env);
     },
   });
 }
@@ -1020,6 +1020,7 @@ async function finalizeMutation(
   startedAt: string,
   invoke: (operation: ValidatedOrcaOperation) => Promise<OrcaJsonEnvelope>,
   now: () => Date,
+  env: Readonly<Record<string, string | undefined>>,
 ): Promise<OrcaAdapterResponse> {
   validateMutationReceipt(operation, envelope);
   const plan = readbackPlan(operation, envelope.result);
@@ -1028,7 +1029,7 @@ async function finalizeMutation(
     try {
       readback = await invoke(plan.operation);
     } catch (error) {
-      throw mapReadbackFailure(operation.operation, plan.operation.operation, error);
+      throw mapReadbackFailure(operation, plan.operation.operation, error, env);
     }
     if (!plan.matches(readback.result)) {
       throw new OrcaAdapterError(
@@ -1055,14 +1056,15 @@ async function finalizeMutation(
 }
 
 function mapReadbackFailure(
-  mutation: OrcaOrchestrationVerb,
+  mutation: ValidatedOrcaOperation,
   readback: OrcaOrchestrationVerb,
   error: unknown,
+  env: Readonly<Record<string, string | undefined>>,
 ): OrcaAdapterError {
   if (!(error instanceof OrcaAdapterError)) {
     return new OrcaAdapterError(
       'unexpected_response',
-      mutation,
+      mutation.operation,
       'readback',
       'unrecoverably-ambiguous',
       `Inspect state with orchestration ${readback}; do not retry the mutation automatically.`,
@@ -1071,11 +1073,15 @@ function mapReadbackFailure(
   }
   return new OrcaAdapterError(
     error.code,
-    mutation,
+    mutation.operation,
     'readback',
     'readback-required',
     `Repeat or inspect orchestration ${readback}; do not retry the mutation automatically.`,
-    `${readback} failed after Orca returned a valid mutation receipt: ${error.message}`,
+    sanitizeDiagnosticText(
+      `${readback} failed after Orca returned a valid mutation receipt: ${error.message}`,
+      mutation,
+      env,
+    ),
     error.stderr,
   );
 }
@@ -1155,7 +1161,15 @@ function sanitizeStderr(
   operation: ValidatedOrcaOperation,
   env: Readonly<Record<string, string | undefined>>,
 ): string {
-  let safe = [...stderr]
+  return sanitizeDiagnosticText(stderr, operation, env);
+}
+
+function sanitizeDiagnosticText(
+  text: string,
+  operation: ValidatedOrcaOperation,
+  env: Readonly<Record<string, string | undefined>>,
+): string {
+  let safe = [...text]
     .filter((character) => {
       const code = character.charCodeAt(0);
       return code === 9 || code === 10 || code === 13 || (code >= 32 && code !== 127 && code < 128) || code > 159;

--- a/src/lib/orca-orchestration-adapter.ts
+++ b/src/lib/orca-orchestration-adapter.ts
@@ -466,6 +466,49 @@ export const spawnOrcaProcess: OrcaProcessExecutor = async (request) =>
     });
   });
 
+const jsonScalar = z.union([z.string(), z.number().finite(), z.boolean(), z.null()]);
+type JsonValue = z.infer<typeof jsonScalar> | JsonValue[] | { [key: string]: JsonValue };
+const jsonValue: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([jsonScalar, z.array(jsonValue).max(10_000), z.record(jsonValue)]),
+);
+const boundedResult = z
+  .record(jsonValue)
+  .refine((value) => Buffer.byteLength(JSON.stringify(value)) <= MAX_ORCA_STDOUT_BYTES);
+
+/*
+ * Orca deliberately evolves the fields inside its public result objects.  The
+ * adapter still keeps a finite contract: every supported verb is named here,
+ * every result is an object, and mutations must expose the identifiers needed
+ * for their receipt/readback proof.  No verb falls through to `unknown`.
+ */
+const responseSchemas: Readonly<Record<OrcaOrchestrationVerb, z.ZodType<Record<string, JsonValue>>>> = {
+  'run-create': boundedResult.refine((value) => findString(value, ['runId', 'id']) !== undefined),
+  'run-list': boundedResult,
+  'run-show': boundedResult,
+  'run-current': boundedResult,
+  'run-use': boundedResult.refine((value) => findString(value, ['runId', 'id']) !== undefined),
+  'task-create': boundedResult.refine((value) => findString(value, ['taskId', 'id']) !== undefined),
+  'task-list': boundedResult,
+  'task-update': boundedResult.refine((value) => findString(value, ['taskId', 'id']) !== undefined),
+  'worker-start': boundedResult.refine(
+    (value) => findString(value, ['dispatchId', 'id']) !== undefined && findString(value, ['taskId']) !== undefined,
+  ),
+  'worker-show': boundedResult,
+  'worker-read': boundedResult,
+  'worker-release': boundedResult.refine((value) => findString(value, ['dispatchId', 'id']) !== undefined),
+  send: boundedResult.refine((value) => findString(value, ['messageId', 'id']) !== undefined),
+  check: boundedResult,
+  reply: boundedResult.refine((value) => findString(value, ['messageId', 'id']) !== undefined),
+  ask: boundedResult.refine((value) => findString(value, ['messageId', 'id']) !== undefined),
+  'gate-create': boundedResult.refine(
+    (value) => findString(value, ['gateId', 'id']) !== undefined && findString(value, ['taskId']) !== undefined,
+  ),
+  'gate-list': boundedResult,
+  'gate-resolve': boundedResult.refine(
+    (value) => findString(value, ['gateId', 'id']) !== undefined && findString(value, ['taskId']) !== undefined,
+  ),
+};
+
 const envelopeSchema = z
   .object({
     id: z.string().min(1).max(256),
@@ -482,7 +525,20 @@ const envelopeSchema = z
 
 export type OrcaJsonEnvelope = z.infer<typeof envelopeSchema>;
 
+export interface OrcaMutationReceipt {
+  readonly verb: OrcaOrchestrationVerb;
+  readonly ids: Readonly<Record<string, string>>;
+  readonly runtimeId: string | null;
+  readonly runtimeVersion: string | null;
+  readonly startedAt: string;
+  readonly completedAt: string;
+  readonly readbackVerb: OrcaOrchestrationVerb | null;
+}
+
+export type OrcaAdapterResponse = OrcaJsonEnvelope & { readonly receipt?: OrcaMutationReceipt };
+
 function parseEnvelope(operation: OrcaOrchestrationVerb, stdout: string): OrcaJsonEnvelope {
+  const mutation = mutationVerbs.has(operation);
   let decoded: unknown;
   try {
     decoded = JSON.parse(stdout);
@@ -491,8 +547,10 @@ function parseEnvelope(operation: OrcaOrchestrationVerb, stdout: string): OrcaJs
       'malformed_json',
       operation,
       'decode',
-      'safe',
-      'Inspect Orca health and retry this read-only operation when safe.',
+      mutation ? 'readback-required' : 'safe',
+      mutation
+        ? 'Inspect state with the documented public read operation; do not retry the mutation automatically.'
+        : 'Inspect Orca health and retry this read-only operation when safe.',
       'stdout was not one JSON document',
     );
   }
@@ -502,10 +560,23 @@ function parseEnvelope(operation: OrcaOrchestrationVerb, stdout: string): OrcaJs
       'unexpected_response',
       operation,
       'decode',
-      'safe',
+      mutation ? 'readback-required' : 'safe',
       'Use a compatible Orca CLI version.',
       'stdout did not match the Orca envelope contract',
     );
+  }
+  if (parsed.data.ok) {
+    const result = responseSchemas[operation].safeParse(parsed.data.result);
+    if (!result.success) {
+      throw new OrcaAdapterError(
+        mutationVerbs.has(operation) ? 'missing_receipt' : 'unexpected_response',
+        operation,
+        mutationVerbs.has(operation) ? 'receipt' : 'decode',
+        mutationVerbs.has(operation) ? 'readback-required' : 'safe',
+        'Use a compatible Orca CLI version and inspect the public operation result.',
+        `success result did not match the finite ${operation} response contract`,
+      );
+    }
   }
   return parsed.data;
 }
@@ -516,11 +587,12 @@ export interface OrcaAdapterOptions {
   env?: Readonly<Record<string, string | undefined>>;
   managedTerminal?: boolean;
   timeoutMs?: number;
+  now?: () => Date;
 }
 
 export interface OrcaOrchestrationAdapter {
   readonly executable: string;
-  execute(input: unknown): Promise<OrcaJsonEnvelope>;
+  execute(input: unknown): Promise<OrcaAdapterResponse>;
 }
 
 const mutationVerbs = new Set<OrcaOrchestrationVerb>([
@@ -539,6 +611,88 @@ const mutationVerbs = new Set<OrcaOrchestrationVerb>([
 
 function hasAcknowledgement(operation: OrcaOrchestrationVerb, input: unknown): boolean {
   return operation === 'check' && typeof input === 'object' && input !== null && 'ack' in input;
+}
+
+function findString(value: unknown, keys: readonly string[]): string | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  if (Array.isArray(value)) {
+    for (const member of value) {
+      const found = findString(member, keys);
+      if (found !== undefined) return found;
+    }
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  for (const key of keys) if (typeof record[key] === 'string') return record[key];
+  for (const member of Object.values(record)) {
+    const found = findString(member, keys);
+    if (found !== undefined) return found;
+  }
+  return undefined;
+}
+
+function collectIds(value: unknown): Readonly<Record<string, string>> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return Object.freeze({});
+  const ids: Record<string, string> = {};
+  const visit = (entry: unknown): void => {
+    if (typeof entry !== 'object' || entry === null) return;
+    if (Array.isArray(entry)) {
+      entry.forEach(visit);
+      return;
+    }
+    for (const [key, member] of Object.entries(entry)) {
+      if ((key === 'id' || key.endsWith('Id')) && typeof member === 'string' && id.safeParse(member).success)
+        ids[key] = member;
+      else visit(member);
+    }
+  };
+  visit(value);
+  return Object.freeze(ids);
+}
+
+type ReadbackPlan = { operation: ValidatedOrcaOperation; matches: (result: unknown) => boolean };
+
+function readbackPlan(operation: ValidatedOrcaOperation, result: unknown): ReadbackPlan | undefined {
+  if (operation.operation === 'run-use') {
+    const runId = findString(result, ['runId', 'id']);
+    return {
+      operation: { operation: 'run-current' },
+      matches: (readback) => runId === operation.id && findString(readback, ['runId', 'id']) === operation.id,
+    };
+  }
+  if (operation.operation === 'gate-resolve') {
+    const gateId = findString(result, ['gateId', 'id']);
+    const taskId = findString(result, ['taskId']);
+    return {
+      operation: { operation: 'gate-list', task: operation.task },
+      matches: (readback) => {
+        if (gateId !== operation.id || taskId !== operation.task) return false;
+        const gates =
+          typeof readback === 'object' && readback !== null ? (readback as Record<string, unknown>).gates : undefined;
+        return (
+          Array.isArray(gates) &&
+          gates.some(
+            (gate) =>
+              findString(gate, ['gateId', 'id']) === gateId &&
+              findString(gate, ['taskId']) === operation.task &&
+              findString(gate, ['status']) === 'resolved' &&
+              findString(gate, ['resolution']) === operation.resolution,
+          )
+        );
+      },
+    };
+  }
+  if (operation.operation === 'worker-release') {
+    const dispatchId = findString(result, ['dispatchId', 'id']);
+    return {
+      operation: { operation: 'worker-show', dispatch: operation.dispatch },
+      matches: (readback) =>
+        dispatchId === operation.dispatch &&
+        findString(readback, ['dispatchId', 'id']) === operation.dispatch &&
+        findString(readback, ['releaseState', 'state', 'status']) === 'released',
+    };
+  }
+  return undefined;
 }
 
 function processFailure(
@@ -560,13 +714,15 @@ function processFailure(
   }
   if (result.timedOut) {
     return new OrcaAdapterError(
-      acknowledgement ? 'ambiguous_after_possible_commit' : 'timeout',
+      mutation ? 'ambiguous_after_possible_commit' : 'timeout',
       operation,
       'execute',
-      acknowledgement ? 'unrecoverably-ambiguous' : mutation ? 'readback-required' : 'safe',
-      acknowledgement
-        ? 'Do not acknowledge again automatically; only external confirmation can establish whether it committed.'
-        : 'Use the documented public readback before retrying a mutation.',
+      mutation ? 'unrecoverably-ambiguous' : 'safe',
+      mutation
+        ? acknowledgement
+          ? 'Do not acknowledge again automatically; only external confirmation can establish whether it committed.'
+          : 'Do not retry automatically; use the documented public readback before choosing another mutation.'
+        : 'Retry the read-only operation when Orca is healthy.',
       'Orca did not finish before the deadline',
     );
   }
@@ -591,47 +747,105 @@ export function createOrcaOrchestrationAdapter(options: OrcaAdapterOptions = {})
     resolveOrcaExecutable({ env, managedTerminal: options.managedTerminal ?? env.TERM_PROGRAM === 'Orca' });
   const executor = options.executor ?? spawnOrcaProcess;
   const defaultTimeout = options.timeoutMs ?? DEFAULT_ORCA_TIMEOUT_MS;
+  const now = options.now ?? (() => new Date());
+  const invoke = async (operation: ValidatedOrcaOperation): Promise<OrcaJsonEnvelope> => {
+    const argv = buildOrcaOrchestrationArgv(operation);
+    let result: OrcaProcessResult;
+    try {
+      result = await executor({
+        executable,
+        argv,
+        shell: false,
+        timeoutMs: defaultTimeout,
+        maxStdoutBytes: MAX_ORCA_STDOUT_BYTES,
+        maxStderrBytes: MAX_ORCA_STDERR_BYTES,
+        env,
+      });
+    } catch (error) {
+      throw new OrcaAdapterError(
+        'executable_unavailable',
+        operation.operation,
+        'execute',
+        'safe',
+        `Verify that ${executable} is installed and available to the plugin host.`,
+        error instanceof Error ? error.message : 'failed to launch Orca',
+      );
+    }
+    const failure = processFailure(operation.operation, operation, result);
+    if (failure !== undefined) throw failure;
+    const envelope = parseEnvelope(operation.operation, result.stdout);
+    if (!envelope.ok) {
+      const isMutation = mutationVerbs.has(operation.operation) || hasAcknowledgement(operation.operation, operation);
+      throw new OrcaAdapterError(
+        'unexpected_response',
+        operation.operation,
+        'decode',
+        isMutation ? 'readback-required' : 'safe',
+        'Follow the public Orca diagnostic and inspect state before retrying.',
+        envelope.error?.message ?? 'Orca returned an error envelope',
+      );
+    }
+    return envelope;
+  };
   return Object.freeze({
     executable,
-    async execute(input: unknown): Promise<OrcaJsonEnvelope> {
-      const argv = buildOrcaOrchestrationArgv(input);
-      const operation = argv[1] as OrcaOrchestrationVerb;
-      let result: OrcaProcessResult;
-      try {
-        result = await executor({
-          executable,
-          argv,
-          shell: false,
-          timeoutMs: defaultTimeout,
-          maxStdoutBytes: MAX_ORCA_STDOUT_BYTES,
-          maxStderrBytes: MAX_ORCA_STDERR_BYTES,
-          env,
-        });
-      } catch (error) {
+    async execute(input: unknown): Promise<OrcaAdapterResponse> {
+      const parsed = orcaOperationSchema.safeParse(input);
+      if (!parsed.success) {
+        buildOrcaOrchestrationArgv(input);
+        throw new Error('unreachable');
+      }
+      const operation = parsed.data as ValidatedOrcaOperation;
+      const startedAt = now().toISOString();
+      const envelope = await invoke(operation);
+      if (!mutationVerbs.has(operation.operation) && !hasAcknowledgement(operation.operation, operation))
+        return envelope;
+
+      if (
+        operation.operation === 'check' &&
+        operation.ack !== undefined &&
+        findString(envelope.result, ['deliveryId', 'id']) !== operation.ack
+      ) {
         throw new OrcaAdapterError(
-          'executable_unavailable',
-          operation,
-          'execute',
-          'safe',
-          `Verify that ${executable} is installed and available to the plugin host.`,
-          error instanceof Error ? error.message : 'failed to launch Orca',
+          'missing_receipt',
+          operation.operation,
+          'receipt',
+          'unrecoverably-ambiguous',
+          'Do not acknowledge again automatically; only external confirmation can establish whether it committed.',
+          'check --ack success did not contain its matching delivery identifier',
         );
       }
-      const failure = processFailure(operation, input, result);
-      if (failure !== undefined) throw failure;
-      const envelope = parseEnvelope(operation, result.stdout);
-      if (!envelope.ok) {
-        const isMutation = mutationVerbs.has(operation) || hasAcknowledgement(operation, input);
-        throw new OrcaAdapterError(
-          'unexpected_response',
-          operation,
-          'decode',
-          isMutation ? 'readback-required' : 'safe',
-          'Follow the public Orca diagnostic and inspect state before retrying.',
-          envelope.error?.message ?? 'Orca returned an error envelope',
-        );
+
+      const plan = readbackPlan(operation, envelope.result);
+      if (plan !== undefined) {
+        const readback = await invoke(plan.operation);
+        if (!plan.matches(readback.result)) {
+          throw new OrcaAdapterError(
+            'readback_mismatch',
+            operation.operation,
+            'readback',
+            'unsafe',
+            `Inspect state with orchestration ${plan.operation.operation}; do not retry the mutation automatically.`,
+            `${plan.operation.operation} disagreed with the mutation receipt`,
+          );
+        }
       }
-      return envelope;
+      const meta = envelope._meta as Record<string, unknown> | undefined;
+      const receipt: OrcaMutationReceipt = Object.freeze({
+        verb: operation.operation,
+        ids: collectIds(envelope.result),
+        runtimeId: typeof meta?.runtimeId === 'string' ? meta.runtimeId : null,
+        runtimeVersion:
+          typeof meta?.runtimeVersion === 'string'
+            ? meta.runtimeVersion
+            : typeof meta?.version === 'string'
+              ? meta.version
+              : null,
+        startedAt,
+        completedAt: now().toISOString(),
+        readbackVerb: plan?.operation.operation ?? null,
+      });
+      return Object.freeze({ ...envelope, receipt });
     },
   });
 }


### PR DESCRIPTION
## Summary

- add a closed, argv-only adapter for official Orca orchestration commands
- enforce final JSON output, bounded execution, strict parsing, receipts, and no-retry recovery semantics
- redact request, environment, and credential-bearing URL diagnostics, including post-receipt readback errors

## Verification

- frozen install and focused adapter suite: 45 tests, 467 assertions
- independent adversarial security review: SHIP at 5f47da7ff015e2a28c585fd43274871336508ffd
- full check advanced through typecheck, Biome, dead-code, skills/wishes, complexity, and council gates before the known checkout mode mismatch (validate-wish.cjs is 0700 while the repository tree requires 0755)
- full suite was exercised; remaining failures are documented baseline mode/digest/timing/installer/doctor issues outside this two-file diff

This is a transport primitive only. The later plugin and lifecycle PRs remain deliberately separate and merge-dependent.