### PR TITLE
fix(release): ship native Orca plugin payload

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -185,7 +185,7 @@ jobs:
       # SECURITY: every command in this step is trusted workflow control loaded
       # from main. Do not run package scripts, dependency installers, hooks, or
       # any executable from the dev checkout in this write-capable workflow.
-      - name: Synchronize the exact seven version fields
+      - name: Synchronize the exact nine version fields
         if: steps.context.outputs.should_bump == 'true'
         env:
           VERSION: ${{ steps.version.outputs.version }}
@@ -196,6 +196,7 @@ jobs:
             plugins/genie/.claude-plugin/plugin.json
             plugins/genie/.codex-plugin/plugin.json
             plugins/genie/.kimi-plugin/plugin.json
+            plugins/genie/orca-plugin.json
             plugins/genie/package.json
             plugins/pi-genie/package.json
           )
@@ -268,7 +269,7 @@ jobs:
           EXPECTED="$(printf '%s\n' "${VERSION_PATHS[@]}" | LC_ALL=C sort)"
           ACTUAL="$(git diff --cached --name-only -- | LC_ALL=C sort)"
           if [[ "$ACTUAL" != "$EXPECTED" ]]; then
-            echo "::error ::release-version.delta_untrusted expected exactly eight version files"
+            echo "::error ::release-version.delta_untrusted expected exactly nine version files"
             printf 'expected:\n%s\nactual:\n%s\n' "$EXPECTED" "$ACTUAL" >&2
             exit 1
           fi

--- a/plugins/genie/orca-plugin.json
+++ b/plugins/genie/orca-plugin.json
@@ -3,7 +3,7 @@
   "id": "genie",
   "publisher": "automagik",
   "name": "Genie",
-  "version": "5.260829.1",
+  "version": "5.260829.4",
   "description": "Genie workflows backed by Orca as the sole lifecycle authority.",
   "author": {
     "name": "Namastex Labs",

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -129,6 +129,8 @@ for required in \
   ".claude-plugin/marketplace.json" \
   "plugins/genie/.codex-plugin/plugin.json" \
   "plugins/genie/.kimi-plugin/plugin.json" \
+  "plugins/genie/orca-plugin.json" \
+  "plugins/genie/orca-entrypoint.min.js" \
   "plugins/genie/scripts/mcp-launcher.cjs" \
   "plugins/genie/.claude-plugin/plugin.json" \
   "plugins/genie/hooks/hooks.json" \

--- a/scripts/release-docs.test.ts
+++ b/scripts/release-docs.test.ts
@@ -63,6 +63,7 @@ describe('Group E release and documentation contracts', () => {
       'plugins/genie/.claude-plugin/plugin.json',
       'plugins/genie/.codex-plugin/plugin.json',
       'plugins/genie/.kimi-plugin/plugin.json',
+      'plugins/genie/orca-plugin.json',
       'plugins/genie/package.json',
       'plugins/pi-genie/package.json',
       '.claude-plugin/marketplace.json',

--- a/scripts/release-guard.sh
+++ b/scripts/release-guard.sh
@@ -158,6 +158,7 @@ version_child_matches_parent() {
     'plugins/genie/.claude-plugin/plugin.json' \
     'plugins/genie/.codex-plugin/plugin.json' \
     'plugins/genie/.kimi-plugin/plugin.json' \
+    'plugins/genie/orca-plugin.json' \
     'plugins/genie/package.json' \
     'plugins/pi-genie/package.json' \
     'plugins/hermes-genie/plugin.yaml' | LC_ALL=C sort)"
@@ -169,6 +170,7 @@ version_child_matches_parent() {
     plugins/genie/.claude-plugin/plugin.json \
     plugins/genie/.codex-plugin/plugin.json \
     plugins/genie/.kimi-plugin/plugin.json \
+    plugins/genie/orca-plugin.json \
     plugins/genie/package.json \
     plugins/pi-genie/package.json; do
     git show "${child_sha}:${path}" |

--- a/scripts/release-guard.test.ts
+++ b/scripts/release-guard.test.ts
@@ -308,6 +308,7 @@ function writeVersionTree(root: string, version: string, packageScript?: string)
     ['plugins/genie/.claude-plugin/plugin.json', { name: 'genie', version }],
     ['plugins/genie/.codex-plugin/plugin.json', { name: 'genie', version }],
     ['plugins/genie/.kimi-plugin/plugin.json', { name: 'genie', version }],
+    ['plugins/genie/orca-plugin.json', { id: 'genie', version }],
     ['plugins/genie/package.json', { name: 'genie-plugin', version }],
     ['plugins/pi-genie/package.json', { name: 'genie-pi-plugin', version }],
   ];
@@ -339,7 +340,7 @@ function versionRepo(packageScript?: string) {
 }
 
 describe('check-version-child (parent CI inheritance)', () => {
-  test('accepts the exact deterministic six-field auto-version child', () => {
+  test('accepts the exact deterministic version-only child', () => {
     const fixture = versionRepo();
     const result = guard('check-version-child', {}, [fixture.parent, fixture.child, '5.260714.2'], fixture.root);
     expect(result.exitCode).toBe(0);

--- a/scripts/release-payload-version.test.ts
+++ b/scripts/release-payload-version.test.ts
@@ -30,6 +30,7 @@ describe('release payload version contract', () => {
       'plugins/genie/.claude-plugin/plugin.json',
       'plugins/genie/.codex-plugin/plugin.json',
       'plugins/genie/.kimi-plugin/plugin.json',
+      'plugins/genie/orca-plugin.json',
     ]) {
       writeJson(root, path, { name: 'genie', version: '5.000000.0' });
     }
@@ -68,6 +69,7 @@ describe('release payload version contract', () => {
       'plugins/genie/.claude-plugin/plugin.json',
       'plugins/genie/.codex-plugin/plugin.json',
       'plugins/genie/.kimi-plugin/plugin.json',
+      'plugins/genie/orca-plugin.json',
     ]) {
       expect(JSON.parse(readFileSync(join(root, path), 'utf8')).version).toBe(version);
     }
@@ -85,6 +87,17 @@ describe('release payload version contract', () => {
     writeJson(root, 'plugins/genie/.codex-plugin/plugin.json', { name: 'genie', version: '5.260711.9' });
 
     expect(() => verifyReleasePayloadVersion(root, version)).toThrow('.codex-plugin/plugin.json');
+  });
+
+  test('verification catches a diverging or missing native Orca manifest', () => {
+    const root = fixture();
+    const version = '5.260711.10';
+    stampReleasePayloadVersion(root, version);
+    writeJson(root, 'plugins/genie/orca-plugin.json', { id: 'genie', version: '5.260711.9' });
+    expect(() => verifyReleasePayloadVersion(root, version)).toThrow('orca-plugin.json');
+
+    rmSync(join(root, 'plugins/genie/orca-plugin.json'));
+    expect(() => verifyReleasePayloadVersion(root, version)).toThrow('metadata is missing');
   });
 
   test('source preflight rejects committed drift before a staged override can hide it', () => {
@@ -119,5 +132,7 @@ describe('release payload version contract', () => {
     expect(sourcePreflight).toBeLessThan(stageStamp);
     expect(buildScript).toContain('release-payload-version.ts" --stamp');
     expect(buildScript).toContain('release-payload-version.ts" --verify');
+    expect(buildScript).toContain('"plugins/genie/orca-plugin.json"');
+    expect(buildScript).toContain('"plugins/genie/orca-entrypoint.min.js"');
   });
 });

--- a/scripts/release-payload-version.ts
+++ b/scripts/release-payload-version.ts
@@ -18,6 +18,7 @@ const TOP_LEVEL_VERSION_FILES = [
   'plugins/genie/.claude-plugin/plugin.json',
   'plugins/genie/.codex-plugin/plugin.json',
   'plugins/genie/.kimi-plugin/plugin.json',
+  'plugins/genie/orca-plugin.json',
 ] as const;
 
 const COMMITTED_VERSION_FILES = ['package.json', ...TOP_LEVEL_VERSION_FILES] as const;

--- a/scripts/version-ci-staging.test.ts
+++ b/scripts/version-ci-staging.test.ts
@@ -34,6 +34,7 @@ describe('synchronizeVersionFiles CI staging', () => {
       'plugins/genie/.claude-plugin/plugin.json',
       'plugins/genie/.codex-plugin/plugin.json',
       'plugins/genie/.kimi-plugin/plugin.json',
+      'plugins/genie/orca-plugin.json',
       'plugins/genie/package.json',
       'plugins/pi-genie/package.json',
     ]) {
@@ -71,6 +72,7 @@ describe('synchronizeVersionFiles CI staging', () => {
     const staged = stagedPaths(root);
     expect(staged).toContain('plugins/hermes-genie/plugin.yaml');
     expect(staged).toContain('plugins/pi-genie/package.json');
+    expect(staged).toContain('plugins/genie/orca-plugin.json');
     expect(staged).toContain('package.json');
     expect(staged).toContain('.claude-plugin/marketplace.json');
     // The rewritten value is actually on disk (staging did not mask a no-op).

--- a/scripts/version-format.test.ts
+++ b/scripts/version-format.test.ts
@@ -49,6 +49,7 @@ describe('manifest version formatting', () => {
       'plugins/genie/.claude-plugin/plugin.json',
       'plugins/genie/.codex-plugin/plugin.json',
       'plugins/genie/.kimi-plugin/plugin.json',
+      'plugins/genie/orca-plugin.json',
       'plugins/genie/package.json',
       'plugins/pi-genie/package.json',
     ]) {
@@ -120,6 +121,7 @@ describe('manifest version formatting', () => {
       );
       // The pi plugin manifest carries the same release version.
       expect(JSON.parse(readFileSync(join(root, 'plugins/pi-genie/package.json'), 'utf8')).version).toBe('5.260711.3');
+      expect(JSON.parse(readFileSync(join(root, 'plugins/genie/orca-plugin.json'), 'utf8')).version).toBe('5.260711.3');
 
       rmSync(join(root, 'plugins/genie/.codex-plugin/plugin.json'));
       await expect(synchronizeVersionFiles(root, '5.260711.4')).rejects.toThrow(

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -14,6 +14,7 @@
  * - package.json (root)
  * - plugins/genie/.claude-plugin/plugin.json (Claude Code)
  * - plugins/genie/.codex-plugin/plugin.json (Codex)
+ * - plugins/genie/orca-plugin.json (Orca)
  * - plugins/genie/package.json (runtime payload metadata)
  * - .claude-plugin/marketplace.json (marketplace listing)
  * - plugins/hermes-genie/plugin.yaml (Hermes native surface, YAML manifest)
@@ -199,6 +200,7 @@ export async function synchronizeVersionFiles(rootDir: string, version: string):
     join(rootDir, 'plugins/genie/.claude-plugin/plugin.json'),
     join(rootDir, 'plugins/genie/.codex-plugin/plugin.json'),
     join(rootDir, 'plugins/genie/.kimi-plugin/plugin.json'),
+    join(rootDir, 'plugins/genie/orca-plugin.json'),
     join(rootDir, 'plugins/genie/package.json'),
     join(rootDir, 'plugins/pi-genie/package.json'),
   ];


### PR DESCRIPTION
## Summary

Ships the already-native Genie-owned Orca plugin as a release payload: version synchronization, version-only CI child guards, staging verification, and extracted tarball verification now require both `orca-plugin.json` and `orca-entrypoint.min.js`.

This PR is limited to packaging/release metadata and tests; it does not register a host plugin, promote a release, add a fallback, or change the closed Option-A orchestration boundary.

## Evidence

- Base: `origin/dev` `2523a4bdbf4773587abb65bc224e361508b84d25`
- Head: `9d26c00e804f8238c388b9a849015a455fba255a`
- Independent re-review: SHIP; exact 11-file scope and every canonical version field at `5.260829.4`
- Focused tests: 98 pass / 0 fail (924 expectations)
- Four tarball builds and inventory checks were completed before rebase; PR CI is the authoritative current-head packaging proof.