### PR TITLE
feat(orca): preserve lifecycle mode transitions

### DIFF
--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -77,6 +77,7 @@ import {
 import { hasDuplicateMcpGenieKeys } from '../lib/hermes-mcp-config.js';
 import { hasDuplicateSkillsExternalDirsKeys, resolveProductSkillsRoot } from '../lib/hermes-skills-config.js';
 import { resolveOmniRuntimeConfig } from '../lib/omni-config.js';
+import { type OrcaPluginCompatibilityResult, inspectOrcaPluginLifecycle } from '../lib/orca-plugin-lifecycle.js';
 import {
   CANONICAL_GENIE_SKILL_NAMES,
   type CodexAgentDisplayState,
@@ -273,6 +274,10 @@ function checkGit(root: string | null): CheckResult[] {
 }
 
 function checkDatabase(root: string | null): CheckResult[] {
+  const lifecycle = inspectOrcaPluginLifecycle();
+  if (lifecycle.mode === 'orca') {
+    return [{ name: 'genie.db', status: 'pass', detail: 'not opened — Orca is the selected lifecycle authority' }];
+  }
   const dbPath = join(root ?? process.cwd(), '.genie', 'genie.db');
   if (!existsSync(dbPath)) {
     return [
@@ -2062,6 +2067,9 @@ function indexTargetExists(genieDir: string, relativePath: string): boolean {
  */
 export function checkIndexLaneDrift(root: string | null, databaseRoot: string | null): CheckResult[] {
   const name = 'jar: index-lane drift';
+  if (inspectOrcaPluginLifecycle().mode === 'orca') {
+    return [{ name, status: 'pass', detail: 'not read — Orca is the selected lifecycle authority' }];
+  }
   const base = root ?? process.cwd();
   const indexPath = join(base, '.genie', 'INDEX.md');
   if (!existsSync(indexPath)) {
@@ -2137,6 +2145,51 @@ export interface DoctorDeps {
   projectContext?: ProjectContext | null;
   /** TEST-ONLY cryptographic seam for persisted delivery-evidence fixtures; no CLI/env path exposes it. */
   deliveryEvidenceVerification?: DeliveryEvidenceVerificationDependencies;
+  /** A3 public compatibility probe seam for Orca-mode diagnostics. */
+  orcaCompatibilityProbe?: () => Promise<OrcaPluginCompatibilityResult>;
+}
+
+export async function checkOrcaLifecycle(deps: DoctorDeps, probeLiveRuntime = true): Promise<CheckResult[]> {
+  const state = inspectOrcaPluginLifecycle();
+  const payloadStatus =
+    state.payload === 'owned-clean' || (state.mode === 'standalone' && state.payload === 'unmanaged');
+  const results: CheckResult[] = [
+    {
+      name: 'orchestration authority',
+      status: state.mode === 'invalid' ? 'fail' : 'pass',
+      detail: `mode=${state.mode}; payload=${state.payload}; host_registration=${state.hostRegistration}`,
+      suggestion: state.recovery,
+    },
+  ];
+  if (state.mode !== 'orca') return results;
+  if (!payloadStatus) {
+    const authority = results[0];
+    if (authority !== undefined) results[0] = { ...authority, status: 'fail' };
+    return results;
+  }
+  if (!probeLiveRuntime && deps.orcaCompatibilityProbe === undefined) return results;
+  try {
+    const probe =
+      deps.orcaCompatibilityProbe ??
+      (async () => {
+        const { createOrcaPluginRuntime } = await import('../../plugins/genie/orca-runtime.js');
+        return createOrcaPluginRuntime().probe();
+      });
+    const compatibility = await probe();
+    results.push({
+      name: 'Orca compatibility',
+      status: 'pass',
+      detail: `runtime=${compatibility.runtimeVersion}; contract=${compatibility.contract}; runtime_id=${compatibility.runtimeId}`,
+    });
+  } catch (error) {
+    results.push({
+      name: 'Orca compatibility',
+      status: 'fail',
+      detail: error instanceof Error ? error.message : String(error),
+      suggestion: 'Use a supported Orca runtime, then retry `genie setup --orchestration-mode orca`.',
+    });
+  }
+  return results;
 }
 
 // ============================================================================
@@ -2267,6 +2320,7 @@ export async function doctorCommand(options?: { json?: boolean; fix?: boolean },
       : (hostObservation?.probe ?? probeCodexGeniePlugin());
   const results: CheckResult[] = [
     ...checkGenieBinary(),
+    ...(await checkOrcaLifecycle(deps, !injectedRoot || deps.orcaCompatibilityProbe !== undefined)),
     ...checkGit(root),
     ...checkDatabase(databaseRoot),
     ...checkSkills(root),

--- a/src/genie-commands/setup.ts
+++ b/src/genie-commands/setup.ts
@@ -60,6 +60,7 @@ import {
   saveGenieConfig,
 } from '../lib/genie-config.js';
 import { resolveCodexDir, resolveGenieHome } from '../lib/genie-home.js';
+import { type OrcaPluginCompatibilityResult, switchOrchestrationMode } from '../lib/orca-plugin-lifecycle.js';
 import { acquireOrderedLifecycleLeases, releaseOrderedLifecycleLeases } from '../lib/ordered-lifecycle-leases.js';
 import {
   type CodexAgentInstallResult,
@@ -83,6 +84,7 @@ export interface SetupOptions {
   session?: boolean;
   reset?: boolean;
   show?: boolean;
+  orchestrationMode?: 'standalone' | 'orca';
 }
 
 export interface SetupDeps {
@@ -132,6 +134,8 @@ export interface SetupDeps {
     afterAssets?: () => void;
     afterRoute?: () => void;
   };
+  /** A3 public compatibility probe seam for isolated Orca mode-switch tests. */
+  orcaCompatibilityProbe?: () => Promise<OrcaPluginCompatibilityResult>;
 }
 
 export class SetupIntegrationError extends Error {
@@ -1028,6 +1032,17 @@ async function runSetupCommand(options: SetupOptions, deps: SetupDeps): Promise<
     await withSetupLease(deps, () => resetConfig());
     console.log('\x1b[32m\u2713 Configuration reset to defaults.\x1b[0m');
     console.log();
+    return;
+  }
+
+  if (options.orchestrationMode !== undefined) {
+    if (options.orchestrationMode !== 'standalone' && options.orchestrationMode !== 'orca') {
+      throw new SetupIntegrationError('orchestration mode must be either "standalone" or "orca"');
+    }
+    const result = await switchOrchestrationMode(options.orchestrationMode, { probe: deps.orcaCompatibilityProbe });
+    const detail = result.changed ? 'changed' : 'already selected';
+    console.log(`\x1b[32m\u2713\x1b[0m Orchestration mode ${detail}: ${result.mode}`);
+    if (result.backupPath !== null) console.log(`  Previous config backed up at ${contractPath(result.backupPath)}`);
     return;
   }
 

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -59,6 +59,7 @@ import {
 } from '../lib/install-promotion.js';
 import { inspectPhysicalPath } from '../lib/install-transaction.js';
 import { retireInstallVersionMarker } from '../lib/install-version-marker.js';
+import { refreshOwnedOrcaPluginMetadata } from '../lib/orca-plugin-lifecycle.js';
 import {
   type HeldOrderedLifecycleLeases,
   acquireOrderedLifecycleLeases,
@@ -3177,6 +3178,10 @@ async function runDelivery(
         cleanupStagingArtifacts(externalRoot, tarballPath);
       },
     });
+    // A4: refresh only an existing Genie ownership claim. The public A3
+    // compatibility probe must succeed before the marker advances; config and
+    // both authorities' lifecycle history remain untouched.
+    await refreshOwnedOrcaPluginMetadata();
     // The payload is now in GENIE_HOME; publish attested delivery facts (and the
     // rollback sidecar for a protocol-capable backup) under the held lease.
     const deliveryRoot = resolveCanonicalPayloadRoot();

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -73,6 +73,11 @@ program
   .option('--codex', 'Activate the authenticated Codex delivery and converge its managed surfaces')
   .option('--terminal', 'Only configure terminal defaults')
   .option('--session', 'Only configure session settings')
+  .addOption(
+    new Option('--orchestration-mode <mode>', 'Select lifecycle authority explicitly')
+      .choices(['standalone', 'orca'])
+      .conflicts(['quick', 'shortcuts', 'codex', 'terminal', 'session', 'reset', 'show']),
+  )
   .option('--reset', 'Reset configuration to defaults')
   .option('--show', 'Show current configuration')
   .action(async (options: SetupOptions) => {

--- a/src/lib/orca-plugin-lifecycle.test.ts
+++ b/src/lib/orca-plugin-lifecycle.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { checkOrcaLifecycle } from '../genie-commands/doctor.js';
+import { setupCommand } from '../genie-commands/setup.js';
+import {
+  inspectOrcaPluginLifecycle,
+  refreshOwnedOrcaPluginMetadata,
+  switchOrchestrationMode,
+  uninstallOwnedOrcaPluginMetadata,
+} from './orca-plugin-lifecycle.js';
+
+let home: string;
+let previousHome: string | undefined;
+
+function writePayload(manifest = '{"version":"1"}', entrypoint = 'export default {}') {
+  const root = join(home, 'plugins', 'genie');
+  mkdirSync(root, { recursive: true });
+  writeFileSync(join(root, 'orca-plugin.json'), manifest);
+  writeFileSync(join(root, 'orca-entrypoint.min.js'), entrypoint);
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'genie-orca-lifecycle-'));
+  previousHome = process.env.GENIE_HOME;
+  process.env.GENIE_HOME = home;
+});
+
+afterEach(() => {
+  if (previousHome === undefined) process.env.GENIE_HOME = undefined;
+  else process.env.GENIE_HOME = previousHome;
+});
+
+describe('Orca plugin lifecycle transitions', () => {
+  test('switches to Orca only after the public compatibility probe and preserves unrelated config', async () => {
+    writePayload();
+    writeFileSync(join(home, 'config.json'), '{\n  "custom": {"kept": true}\n}\n');
+    let probed = false;
+
+    const result = await switchOrchestrationMode('orca', {
+      probe: async () => {
+        probed = true;
+        return { runtimeId: 'runtime_1', runtimeVersion: '1.4.193', contract: 'orchestration.contract.v1' };
+      },
+    });
+
+    expect(probed).toBe(true);
+    expect(result.changed).toBe(true);
+    expect(JSON.parse(readFileSync(join(home, 'config.json'), 'utf8'))).toMatchObject({
+      custom: { kept: true },
+      orchestration: { mode: 'orca' },
+    });
+    expect(existsSync(result.backupPath!)).toBe(true);
+    expect(inspectOrcaPluginLifecycle()).toMatchObject({ payload: 'owned-clean', mode: 'orca' });
+  });
+
+  test('probe failure preserves exact config bytes and creates no ownership claim', async () => {
+    writePayload();
+    const original = '{\n  "custom": true\n}\n';
+    writeFileSync(join(home, 'config.json'), original);
+
+    await expect(
+      switchOrchestrationMode('orca', {
+        probe: async () => {
+          throw new Error('incompatible');
+        },
+      }),
+    ).rejects.toThrow('incompatible');
+
+    expect(readFileSync(join(home, 'config.json'), 'utf8')).toBe(original);
+    expect(inspectOrcaPluginLifecycle().payload).toBe('unmanaged');
+  });
+
+  for (const boundary of ['afterBackup', 'afterOwnership', 'beforeConfigCommit'] as const) {
+    test(`failure at ${boundary} restores config and ownership exactly`, async () => {
+      writePayload();
+      const original = '{\n  "custom": "preserved"\n}\n';
+      writeFileSync(join(home, 'config.json'), original);
+
+      await expect(
+        switchOrchestrationMode('orca', {
+          probe: async () => ({
+            runtimeId: 'runtime_1',
+            runtimeVersion: '1.4.193',
+            contract: 'orchestration.contract.v1',
+          }),
+          hooks: {
+            [boundary]: () => {
+              throw new Error(`failed at ${boundary}`);
+            },
+          },
+        }),
+      ).rejects.toThrow(`failed at ${boundary}`);
+      expect(readFileSync(join(home, 'config.json'), 'utf8')).toBe(original);
+      expect(inspectOrcaPluginLifecycle().payload).toBe('unmanaged');
+    });
+  }
+
+  test('repeat transitions are idempotent and standalone never probes or rewrites lifecycle history', async () => {
+    writePayload();
+    writeFileSync(join(home, 'config.json'), JSON.stringify({ orchestration: { mode: 'standalone' } }));
+    writeFileSync(join(home, 'genie.db'), 'database-history');
+    let probes = 0;
+    const deps = {
+      probe: async () => {
+        probes += 1;
+        return { runtimeId: 'runtime_1', runtimeVersion: '1.4.193', contract: 'orchestration.contract.v1' as const };
+      },
+    };
+
+    expect((await switchOrchestrationMode('orca', deps)).changed).toBe(true);
+    expect((await switchOrchestrationMode('orca', deps)).changed).toBe(false);
+    expect((await switchOrchestrationMode('standalone', deps)).changed).toBe(true);
+    expect((await switchOrchestrationMode('standalone', deps)).changed).toBe(false);
+    expect(probes).toBe(1);
+    expect(readFileSync(join(home, 'genie.db'), 'utf8')).toBe('database-history');
+  });
+
+  test('uninstall removes only a clean Genie ownership marker and never payload or history', async () => {
+    writePayload();
+    writeFileSync(join(home, 'config.json'), JSON.stringify({ orchestration: { mode: 'standalone' } }));
+    writeFileSync(join(home, 'roadmap.json'), 'history');
+    await switchOrchestrationMode('orca', {
+      probe: async () => ({
+        runtimeId: 'runtime_1',
+        runtimeVersion: '1.4.193',
+        contract: 'orchestration.contract.v1',
+      }),
+    });
+
+    expect(uninstallOwnedOrcaPluginMetadata()).toBe('removed');
+    expect(existsSync(join(home, 'plugins', 'genie', 'orca-plugin.json'))).toBe(true);
+    expect(readFileSync(join(home, 'roadmap.json'), 'utf8')).toBe('history');
+    expect(uninstallOwnedOrcaPluginMetadata()).toBe('absent');
+  });
+
+  test('update refreshes only an existing ownership claim after compatibility succeeds', async () => {
+    writePayload();
+    writeFileSync(join(home, 'config.json'), JSON.stringify({ orchestration: { mode: 'standalone' } }));
+    const compatible = async () => ({
+      runtimeId: 'runtime_1',
+      runtimeVersion: '1.4.193',
+      contract: 'orchestration.contract.v1' as const,
+    });
+    await switchOrchestrationMode('orca', { probe: compatible });
+    const markerPath = join(home, 'plugins', 'genie', '.orca-plugin-ownership.json');
+    const previousMarker = readFileSync(markerPath, 'utf8');
+    writeFileSync(join(home, 'plugins', 'genie', 'orca-entrypoint.min.js'), 'updated');
+
+    await expect(
+      refreshOwnedOrcaPluginMetadata(async () => {
+        throw new Error('unsupported update payload');
+      }),
+    ).rejects.toThrow('unsupported update payload');
+    expect(readFileSync(markerPath, 'utf8')).toBe(previousMarker);
+    expect(await refreshOwnedOrcaPluginMetadata(compatible)).toBe('refreshed');
+    expect(inspectOrcaPluginLifecycle().payload).toBe('owned-clean');
+  });
+
+  test('setup mode surface reports success, idempotency, and error exit/stderr', async () => {
+    writePayload();
+    const output: string[] = [];
+    const errors: string[] = [];
+    const priorLog = console.log;
+    const priorError = console.error;
+    const priorExit = process.exitCode;
+    console.log = (...args) => output.push(args.join(' '));
+    console.error = (...args) => errors.push(args.join(' '));
+    process.exitCode = 0;
+    try {
+      const probe = async () => ({
+        runtimeId: 'runtime_1',
+        runtimeVersion: '1.4.193',
+        contract: 'orchestration.contract.v1' as const,
+      });
+      await setupCommand({ orchestrationMode: 'orca' }, { orcaCompatibilityProbe: probe });
+      await setupCommand({ orchestrationMode: 'orca' }, { orcaCompatibilityProbe: probe });
+      expect(output.join('\n')).toContain('Orchestration mode changed: orca');
+      expect(output.join('\n')).toContain('Orchestration mode already selected: orca');
+      expect(process.exitCode).toBe(0);
+
+      await setupCommand({ orchestrationMode: 'automatic' as never });
+      expect(process.exitCode).toBe(1);
+      expect(errors.join('\n')).toContain('orchestration mode must be either');
+    } finally {
+      console.log = priorLog;
+      console.error = priorError;
+      process.exitCode = priorExit;
+    }
+  });
+
+  test('doctor truthfully reports selected mode, compatibility, and unmanaged host registration', async () => {
+    writePayload();
+    writeFileSync(join(home, 'config.json'), JSON.stringify({ orchestration: { mode: 'standalone' } }));
+    const probe = async () => ({
+      runtimeId: 'runtime_1',
+      runtimeVersion: '1.4.193',
+      contract: 'orchestration.contract.v1' as const,
+    });
+    await switchOrchestrationMode('orca', { probe });
+
+    const checks = await checkOrcaLifecycle({ orcaCompatibilityProbe: probe });
+    expect(checks).toHaveLength(2);
+    expect(checks[0]).toMatchObject({ status: 'pass' });
+    expect(checks[0]?.detail).toContain('mode=orca');
+    expect(checks[0]?.detail).toContain('host_registration=not-managed');
+    expect(checks[1]?.detail).toContain('runtime=1.4.193');
+  });
+});

--- a/src/lib/orca-plugin-lifecycle.ts
+++ b/src/lib/orca-plugin-lifecycle.ts
@@ -1,0 +1,250 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { getGenieConfigPath, getGenieDir } from './genie-config.js';
+import { type OrchestrationMode, resolveOrchestrationMode } from './orchestration-mode.js';
+
+const OWNERSHIP_FILE = '.orca-plugin-ownership.json';
+const BACKUP_DIR = 'backups/orchestration-mode';
+
+/** Structural result of A3's public typed compatibility probe. */
+export interface OrcaPluginCompatibilityResult {
+  readonly runtimeId: string;
+  readonly runtimeVersion: string;
+  readonly contract: 'orchestration.contract.v1';
+}
+
+interface Ownership {
+  schemaVersion: 1;
+  owner: 'genie';
+  manifestSha256: string;
+  entrypointSha256: string;
+}
+
+export interface OrcaLifecycleInspection {
+  mode: OrchestrationMode | 'invalid';
+  payload: 'absent' | 'unmanaged' | 'owned-clean' | 'owned-modified' | 'unsafe-ownership';
+  hostRegistration: 'not-managed';
+  manifestPath: string;
+  recovery?: string;
+}
+
+export interface OrcaModeSwitchDependencies {
+  probe?: () => Promise<OrcaPluginCompatibilityResult>;
+  /** Test-only boundary hooks. */
+  hooks?: {
+    afterBackup?: () => void;
+    afterOwnership?: () => void;
+    beforeConfigCommit?: () => void;
+  };
+}
+
+export interface OrcaModeSwitchResult {
+  changed: boolean;
+  mode: OrchestrationMode;
+  backupPath: string | null;
+  compatibility: OrcaPluginCompatibilityResult | null;
+}
+
+function paths() {
+  const home = getGenieDir();
+  const payloadRoot = join(home, 'plugins', 'genie');
+  return {
+    home,
+    config: getGenieConfigPath(),
+    manifest: join(payloadRoot, 'orca-plugin.json'),
+    entrypoint: join(payloadRoot, 'orca-entrypoint.min.js'),
+    ownership: join(payloadRoot, OWNERSHIP_FILE),
+    backups: join(home, BACKUP_DIR),
+  };
+}
+
+function digest(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+function expectedOwnership(): Ownership {
+  const target = paths();
+  if (!existsSync(target.manifest) || !existsSync(target.entrypoint)) {
+    throw new Error('Orca plugin payload is incomplete; reinstall Genie before selecting Orca mode');
+  }
+  return {
+    schemaVersion: 1,
+    owner: 'genie',
+    manifestSha256: digest(target.manifest),
+    entrypointSha256: digest(target.entrypoint),
+  };
+}
+
+function atomicWrite(path: string, bytes: string): void {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const temporary = `${path}.tmp-${process.pid}-${randomBytes(8).toString('hex')}`;
+  try {
+    writeFileSync(temporary, bytes, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
+    renameSync(temporary, path);
+  } finally {
+    rmSync(temporary, { force: true });
+  }
+}
+
+function readOwnership(path: string): Ownership | null | 'unsafe' {
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return 'unsafe';
+    const record = parsed as Record<string, unknown>;
+    if (
+      Object.keys(record).sort().join(',') !== 'entrypointSha256,manifestSha256,owner,schemaVersion' ||
+      record.schemaVersion !== 1 ||
+      record.owner !== 'genie' ||
+      typeof record.manifestSha256 !== 'string' ||
+      !/^[a-f0-9]{64}$/.test(record.manifestSha256) ||
+      typeof record.entrypointSha256 !== 'string' ||
+      !/^[a-f0-9]{64}$/.test(record.entrypointSha256)
+    ) {
+      return 'unsafe';
+    }
+    return record as unknown as Ownership;
+  } catch {
+    return 'unsafe';
+  }
+}
+
+function sameOwnership(left: Ownership, right: Ownership): boolean {
+  return left.manifestSha256 === right.manifestSha256 && left.entrypointSha256 === right.entrypointSha256;
+}
+
+function backupConfig(backupRoot: string, bytes: string | null): string {
+  mkdirSync(backupRoot, { recursive: true, mode: 0o700 });
+  const backupPath = join(backupRoot, `config-${Date.now()}-${randomBytes(8).toString('hex')}.json`);
+  writeFileSync(backupPath, bytes ?? '', { encoding: 'utf8', mode: 0o600, flag: 'wx' });
+  return backupPath;
+}
+
+function restore(path: string, bytes: string | null): void {
+  if (bytes === null) rmSync(path, { force: true });
+  else atomicWrite(path, bytes);
+}
+
+function nextConfig(original: string | null, mode: OrchestrationMode): string {
+  let value: Record<string, unknown> = {};
+  if (original !== null) {
+    const parsed = JSON.parse(original) as unknown;
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) throw new Error('Invalid Genie config');
+    value = parsed as Record<string, unknown>;
+  }
+  return `${JSON.stringify({ ...value, orchestration: { mode } }, null, 2)}\n`;
+}
+
+/** Explicit, backup-first authority switch. It never reads or changes lifecycle history. */
+export async function switchOrchestrationMode(
+  mode: OrchestrationMode,
+  dependencies: OrcaModeSwitchDependencies = {},
+): Promise<OrcaModeSwitchResult> {
+  const current = resolveOrchestrationMode();
+  if (current === mode) return { changed: false, mode, backupPath: null, compatibility: null };
+
+  const target = paths();
+  const originalConfig = existsSync(target.config) ? readFileSync(target.config, 'utf8') : null;
+  const originalOwnership = existsSync(target.ownership) ? readFileSync(target.ownership, 'utf8') : null;
+  let compatibility: OrcaPluginCompatibilityResult | null = null;
+  let ownership: Ownership | null = null;
+
+  if (mode === 'orca') {
+    ownership = expectedOwnership();
+    const existing = readOwnership(target.ownership);
+    if (existing === 'unsafe' || (existing !== null && !sameOwnership(existing, ownership))) {
+      throw new Error('Orca plugin ownership metadata is unsafe or does not match the shipped payload');
+    }
+    const probe =
+      dependencies.probe ??
+      (async () => {
+        const { createOrcaPluginRuntime } = await import('../../plugins/genie/orca-runtime.js');
+        return createOrcaPluginRuntime().probe();
+      });
+    compatibility = await probe();
+  }
+
+  const backupPath = backupConfig(target.backups, originalConfig);
+  dependencies.hooks?.afterBackup?.();
+  try {
+    if (ownership !== null) atomicWrite(target.ownership, `${JSON.stringify(ownership, null, 2)}\n`);
+    dependencies.hooks?.afterOwnership?.();
+    dependencies.hooks?.beforeConfigCommit?.();
+    atomicWrite(target.config, nextConfig(originalConfig, mode));
+  } catch (error) {
+    restore(target.config, originalConfig);
+    restore(target.ownership, originalOwnership);
+    throw error;
+  }
+  return { changed: true, mode, backupPath, compatibility };
+}
+
+/** Read-only status used by doctor; host registration is intentionally user-managed. */
+export function inspectOrcaPluginLifecycle(): OrcaLifecycleInspection {
+  const target = paths();
+  let mode: OrcaLifecycleInspection['mode'];
+  try {
+    mode = resolveOrchestrationMode();
+  } catch {
+    mode = 'invalid';
+  }
+  const base = { mode, hostRegistration: 'not-managed' as const, manifestPath: target.manifest };
+  if (!existsSync(target.manifest) && !existsSync(target.entrypoint)) return { ...base, payload: 'absent' };
+  if (!existsSync(target.manifest) || !existsSync(target.entrypoint)) {
+    return { ...base, payload: 'owned-modified', recovery: 'reinstall Genie to restore the complete Orca payload' };
+  }
+  const existing = readOwnership(target.ownership);
+  if (existing === null) return { ...base, payload: 'unmanaged' };
+  if (existing === 'unsafe') {
+    return { ...base, payload: 'unsafe-ownership', recovery: 'review the ownership marker; Genie will not replace it' };
+  }
+  return sameOwnership(existing, expectedOwnership())
+    ? { ...base, payload: 'owned-clean' }
+    : { ...base, payload: 'owned-modified', recovery: 'reinstall or update Genie; modified payload was preserved' };
+}
+
+/** Remove only the digest-proven ownership marker; payload and all history remain untouched. */
+export function uninstallOwnedOrcaPluginMetadata(): 'removed' | 'absent' | 'preserved' {
+  const target = paths();
+  const existing = readOwnership(target.ownership);
+  if (existing === null) return 'absent';
+  if (existing === 'unsafe') return 'preserved';
+  let expected: Ownership;
+  try {
+    expected = expectedOwnership();
+  } catch {
+    return 'preserved';
+  }
+  if (!sameOwnership(existing, expected)) return 'preserved';
+  rmSync(target.ownership);
+  return 'removed';
+}
+
+/** Refresh a prior Genie ownership claim after update/rollback replaces the verified payload. */
+export async function refreshOwnedOrcaPluginMetadata(
+  probeOverride?: () => Promise<OrcaPluginCompatibilityResult>,
+): Promise<'standalone' | 'unmanaged' | 'unchanged' | 'refreshed'> {
+  if (resolveOrchestrationMode() !== 'orca') return 'standalone';
+  const target = paths();
+  const previous = readOwnership(target.ownership);
+  if (previous === null) return 'unmanaged';
+  if (previous === 'unsafe') throw new Error('Orca plugin ownership metadata is unsafe; update preserved it');
+  const expected = expectedOwnership();
+  if (sameOwnership(previous, expected)) return 'unchanged';
+  const probe =
+    probeOverride ??
+    (async () => {
+      const { createOrcaPluginRuntime } = await import('../../plugins/genie/orca-runtime.js');
+      return createOrcaPluginRuntime().probe();
+    });
+  await probe();
+  const original = readFileSync(target.ownership, 'utf8');
+  try {
+    atomicWrite(target.ownership, `${JSON.stringify(expected, null, 2)}\n`);
+  } catch (error) {
+    atomicWrite(target.ownership, original);
+    throw error;
+  }
+  return 'refreshed';
+}


### PR DESCRIPTION
## A4 — lifecycle preservation, transitions, and doctor

Directly based on A3 integration and implements the Option-A ownership boundary:

- explicit backup-first `--orchestration-mode standalone|orca` transition through setup, with typed compatibility preflight before the config commit
- digest-backed metadata only for Genie-owned shipped payload artifacts; update/rollback/uninstall never adopt or delete user config, lifecycle history, or Orca records
- truthful, read-only doctor reporting for mode, payload, compatibility, and `host_registration: not-managed`
- no private Orca host registration/state writes: marketplace installation remains native-host/user-managed for A5/A6

Independent review: SHIP. The reviewer reproduced the only local doctor latency failure against the base; local full-gate mode drift is physical checkout state (tracked 100755 materialized 0700). Exact-head CI is the merge gate.