### PR TITLE
ci(commitlint): pin the four #2817 review-wave squash subjects

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -51,9 +51,9 @@ export default {
         'spawn-context-contract#doctor-modes: mode-drift check + tighten-only --fix across all worktrees (#2779)',
         'feat(hooks): retire orchestration-guard, validate-completion, and hook trust (hooks-v2#retire) (#2780)',
       ].includes(message.split('\n')[0]),
-    // Historical exception (2026-08-30, #2817 review-fix wave): four squash
+    // Historical exception (2026-08-30, #2817 review-fix wave): five squash
     // subjects landed on dev over the 100-character gate once GitHub appended
-    // `(#NNNN)` (#2828/#2829/#2837), and one (#2830) has a capitalised
+    // `(#NNNN)` (#2828/#2829/#2837/#2840), and one (#2830) has a capitalised
     // "Orca-mode" subject that trips subject-case. Same posture as above:
     // exact full-subject pins, no rewrite of shared dev history, do not
     // reuse these subjects and do not broaden this to a pattern.
@@ -63,6 +63,7 @@ export default {
         'fix(orca): adapter readback, wait bound, stream faults, version gate, and doctor resilience (#2829)',
         'fix: Orca-mode lifecycle guards + retire the dead `genie mcp` entry in .mcp.json (#2830)',
         'docs(wish): record re-review #1 of #2817, refresh the fix disposition, retire the UI entries (#2837)',
+        'docs(wish): promotion sequence without #2833; record staging-leak follow-up and dogfood evidence (#2840)',
       ].includes(message.split('\n')[0]),
     // Historical exception: four `wish:`-prefixed wish-evolution commits on
     // the release-pipeline-collapse PR branch pre-date the engineering work.

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -51,6 +51,19 @@ export default {
         'spawn-context-contract#doctor-modes: mode-drift check + tighten-only --fix across all worktrees (#2779)',
         'feat(hooks): retire orchestration-guard, validate-completion, and hook trust (hooks-v2#retire) (#2780)',
       ].includes(message.split('\n')[0]),
+    // Historical exception (2026-08-30, #2817 review-fix wave): four squash
+    // subjects landed on dev over the 100-character gate once GitHub appended
+    // `(#NNNN)` (#2828/#2829/#2837), and one (#2830) has a capitalised
+    // "Orca-mode" subject that trips subject-case. Same posture as above:
+    // exact full-subject pins, no rewrite of shared dev history, do not
+    // reuse these subjects and do not broaden this to a pattern.
+    (message: string) =>
+      [
+        'docs(wish): record the #2817 FIX-FIRST review and fix disposition in the dual-mode Orca ledger (#2828)',
+        'fix(orca): adapter readback, wait bound, stream faults, version gate, and doctor resilience (#2829)',
+        'fix: Orca-mode lifecycle guards + retire the dead `genie mcp` entry in .mcp.json (#2830)',
+        'docs(wish): record re-review #1 of #2817, refresh the fix disposition, retire the UI entries (#2837)',
+      ].includes(message.split('\n')[0]),
     // Historical exception: four `wish:`-prefixed wish-evolution commits on
     // the release-pipeline-collapse PR branch pre-date the engineering work.
     // They captured the wish-document drafts (council pivot, reviewer


### PR DESCRIPTION
## Problem

#2817's **Commit Messages** check lints the exact `main..dev` range and fails on four commits already merged to `dev`:

- `header-max-length` (100): #2828 (104), #2829 (101), #2837 (102) — each crossed the limit only because GitHub appended the `(#NNNN)` squash suffix.
- `subject-case`: #2830 — `fix: Orca-mode lifecycle guards …` starts with a capital.

## Change

Add the four exact full subjects to the pinned-exception list in `commitlint.config.ts`, matching every prior exception there (no rewrite of shared `dev` history; exact-subject matches only, never a pattern).

## Validation

`bun x commitlint --config commitlint.config.ts --from origin/main --to origin/dev` → 0 problems across the whole promotion range. `bun run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gGxGgKskzyzr1HRUB6cV3