### PR TITLE
ci(version): sync plugins/genie/orca-plugin.json in the auto-version bump

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -185,7 +185,7 @@ jobs:
       # SECURITY: every command in this step is trusted workflow control loaded
       # from main. Do not run package scripts, dependency installers, hooks, or
       # any executable from the dev checkout in this write-capable workflow.
-      - name: Synchronize the exact seven version fields
+      - name: Synchronize the exact nine version fields
         if: steps.context.outputs.should_bump == 'true'
         env:
           VERSION: ${{ steps.version.outputs.version }}
@@ -196,6 +196,7 @@ jobs:
             plugins/genie/.claude-plugin/plugin.json
             plugins/genie/.codex-plugin/plugin.json
             plugins/genie/.kimi-plugin/plugin.json
+            plugins/genie/orca-plugin.json
             plugins/genie/package.json
             plugins/pi-genie/package.json
           )
@@ -268,7 +269,7 @@ jobs:
           EXPECTED="$(printf '%s\n' "${VERSION_PATHS[@]}" | LC_ALL=C sort)"
           ACTUAL="$(git diff --cached --name-only -- | LC_ALL=C sort)"
           if [[ "$ACTUAL" != "$EXPECTED" ]]; then
-            echo "::error ::release-version.delta_untrusted expected exactly eight version files"
+            echo "::error ::release-version.delta_untrusted expected exactly nine version files"
             printf 'expected:\n%s\nactual:\n%s\n' "$EXPECTED" "$ACTUAL" >&2
             exit 1
           fi


### PR DESCRIPTION
## Why this targets the default branch directly

`.github/workflows/version.yml` runs on `workflow_run`, so GitHub always executes the **default-branch** copy — never dev's. Dev already fixed this workflow in #2812/#2816 (nine version fields including `plugins/genie/orca-plugin.json`), but the run for v5.260829.8 still logged `Synchronize the exact seven version fields` and left `orca-plugin.json` at .7. Result: `scripts/release-payload-version.ts --verify-source` fails every dev tarball build and the rolling promotion PR #2817 shows red.

This PR is the byte-identical `version.yml` from `dev` and nothing else (`git checkout origin/dev -- .github/workflows/version.yml`), so the dev→main promotion in #2817 is unaffected content-wise and the *next* dev bump is whole.

Until this merges, every dev merge needs a manual `orca-plugin.json` bump (as #2816 and #2821 do).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gGxGgKskzyzr1HRUB6cV3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated version synchronization to include the Genie Orca plugin.
  * Improved version validation and verification messaging for the expanded set of version files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->