### PR TITLE
fix(update): admit umask-restricted release payloads and re-sync orca-plugin.json

### DIFF
--- a/plugins/genie/orca-plugin.json
+++ b/plugins/genie/orca-plugin.json
@@ -3,7 +3,7 @@
   "id": "genie",
   "publisher": "automagik",
   "name": "Genie",
-  "version": "5.260829.7",
+  "version": "5.260829.8",
   "description": "Genie workflows backed by Orca as the sole lifecycle authority.",
   "author": {
     "name": "Namastex Labs",

--- a/src/lib/install-promotion.test.ts
+++ b/src/lib/install-promotion.test.ts
@@ -127,13 +127,9 @@ function writeReceipt(
     phase,
     member,
   };
-  writeFileSync(
-    join(transactionRoot, 'receipts', `${sequence.toString().padStart(12, '0')}.json`),
-    `${JSON.stringify(body)}\n`,
-    {
-      mode,
-    },
-  );
+  const path = join(transactionRoot, 'receipts', `${sequence.toString().padStart(12, '0')}.json`);
+  writeFileSync(path, `${JSON.stringify(body)}\n`, { mode });
+  chmodSync(path, mode); // the create mode is umask-filtered; tests need the exact bits they asked for
 }
 
 afterEach(() => {
@@ -543,6 +539,7 @@ describe('installer promotion transaction', () => {
     const fixture = makeFixture();
     const previous = join(fixture.bin, '.previous');
     mkdirSync(previous, { mode: 0o755 });
+    chmodSync(previous, 0o755); // the create mode is umask-filtered; the test needs exactly 0755
 
     const report = promote(fixture);
 
@@ -799,6 +796,33 @@ describe('installer promotion transaction', () => {
     expect(readFileSync(join(quarantined, 'plugins', 'generation.txt'), 'utf8')).toBe('2.0.0:plugins\n');
     expect(readdirSync(victim)).toEqual(['sentinel']);
     expect(readFileSync(join(victim, 'sentinel'), 'utf8')).toBe('safe\n');
+  });
+
+  test('admission normalizes a umask-restricted external binary mode before authenticating content', () => {
+    // Regression: `tar -xzf` under umask 077 extracts `genie` as 0700. Admission
+    // used to digest the external payload (mode 0700), copy it, then fchmod the
+    // copy to 0755 — so the mode-bearing digests could never agree and every
+    // update on such a host failed with "does not match the authenticated source".
+    const root = makeRoot();
+    const home = join(root, 'home');
+    const external = join(root, 'external');
+    mkdirSync(join(home, 'bin'), { recursive: true, mode: 0o700 });
+    mkdirSync(external, { mode: 0o700 });
+    writePayload(external, '2.0.0');
+    chmodSync(join(external, 'genie'), 0o700);
+    const guard = admitExternalInstallStaging({
+      genieHome: home,
+      externalStagingRoot: external,
+      expectedVersion: '2.0.0',
+      randomId: () => '99999999-9999-4999-8999-999999999999',
+    });
+    try {
+      expect(Number(lstatSync(join(guard.stagingRoot, 'genie')).mode & 0o777)).toBe(0o755);
+      expect(Number(lstatSync(join(external, 'genie')).mode & 0o777)).toBe(0o755);
+      expect(() => verifyAdmittedInstallStagingPayload(guard)).not.toThrow();
+    } finally {
+      closeInstallStagingDirectory(guard);
+    }
   });
 
   test('post-admission same-root mutation breaks the authenticated payload guard', () => {

--- a/src/lib/install-promotion.ts
+++ b/src/lib/install-promotion.ts
@@ -744,6 +744,36 @@ function copyPayloadIntoHeldStaging(externalStagingRoot: string, guard: InstallS
   if (operationError !== undefined) throw operationError;
 }
 
+/**
+ * Normalize the external payload's Genie binary to the canonical executable
+ * mode before its content is authenticated. The payload digest binds
+ * `mode & 0o777`, and admission always fchmods the held copy to 0755; on a
+ * host whose umask strips group/other bits (e.g. 077) `tar -xzf` extracts the
+ * binary as 0700, so digesting first and normalizing second could never agree.
+ * The external root is our own private extraction sandbox, so this mutates
+ * only an owned physical file we are about to copy anyway.
+ */
+function normalizeExternalBinaryMode(externalStagingRoot: string): void {
+  const path = join(externalStagingRoot, 'genie');
+  let fd: number;
+  try {
+    fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+  } catch (error) {
+    throw new InstallPromotionError(`external install payload binary is not an openable physical file: ${path}`, {
+      cause: error,
+    });
+  }
+  try {
+    const stat = fstatSync(fd, { bigint: true });
+    if (!stat.isFile() || stat.uid !== currentUid() || stat.nlink !== 1n) {
+      throw new InstallPromotionError('external install payload binary is not an owned physical file');
+    }
+    if ((stat.mode & 0o777n) !== 0o755n) fchmodSync(fd, 0o755);
+  } finally {
+    closeSync(fd);
+  }
+}
+
 /** Admit an exact external release payload into the existing promotion engine's private direct-child contract. */
 export function admitExternalInstallStaging(options: AdmitExternalInstallStagingOptions): InstallStagingDirectoryGuard {
   const externalStagingRoot = resolve(options.externalStagingRoot);
@@ -757,6 +787,7 @@ export function admitExternalInstallStaging(options: AdmitExternalInstallStaging
   if (expectedVersion === null) {
     throw new InstallPromotionError('external install staging requires an expectedVersion to authenticate VERSION');
   }
+  normalizeExternalBinaryMode(externalStagingRoot);
   const externalBefore = verifyPayloadLayout(externalStagingRoot, dependencies);
   verifyPayloadVersionStamp(join(externalStagingRoot, 'VERSION'), expectedVersion);
   const authenticatedContentDigest = payloadContentDigest(externalStagingRoot);


### PR DESCRIPTION
## Problem

`genie update --dev` (5.260816.2 → 5.260829.4) fails on any host whose umask strips group/other bits (e.g. `0077`):

```
▸ Promoting verified release generation...
✖ Update failed: admitted install payload content does not match the authenticated source
```

Root cause (`src/lib/install-promotion.ts` → `admitExternalInstallStaging`): `tar -xzf` extracts `genie` as `0700` under that umask. Admission digests the external payload (the digest binds `mode & 0o777`, so it records `0700`), `cpSync`s it into the held stage, then `fchmod`s the copy to `0755` — and only then compares digests. They can never agree. The tarballs themselves are fine (`./genie` is `0755` in every published release); the bug has shipped since v5.260720.1.

## Fix

Normalize the external `genie` to `0755` through an owned `O_NOFOLLOW` descriptor **before** the authenticated digest is taken (`normalizeExternalBinaryMode`). The external root is our own private extraction sandbox and the copy was always going to be `0755`, so this changes no security posture — it moves an existing normalization ahead of the hash.

Verified against the real `genie-5.260829.4-linux-x64-glibc.tar.gz` extracted under umask 077: unpatched module → exact error above; patched → admitted + `verifyAdmittedInstallStagingPayload` passes.

## Tests

- New regression test: external `genie` at `0700` → admission succeeds, both sides end at `0755`, digest guard holds. Fails on `dev` with the exact user-facing error.
- Two existing tests assumed a permissive umask (`mkdirSync({mode:0o755})`, `writeFileSync({mode:0o644})` are umask-filtered); they now `chmod` the bits they assert so the suite is umask-independent.

## Also: `plugins/genie/orca-plugin.json` → 5.260829.8

This PR's CI (and the dev tarball build for v5.260829.8) fails with `committed version mismatch in plugins/genie/orca-plugin.json: expected 5.260829.8, got 5.260829.7`. `version.yml` is a `workflow_run` workflow, so GitHub executes **main's** copy — which still syncs "the exact seven version fields" and doesn't know `orca-plugin.json` (dev's copy from #2812/#2816 lists nine). Every dev bump will keep leaving it behind until main's workflow is updated; #2816 hand-patched .7 for the same reason. This PR hand-patches .8 so CI is green now; the durable fix is promoting the workflow change to main (see companion PR against `main`).

## Note for operators on affected hosts

The installed 5.260816.2 binary runs the buggy admission itself, so `genie update` from it will still fail even after this ships. Use `install.sh` (it promotes via the *new* binary's `__install-promote`) to get onto the first release containing this fix; subsequent `genie update` runs are then fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gGxGgKskzyzr1HRUB6cV3