### PR TITLE
docs(orca): document dual-mode authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,71 @@ From inside a trusted initialized repo, run `genie init` to reconcile the marker
 
 Codex never auto-trusts plugin hooks. H4/H6 definitions bind the exact plugin launcher SHA-256 and the launcher verifies itself before spawning, so launcher changes produce new definitions; the current hook schema still cannot transitively bind the mutable platform-specific Genie binary. After successful Codex setup, inspect the three Genie definitions with `/hooks`, approve only the hashes you understand, and start a new task so the reviewed definitions take effect. Until then they remain untrusted and do not run.
 
+## Standalone and Orca authority
+
+Genie has two explicit lifecycle modes. `standalone` is the default, including when the configuration omits
+`orchestration.mode`; merely installing or opening Orca never changes authority. Standalone keeps the existing local
+task, board, and roadmap behavior. Select Orca only when you intend Orca to become the sole lifecycle authority:
+
+```bash
+genie setup --orchestration-mode orca
+genie doctor
+```
+
+The switch first verifies the shipped plugin payload and a compatible Orca runtime (Orca `1.4.192` or newer with
+`orchestration.contract.v1`). Only after that probe succeeds does Genie back up its configuration and atomically select
+Orca. In Orca mode, Genie does not open `.genie/genie.db` for lifecycle reads or writes and refuses roadmap writes,
+syncs, and exports before they can create or change local files. Existing local history is preserved in place, but it is
+not imported, mirrored, or treated as current. The plugin keeps no fallback database: if Orca is unavailable, the
+operation fails instead of silently returning to standalone.
+
+Switching back is also deliberate and does not import Orca state:
+
+```bash
+genie setup --orchestration-mode standalone
+genie doctor
+```
+
+`genie doctor` reports the selected authority, plugin ownership state, resolved runtime version, and compatibility.
+`unsupported_environment` means the host cannot provide the supported public CLI/child-process boundary; install or
+start a compatible Orca runtime and repeat the Orca selection. Do not work around it with a private API, internal RPC,
+terminal injection, or a local fallback.
+
+### Install, update, rollback, and uninstall
+
+Signed release tarballs include `plugins/genie/orca-plugin.json` and the compiled Orca entrypoint on every supported
+platform. The normal installer stages and verifies that payload; authority remains standalone until the explicit setup
+command above. `genie update` preserves the selected mode and lifecycle history, verifies the replacement payload, and
+refreshes a prior Genie ownership claim only after an Orca compatibility probe. Run `genie doctor` after installation or
+update before resuming lifecycle mutations.
+
+`genie update --rollback` checks the retained rollback state and prints signed-version reinstall guidance when a safe
+in-place rollback is unavailable; follow that guidance, then run `genie doctor`. A failed update, rollback, or mode
+preflight leaves the prior configuration and authority unchanged. `genie uninstall` removes only ownership-proven Genie
+artifacts and registrations. Modified or unproven files are preserved, and neither local Genie history nor Orca records
+are deleted. Review the command's backup/recovery output before removing any retained files manually.
+
+### Ambiguous Orca receipts and recovery
+
+The plugin invokes only a closed subset of official `orca orchestration ... --json` commands. Successful mutations
+require a bounded receipt and, where the public CLI supports it, an immediate public read-back. If the process times out,
+exceeds its output cap, or loses transport after launch without a complete identifying receipt, Genie reports
+`ambiguous_after_possible_commit`. Do not automatically retry: Orca may already have committed the operation. Inspect
+the exact public read operation named by the error only when the identifier was known before launch; otherwise confirm
+the outcome with an Orca operator before deciding whether to issue a new mutation. Genie never guesses an identifier
+from a collection or infers success from a partial response.
+
+### Staged MCP retirement
+
+The Orca plugin does not make the current MCP surface disappear in this documentation release. The legacy `genie mcp`
+remains available, and `genie init` continues to manage only Genie-owned project registrations, until the later A7 PR
+lands after dual-mode parity and migration gates. Do not remove project MCP routes pre-emptively. A7 will retire the
+server and proved-owned registrations with a stable non-zero diagnostic while preserving unrelated configuration and
+standalone history; rollback to a pre-A7 signed release remains the migration escape hatch.
+
+Maintainers should read the [public Orca boundary and verb-amendment contract](plugins/genie/references/orca-orchestration.md)
+before changing the adapter or its operator guidance.
+
 ## Quickstart
 
 The lifecycle is shared by Claude Code and Codex. Claude uses slash skills. A Codex plugin install uses the unambiguous owner-qualified `$genie:<skill>` selector; bare `$<skill>` resolves the user tier, which now only ever holds a separately installed personal copy (Genie no longer seeds the user tier):

--- a/plugins/genie/README.md
+++ b/plugins/genie/README.md
@@ -2,6 +2,10 @@
 
 This directory is the shared release payload for Claude Code and Codex. The two clients load different manifests, but the 22 product skills have one canonical source (`/skills`) and one committed, byte-checked plugin mirror (`plugins/genie/skills`).
 
+For Orca installation, authority selection, recovery, compatibility, and contribution rules, see the
+[Orca dual-mode operator and contributor contract](references/orca-orchestration.md). Standalone remains the default;
+the packaged Orca payload is inert until the operator explicitly selects Orca authority.
+
 ## What Codex gets
 
 | Surface | Delivery | Contract |

--- a/plugins/genie/references/orca-orchestration.md
+++ b/plugins/genie/references/orca-orchestration.md
@@ -1,0 +1,97 @@
+# Orca orchestration boundary
+
+This is the contributor contract for Genie's Option A Orca plugin. Operator commands and recovery are documented in
+the repository [README](../../../README.md#standalone-and-orca-authority). Keep both surfaces aligned with shipped code.
+
+## Authority and compatibility
+
+Standalone is the default. Only `genie setup --orchestration-mode orca` may select Orca lifecycle authority, and it
+must finish the packaged-payload and runtime preflight before committing configuration. In Orca mode, the low-level
+SQLite pre-open barrier rejects local lifecycle reads and writes, and the roadmap pre-write barrier rejects direct and
+indirect writes, syncs, and exports. Do not route around either barrier or serve stale local data as a convenience.
+
+The supported host boundary is the public Orca CLI with child-process execution, runtime version `>=1.4.192`, and the
+`orchestration.contract.v1` capability. A host that cannot satisfy that contract returns `unsupported_environment`.
+No fallback to standalone or to another transport is permitted.
+
+## Closed public CLI adapter
+
+The adapter accepts typed operations, validates them against per-verb closed schemas, and compiles them to an exact
+allowlist of `orca orchestration <verb> ... --json` argv. It owns the final `--json`, selects one deterministic
+executable, and spawns with `shell: false`. Callers cannot provide executable names, raw argv, flags, placement,
+routing, terminal handles, or recovery commands.
+
+Runtime selection is fixed: a host-provided `ORCA_CLI_COMMAND` is accepted only as one validated executable token;
+otherwise Linux outside an Orca terminal selects `orca-ide`, Windows selects `orca.exe`, and macOS or an Orca-managed
+terminal selects `orca`. Failure of that selected executable is final—never probe a second candidate.
+
+The positive boundary currently contains these operations:
+
+```text
+run-create run-list run-show run-current run-use
+task-create task-list task-update
+worker-start worker-show worker-read worker-release
+send check reply ask
+gate-create gate-list gate-resolve
+```
+
+Reject `terminal send`. Reject `--inject`. Reject `internal RPC`. Reject `private API`. Also reject caller-selected
+`--json`, generic command runners, shell strings, setup/worktree/repository placement, impersonation/routing flags, and
+unknown fields before spawning. Examples in public docs must remain inside this finite boundary.
+
+## Receipts, read-backs, and recovery
+
+stdout must be exactly one schema-valid Orca JSON envelope. stderr is bounded diagnostic context, never success data.
+Execution has fixed time and output limits, and errors redact secrets and unbounded payloads.
+
+A mutation succeeds only with a valid identifying receipt plus an exact public read-back where the official CLI exposes
+one. The read-back must prove the requested identity and immutable fields. Receipt-only exceptions are deliberately
+narrow: `send`, `reply`, and `check --ack`, because the allowed public subset has no stable exact-message or separate
+acknowledgement read.
+
+After launch, timeout, output-limit, or transport loss without a complete identifying receipt is
+`ambiguous_after_possible_commit`. Never retry the mutation automatically, scrape a partial response, or enumerate a
+collection to guess which entity was created. An automated public read-back is allowed only when the exact identifier
+was validated independently before launch and the capability table names the exact read operation. Even then the
+read-back informs the caller; it does not authorize an automatic retry. Otherwise only operator or external
+confirmation can resolve the ambiguity.
+
+Every adapter error preserves the safe operation name, failure phase, retry-safety classification, and a public recovery
+hint. It must never suggest silently switching authority.
+
+## Verb amendment checklist
+
+A new verb or field changes the trust boundary. Before implementation:
+
+1. Amend the approved design and explain the current user story; a configurable or speculative allowlist is not enough.
+2. Add a strict input schema, exact argv row, closed response schema, receipt identity, and public read-back contract (or
+   document the narrow reason an official read does not exist).
+3. Add positive exact-argv tests and negative pre-spawn tests for flag-shaped values, raw argv, terminal/placement,
+   routing/impersonation, executable override, caller `--json`, unknown fields, malformed envelopes, time/output limits,
+   missing receipts, and read-back disagreement.
+4. Re-run the supported real-runtime smoke and prove that no local Genie DB or roadmap state changed.
+5. Update this file, the operator README, compatibility range when required, package inventory checks, and the targeted
+   release documentation test. Obtain independent threat-boundary review.
+
+No fallback, cache, retry ledger, mirror, queue, lifecycle store, private host API, or background synchronization may be
+added without a separately approved design.
+
+## Lifecycle and release maintenance
+
+Install and update stage the complete payload, verify its inventory and version, preflight the selected authority, and
+activate atomically. Rollback restores only a verified prior Genie-owned payload/configuration snapshot. Uninstall may
+remove only digest-proven Genie ownership metadata and registrations; it never deletes local lifecycle history, Orca
+records, modified payloads, or unrelated registrations. `genie doctor` is observational and must report mode, ownership,
+resolved runtime compatibility, and actionable recovery without creating lifecycle state.
+
+Every supported release tarball must contain `orca-plugin.json` and `orca-entrypoint.min.js`, agree with `VERSION` and
+package metadata, and pass extracted-package installation verification. Stable remains the default release channel;
+selecting an Orca lifecycle mode is separate from selecting a release channel.
+
+## MCP retirement sequencing
+
+Do not remove `genie mcp`, its launchers, or registrations in Option A documentation work. The legacy MCP remains shipped
+until the later A7 PR, after authority, adapter, plugin, lifecycle, packaging, and documentation gates are green. A7 may
+remove only proved-owned registrations, must preserve unrelated user configuration and both authorities' history, and
+must leave the documented stable non-zero retired diagnostic. Until then, documentation must describe retirement as
+staged rather than complete.

--- a/plugins/genie/references/orca-orchestration.md
+++ b/plugins/genie/references/orca-orchestration.md
@@ -21,9 +21,9 @@ allowlist of `orca orchestration <verb> ... --json` argv. It owns the final `--j
 executable, and spawns with `shell: false`. Callers cannot provide executable names, raw argv, flags, placement,
 routing, terminal handles, or recovery commands.
 
-Runtime selection is fixed: a host-provided `ORCA_CLI_COMMAND` is accepted only as one validated executable token;
-otherwise Linux outside an Orca terminal selects `orca-ide`, Windows selects `orca.exe`, and macOS or an Orca-managed
-terminal selects `orca`. Failure of that selected executable is final—never probe a second candidate.
+Runtime selection is fixed by platform and managed-terminal state: Linux outside an Orca terminal selects `orca-ide`,
+Windows selects `orca.exe`, and macOS or an Orca-managed terminal selects `orca`. Failure of that selected executable
+is final—never probe a second candidate.
 
 The positive boundary currently contains these operations:
 
@@ -46,8 +46,8 @@ Execution has fixed time and output limits, and errors redact secrets and unboun
 
 A mutation succeeds only with a valid identifying receipt plus an exact public read-back where the official CLI exposes
 one. The read-back must prove the requested identity and immutable fields. Receipt-only exceptions are deliberately
-narrow: `send`, `reply`, and `check --ack`, because the allowed public subset has no stable exact-message or separate
-acknowledgement read.
+narrow: `send`, `reply`, `ask`, and `check --ack`, because the allowed public subset has no stable exact-message, ask,
+or separate acknowledgement read.
 
 After launch, timeout, output-limit, or transport loss without a complete identifying receipt is
 `ambiguous_after_possible_commit`. Never retry the mutation automatically, scrape a partial response, or enumerate a

--- a/scripts/release-docs.test.ts
+++ b/scripts/release-docs.test.ts
@@ -832,14 +832,16 @@ describe('Group E release and documentation contracts', () => {
       'orca orchestration',
       '--json',
       'shell: false',
-      'ORCA_CLI_COMMAND',
+      'fixed by platform and managed-terminal state',
       'No fallback',
       'ambiguous_after_possible_commit',
       'Verb amendment checklist',
       'public read-back',
+      '`send`, `reply`, `ask`, and `check --ack`',
     ]) {
       expect(contributor).toContain(topic);
     }
+    expect(contributor).not.toContain('ORCA_CLI_COMMAND');
     for (const forbidden of ['terminal send', '--inject', 'internal RPC', 'private API']) {
       expect(contributor).toContain(`Reject \`${forbidden}\``);
     }

--- a/scripts/release-docs.test.ts
+++ b/scripts/release-docs.test.ts
@@ -803,6 +803,50 @@ describe('Group E release and documentation contracts', () => {
     expect(doc).toContain('scripts/verify-codex-activation-payload.ts');
   });
 
+  test('dual-mode docs preserve the operator and public Orca contributor contracts', () => {
+    const operator = read('README.md');
+    const contributor = read('plugins/genie/references/orca-orchestration.md');
+    const pluginReadme = read('plugins/genie/README.md');
+
+    for (const topic of [
+      '`standalone` is the default',
+      'genie setup --orchestration-mode orca',
+      'genie setup --orchestration-mode standalone',
+      'orchestration.contract.v1',
+      'genie doctor',
+      'ambiguous_after_possible_commit',
+      'unsupported_environment',
+      'genie update --rollback',
+      'genie uninstall',
+      'A7',
+    ]) {
+      expect(operator).toContain(topic);
+    }
+    expect(operator).toContain('Genie does not open `.genie/genie.db`');
+    expect(operator).toContain('roadmap');
+    expect(operator).toContain('The legacy `genie mcp`');
+    expect(operator).toContain('until the later A7 PR');
+    expect(operator).toContain('plugins/genie/references/orca-orchestration.md');
+
+    for (const topic of [
+      'orca orchestration',
+      '--json',
+      'shell: false',
+      'ORCA_CLI_COMMAND',
+      'No fallback',
+      'ambiguous_after_possible_commit',
+      'Verb amendment checklist',
+      'public read-back',
+    ]) {
+      expect(contributor).toContain(topic);
+    }
+    for (const forbidden of ['terminal send', '--inject', 'internal RPC', 'private API']) {
+      expect(contributor).toContain(`Reject \`${forbidden}\``);
+    }
+    expect(pluginReadme).toContain('[Orca dual-mode operator and contributor contract]');
+    expect(pluginReadme).toContain('references/orca-orchestration.md');
+  });
+
   test('release build independently verifies each extracted activation payload', () => {
     const build = read('scripts/build-binary.sh');
     const extract = build.indexOf('tar -xzf "${TARBALL}"');


### PR DESCRIPTION
Summary\n- Documents explicit standalone and Orca authority selection, barriers, lifecycle preservation, recovery, release payload, and deferred MCP retirement.\n- Adds a contributor contract for the closed public Orca CLI boundary with no shell, private API, fallback, or second lifecycle store.\n- Locks the operator and contributor claims with the release-docs contract test.\n\nReview and evidence\n- Initial independent review found two documentation accuracy issues; the one scoped correction received SHIP re-review.\n- Final content was cleanly rebased onto current dev 6a52dac53371965c9195f6dc3150e6490410973c as 656fffba5f7d376c3aab55b4cf0177d3214709c3; focused tests were rerun after rebase.\n- Focused release-docs test: 44 passed, 822 assertions. Pre-test repository gates passed locally after tracked executable materialization normalization; broader local suite retains known environment-sensitive baselines, so attached CI is authoritative.\n\nMCP retirement remains intentionally deferred to A7.