### PR TITLE
fix(update): never abort delivery on the Orca ownership-marker refresh

### DIFF
--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -86,6 +86,7 @@ import {
   narrowUpdatePluginRefreshSelection,
   normalizeVersion,
   persistChannel,
+  refreshOrcaOwnershipAfterDelivery,
   resolveChannel,
   resolveLiveBinaryPath,
   resolvePlatformId,
@@ -1811,6 +1812,40 @@ describe('downloadAndVerifyTarball (G5)', () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
+  });
+});
+
+// ============================================================================
+// A4 — the Orca ownership-marker refresh is advisory to delivery. It spawns
+// the live Orca CLI, so it can fail for reasons unrelated to the delivered
+// bytes (Orca closed, unsupported range, corrupted marker). It must never
+// abort an update whose delivery record is already published.
+// ============================================================================
+
+describe('refreshOrcaOwnershipAfterDelivery (A4 advisory marker refresh)', () => {
+  test('a failing probe is reported and does not reject', async () => {
+    const lines: string[] = [];
+    await expect(
+      refreshOrcaOwnershipAfterDelivery(
+        async () => {
+          throw new Error('Orca runtime probe timed out after 30000ms');
+        },
+        (line) => lines.push(line),
+      ),
+    ).resolves.toBeUndefined();
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('ownership marker was not refreshed');
+    expect(lines[0]).toContain('probe timed out');
+    expect(lines[1]).toContain('genie doctor');
+  });
+
+  test('a successful refresh is silent', async () => {
+    const lines: string[] = [];
+    await refreshOrcaOwnershipAfterDelivery(
+      async () => 'refreshed',
+      (line) => lines.push(line),
+    );
+    expect(lines).toEqual([]);
   });
 });
 

--- a/src/genie-commands/update.ts
+++ b/src/genie-commands/update.ts
@@ -2842,6 +2842,31 @@ export function runManualUpdateConvergence(options: ManualUpdateConvergenceOptio
   return { integrations };
 }
 
+/**
+ * A4 ownership-marker refresh is advisory to delivery, never a delivery
+ * invariant. It spawns the live Orca CLI (public A3 compatibility probe,
+ * bounded at 30 s) and refuses on an unsafe marker, so it can fail for reasons
+ * unrelated to the bytes just delivered: Orca closed, below the supported
+ * range, or a corrupted marker. Before this the call sat unguarded between
+ * the payload swap and `publishCodexDeliveryFacts`, so an Orca-mode operator
+ * updating with Orca closed was left with a swapped binary and no delivery
+ * record — the exact state the delivery contract exists to prevent. The
+ * lifecycle function keeps its throwing contract (marker untouched on
+ * failure); the updater reports and moves on, and `genie doctor` owns the
+ * degraded case (`owned-modified` with a recovery line).
+ */
+export async function refreshOrcaOwnershipAfterDelivery(
+  refresh: () => Promise<unknown> = refreshOwnedOrcaPluginMetadata,
+  report: (message: string) => void = log,
+): Promise<void> {
+  try {
+    await refresh();
+  } catch (cause) {
+    report(`⚠ Orca plugin ownership marker was not refreshed: ${errMsg(cause)}`);
+    report('  Delivery is complete. Run `genie doctor` to re-check the Orca plugin lifecycle.');
+  }
+}
+
 function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
@@ -3178,10 +3203,6 @@ async function runDelivery(
         cleanupStagingArtifacts(externalRoot, tarballPath);
       },
     });
-    // A4: refresh only an existing Genie ownership claim. The public A3
-    // compatibility probe must succeed before the marker advances; config and
-    // both authorities' lifecycle history remain untouched.
-    await refreshOwnedOrcaPluginMetadata();
     // The payload is now in GENIE_HOME; publish attested delivery facts (and the
     // rollback sidecar for a protocol-capable backup) under the held lease.
     const deliveryRoot = resolveCanonicalPayloadRoot();
@@ -3204,6 +3225,10 @@ async function runDelivery(
       throw new CodexDeliveryPublicationError(`delivery record publication failed: ${errMsg(cause)}`);
     }
     if (publication.kind === 'incomplete') throw new CodexDeliveryPublicationError(publication.detail);
+    // A4: refresh only an existing Genie ownership claim. Runs after the
+    // delivery record is published and never fails the update — see
+    // refreshOrcaOwnershipAfterDelivery.
+    await refreshOrcaOwnershipAfterDelivery();
     return auxiliaryOutcomes;
   } finally {
     // The command boundary owns both lifecycle leases. This scope only closes


### PR DESCRIPTION
## Problem (HIGH — flagged independently by the supply-chain and architecture lenses reviewing #2817)

`src/genie-commands/update.ts` called `refreshOwnedOrcaPluginMetadata()` unguarded, **between** the payload swap (`finalizeAuxiliaryDelivery`) and `publishCodexDeliveryFacts`. That function spawns the live Orca CLI (A3 compatibility probe, 30 s bound) and throws on an unsafe marker.

Failure scenario: an Orca-mode operator runs `genie update` with Orca closed / below `1.4.192` / a corrupted marker. Binary and `plugins/` are already swapped into `GENIE_HOME`; the probe throws after up to 30 s; the delivery record is never published — and per CLAUDE.md `genie setup --codex` requires that record before its first mutation. Before this PR series `genie update` had no dependency on any third-party binary.

## Change

- The refresh now runs **after** the delivery record is published, through a small exported `refreshOrcaOwnershipAfterDelivery()` that downgrades a failure to two log lines (reason + `genie doctor` pointer). `genie doctor` already owns the degraded `owned-modified` case with a recovery line.
- `refreshOwnedOrcaPluginMetadata()` itself is unchanged: it still throws and leaves the marker untouched on failure (existing lifecycle test kept).

## Validation

- `bun test src/genie-commands/__tests__/update.test.ts src/lib/orca-plugin-lifecycle.test.ts` → 207 pass (2 new tests: failing probe is reported and does not reject; successful refresh is silent)
- typecheck + biome clean

Independent of #2823 / #2824 / #2825.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QrkgYMEEhrWTUo5E7Nkjg