### PR TITLE
fix(update): preserve archived modes on extraction so admission survives umask 077

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -644,7 +644,10 @@ extract_and_link() {
     die "install staging path is not a physical directory: $STAGING_DIR" 1
   validate_private_temp_root "$STAGING_DIR"
   log "extracting verified release in private temporary staging"
-  tar -xzf "$tarball" -C "$STAGING_DIR" ||
+  # -p: as non-root, tar applies the caller umask to extracted members; under
+  # umask 077 the archived 0755 binary would land as 0700 and the promoter's
+  # mode-covering content digest would reject the admitted copy.
+  tar -xzpf "$tarball" -C "$STAGING_DIR" ||
     die "extraction failed (corrupt tarball?): ${tarball}" 5
   # tar restores the archived root "./" entry's recorded mode (0755 on every
   # published tarball) onto the extraction directory, clobbering the 0700 we

--- a/scripts/install-swap.test.ts
+++ b/scripts/install-swap.test.ts
@@ -308,6 +308,8 @@ describe('install.sh transactional binary promotion (F31a)', () => {
     const body = source.slice(source.indexOf('extract_and_link() {'), source.indexOf('\n}\n\n# Detect pre-cutover'));
 
     expect(body).toContain('"$STAGING_DIR/genie" __install-promote');
+    // Extraction must reproduce archived modes under any caller umask (-p).
+    expect(body).toContain('tar -xzpf "$tarball" -C "$STAGING_DIR"');
     expect(body).toContain('GENIE_LIFECYCLE_LEASE_PATH="$LIFECYCLE_LOCK"');
     expect(body).toContain('GENIE_LIFECYCLE_LEASE_OWNER="$LIFECYCLE_OWNER_RECORD"');
     expect(body).not.toMatch(/\b(?:rm|mv|cp)\b/);

--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -1826,8 +1826,40 @@ describe('extractTarball (G5 — corrupt artifact)', () => {
     try {
       const tarball = join(tmp, 'genie-5.260714.1-linux-x64-glibc.tar.gz');
       writeFileSync(tarball, 'this is not a gzip archive');
-      await expect(extractTarball(tarball, join(tmp, 'extract'))).rejects.toThrow(/tar -xzf/);
+      await expect(extractTarball(tarball, join(tmp, 'extract'))).rejects.toThrow(/tar -xzpf/);
     } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  // Regression (2026-08-30): under `umask 077` a bare `tar -xzf` extracted the
+  // archived 0755 binary as 0700; admission fchmods only its private copy back
+  // to 0755, so the mode-covering content digests diverged and every
+  // `genie update` failed with "admitted install payload content does not match
+  // the authenticated source". Extraction must reproduce archived modes.
+  test('preserves archived member modes regardless of the caller umask', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'genie-extract-umask-'));
+    const priorUmask = process.umask(0o077);
+    try {
+      const stage = join(tmp, 'stage');
+      mkdirSync(join(stage, 'plugins'), { recursive: true });
+      writeFileSync(join(stage, 'genie'), '#!/bin/sh\nexit 0\n');
+      chmodSync(join(stage, 'genie'), 0o755);
+      writeFileSync(join(stage, 'plugins', 'note.md'), 'payload\n');
+      chmodSync(join(stage, 'plugins', 'note.md'), 0o644);
+      chmodSync(join(stage, 'plugins'), 0o755);
+      const tarball = join(tmp, 'genie-5.260830.1-linux-x64-glibc.tar.gz');
+      const packed = spawnSync('tar', ['-czf', tarball, '-C', stage, 'genie', 'plugins'], { stdio: 'ignore' });
+      expect(packed.status).toBe(0);
+
+      const extract = join(tmp, 'extract');
+      await extractTarball(tarball, extract);
+
+      expect(statSync(join(extract, 'genie')).mode & 0o777).toBe(0o755);
+      expect(statSync(join(extract, 'plugins')).mode & 0o777).toBe(0o755);
+      expect(statSync(join(extract, 'plugins', 'note.md')).mode & 0o777).toBe(0o644);
+    } finally {
+      process.umask(priorUmask);
       rmSync(tmp, { recursive: true, force: true });
     }
   });

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -741,13 +741,21 @@ export async function downloadAndVerifyDeliveryAssets(
 
 /**
  * Extract a tarball into a destination directory. Uses the system `tar` since
- * macOS bsdtar and GNU tar both accept `-xzf`. Throws on failure.
+ * macOS bsdtar and GNU tar both accept `-xzpf`. Throws on failure.
+ *
+ * `-p` (--preserve-permissions) is load-bearing: as non-root, both tars apply
+ * the process umask to every extracted member by default, so under `umask 077`
+ * the archived 0755 `genie` lands as 0700. Admission then fchmods only its
+ * private copy back to 0755 and the content digests (which cover mode bits)
+ * diverge — observed 2026-08-30 as "admitted install payload content does not
+ * match the authenticated source". The signed archive's recorded modes are the
+ * contract; extraction must reproduce them regardless of the caller's umask.
  */
 export async function extractTarball(tarballPath: string, destDir: string): Promise<void> {
   mkdirSync(destDir, { recursive: true });
-  const result = await runCommandSilent('tar', ['-xzf', tarballPath, '-C', destDir], undefined, 30_000);
+  const result = await runCommandSilent('tar', ['-xzpf', tarballPath, '-C', destDir], undefined, 30_000);
   if (!result.success) {
-    throw new Error(`tar -xzf ${tarballPath} failed: ${result.output.trim() || 'no output'}`);
+    throw new Error(`tar -xzpf ${tarballPath} failed: ${result.output.trim() || 'no output'}`);
   }
 }
 


### PR DESCRIPTION
## Problem

`genie update --dev` (5.260816.2 → 5.260829.4) failed after signature verification with `admitted install payload content does not match the authenticated source`. Root cause (reproduced with the real tarball and the real `admitExternalInstallStaging`): both extractors (`extractTarball` in `src/genie-commands/update.ts` and `extract_and_link` in `install.sh`) ran a bare `tar -xzf`. As non-root, tar applies the caller's umask to every member, so under `umask 077` (this host's login default) the archived `0755` `genie` was extracted as `0700`; admission `fchmod`ed only its private copy back to `0755` and the mode-covering digests diverged.

#2821 (merged) made **admission** tolerate the binary case by normalizing the external binary to 0755 before digesting. This PR closes the root cause one layer up and covers the whole payload, not just the binary: under umask 077 every skill, plugin file and `.cjs` script was also landing as `0600`/`0700` in `GENIE_HOME`.

## Change

- `tar -xzpf` in both extractors — the signed archive's recorded modes are the contract regardless of the caller's umask (`-p` is accepted by GNU tar and bsdtar).
- Regression tests: extraction keeps `0755`/`0644` under `umask 077`; the `install.sh` `extract_and_link` body must carry `-p`.

## Validation

- Proof against the real `genie-5.260829.4-linux-x64-glibc.tar.gz` under `umask 077`: `tar -xzf` → admission fails; `tar -xzpf` → admitted OK.
- `bun test src/genie-commands/__tests__/update.test.ts scripts/install-swap.test.ts src/lib/install-promotion.test.ts` → 246 pass; typecheck + biome clean.

## Operator note

Hosts still on a pre-#2821 binary need `(umask 022 && genie update --dev)` once to reach a fixed release, because the old binary does the extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QrkgYMEEhrWTUo5E7Nkjg