### PR TITLE
ci(plugin): gate the skill mirror + kimi orphan check; ignore init's .mcp.json backup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,9 @@ jobs:
       - name: Shipped plugin executable static checks
         run: bun run lint:plugin-executables
 
+      - name: Plugin skill mirror + Kimi command orphan check
+        run: bun run lint:plugin-skills
+
       - name: Fresh-install smoke
         run: bun run scripts/fresh-install-smoke.ts
 

--- a/package.json
+++ b/package.json
@@ -37,10 +37,11 @@
     "hooks:bind": "bun scripts/hook-content-binding.ts --write",
     "lint:hook-content": "bun scripts/hook-content-binding.ts --check",
     "lint:plugin-executables": "bun scripts/plugin-executables-check.ts",
+    "lint:plugin-skills": "bun scripts/sync-plugin-skills.ts --check",
     "smoke:codex": "bun run scripts/codex-plugin-only-smoke.ts",
     "smoke:codex-discovery": "bun run scripts/codex-debug-discovery-smoke.ts",
-    "check": "bun run typecheck && bun run lint && bun run dead-code && bun run skills:lint && bun run wishes:lint && bun run lint:complexity-budget && bun run lint:council-workflow && bun run lint:hook-bundles && bun run lint:orca-bundle && bun run lint:hook-budgets && bun run lint:hook-content && bun run lint:plugin-executables && bun test",
-    "check:fast": "bun run typecheck && bun run lint && bun run dead-code && bun run skills:lint && bun run wishes:lint && bun run lint:complexity-budget && bun run lint:council-workflow && bun run lint:hook-bundles && bun run lint:orca-bundle && bun run lint:hook-budgets && bun run lint:hook-content && bun run lint:plugin-executables",
+    "check": "bun run typecheck && bun run lint && bun run dead-code && bun run skills:lint && bun run wishes:lint && bun run lint:complexity-budget && bun run lint:council-workflow && bun run lint:hook-bundles && bun run lint:orca-bundle && bun run lint:hook-budgets && bun run lint:hook-content && bun run lint:plugin-executables && bun run lint:plugin-skills && bun test",
+    "check:fast": "bun run typecheck && bun run lint && bun run dead-code && bun run skills:lint && bun run wishes:lint && bun run lint:complexity-budget && bun run lint:council-workflow && bun run lint:hook-bundles && bun run lint:orca-bundle && bun run lint:hook-budgets && bun run lint:hook-content && bun run lint:plugin-executables && bun run lint:plugin-skills",
     "verify:release": "scripts/verify-release.sh"
   },
   "dependencies": {

--- a/scripts/release-docs.test.ts
+++ b/scripts/release-docs.test.ts
@@ -732,6 +732,9 @@ describe('Group E release and documentation contracts', () => {
     expect(pkg.scripts['check:fast']).toContain('bun run lint:orca-bundle');
     expect(workflow).toContain('bun run lint:hook-content');
     expect(workflow).toContain('bun run lint:plugin-executables');
+    expect(workflow).toContain('bun run lint:plugin-skills');
+    expect(pkg.scripts.check).toContain('bun run lint:plugin-skills');
+    expect(pkg.scripts['check:fast']).toContain('bun run lint:plugin-skills');
     expect(pkg.scripts.check).toContain('bun run lint:hook-content');
     expect(pkg.scripts['check:fast']).toContain('bun run lint:hook-content');
     expect(pkg.scripts.check).toContain('bun run lint:plugin-executables');

--- a/src/term-commands/init.test.ts
+++ b/src/term-commands/init.test.ts
@@ -14,7 +14,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 const CLI = join(import.meta.dir, '..', 'genie.ts');
-const GITIGNORE_RULES = ['.genie/genie.db', '.genie/genie.db-wal', '.genie/genie.db-shm', '.genie/launch/'];
+const GITIGNORE_RULES = [
+  '.genie/genie.db',
+  '.genie/genie.db-wal',
+  '.genie/genie.db-shm',
+  '.genie/launch/',
+  '.mcp.json.genie-backup-*',
+];
 
 let dir: string;
 

--- a/src/term-commands/init.ts
+++ b/src/term-commands/init.ts
@@ -72,8 +72,17 @@ const INDEX_SKELETON = `# Plans Index
  * Operational artifacts that must never be committed. The `.genie/launch/`
  * rule is legacy residue protection — nothing writes there since the launch
  * command was removed, but existing kickoff prompts stay ignored.
+ * `.mcp.json.genie-backup-*` is the backup-first copy `genie init` writes
+ * next to a user-owned `.mcp.json` when it retires a legacy `genie mcp`
+ * registration; it is an operational artifact, not project content.
  */
-const GITIGNORE_RULES = ['.genie/genie.db', '.genie/genie.db-wal', '.genie/genie.db-shm', '.genie/launch/'];
+const GITIGNORE_RULES = [
+  '.genie/genie.db',
+  '.genie/genie.db-wal',
+  '.genie/genie.db-shm',
+  '.genie/launch/',
+  '.mcp.json.genie-backup-*',
+];
 
 // ============================================================================
 // Git repo resolution


### PR DESCRIPTION
Two MEDIUM items from the #2817 re-review (M12, M15).

**M12 — the Kimi command orphan check was not in any gate.** `scripts/sync-plugin-skills.ts --check` (plugin skill mirror + `assertKimiCommandsMatchSkills` from #2826) ran only from its own `main()` and unit test. Now `lint:plugin-skills`, wired into `check`, `check:fast`, and `ci.yml` ("Plugin skill mirror + Kimi command orphan check"), and asserted by `release-docs.test.ts`. Passes today (`22 physical skills, byte-identical mirror`).

**M15 — `genie init` dirtied `git status`.** The backup-first retirement of a legacy `genie mcp` entry writes `.mcp.json.genie-backup-<stamp>` next to the user's `.mcp.json`; the scaffolded `.gitignore` now includes `.mcp.json.genie-backup-*` (rule list + rationale comment; `init.test.ts` mirrors the list and its check-ignore loop covers the new rule).

Validation: `bun test src/term-commands/init.test.ts scripts/release-docs.test.ts` → 65 pass; `bun run lint:plugin-skills` OK; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QrkgYMEEhrWTUo5E7Nkjg
