### PR TITLE
fix(dogfood): record candidate argv independently of the execution adapter

### DIFF
--- a/scripts/validate-live-dogfood-evidence.test.ts
+++ b/scripts/validate-live-dogfood-evidence.test.ts
@@ -244,6 +244,34 @@ function evidence(manifest = validManifest(), doctor: unknown = DOCTOR): string 
   )}\n\`\`\`\n`;
 }
 
+const ADAPTER = '/tmp/dogfood/bin/run-musl-dogfood.sh';
+
+/**
+ * Reshape every stage observation the way an execution adapter records it:
+ * the adapter is the executable, the candidate binary moves into adapterArgv,
+ * and argv stays the candidate's OWN arguments. Only linux-x64-musl runs this
+ * way, which is why the pre-fix binary-prefixed argv escaped every other leg.
+ */
+function adapterShaped(manifest: Record<string, any>): void {
+  for (const stage of manifest.lifecycle.stages) {
+    for (const command of stage.observation.commands) {
+      command.adapterArgv = [command.candidateBinary, ...command.argv];
+      command.executable = ADAPTER;
+      command.executableSha256 = HEX('9');
+    }
+    reprojectStage(stage);
+  }
+}
+
+function reprojectStage(stage: Record<string, any>): void {
+  stage.command = stage.observation.commands
+    .map((entry: Record<string, any>) => [entry.executable, ...(entry.adapterArgv ?? entry.argv)].join(' '))
+    .join(' && ');
+  stage.observationSha256 = createHash('sha256')
+    .update(`${JSON.stringify(stage.observation, null, 2)}\n`)
+    .digest('hex');
+}
+
 function errorsAfter(mutator: (manifest: Record<string, any>) => void): string[] {
   const manifest = validManifest();
   mutator(manifest);
@@ -261,6 +289,39 @@ describe('validate-live-dogfood-evidence schema v2', () => {
       errorsAfter((manifest) => {
         const stage = manifest.lifecycle.stages.find((entry: { id: string }) => entry.id === 'new-thread-sentinel');
         stage.observation.commands[0].argv = ['mcpServer/tool/call', 'genie', 'genie_board'];
+      }).join('\n'),
+    ).toContain('must reject retired MCP evidence');
+  });
+
+  test('accepts adapter-shaped observations and rejects binary-prefixed argv', () => {
+    expect(errorsAfter(adapterShaped)).toEqual([]);
+    // The linux-x64-musl regression: argv carried [<candidate binary>, 'task',
+    // 'list', '--json'], so the standalone assertion could never match.
+    const prefixed = errorsAfter((manifest) => {
+      adapterShaped(manifest);
+      for (const stage of manifest.lifecycle.stages) {
+        for (const command of stage.observation.commands) command.argv = [...command.adapterArgv];
+        reprojectStage(stage);
+      }
+    });
+    for (const index of [5, 6, 7]) {
+      expect(prefixed).toContain(
+        `stages[${index}].standalone must contain standalone task list --json and board --json observations`,
+      );
+    }
+    expect(
+      errorsAfter((manifest) => {
+        adapterShaped(manifest);
+        manifest.lifecycle.stages[0].observation.commands[0].adapterArgv = ['ok', 7];
+        reprojectStage(manifest.lifecycle.stages[0]);
+      }).join('\n'),
+    ).toContain('commands[0].adapterArgv must be a string array');
+    expect(
+      errorsAfter((manifest) => {
+        adapterShaped(manifest);
+        const stage = manifest.lifecycle.stages.find((entry: { id: string }) => entry.id === 'new-thread-sentinel');
+        stage.observation.commands[0].adapterArgv.push('genie_board@mcp');
+        reprojectStage(stage);
       }).join('\n'),
     ).toContain('must reject retired MCP evidence');
   });

--- a/scripts/validate-live-dogfood-evidence.ts
+++ b/scripts/validate-live-dogfood-evidence.ts
@@ -483,6 +483,12 @@ const STAGE_EXPECTATIONS: Record<(typeof REQUIRED_STAGE_IDS)[number], StageExpec
   },
 };
 
+/** The real spawned vector: the adapter's argv when one wrapped the candidate. */
+function spawnArgv(command: JsonRecord): unknown[] {
+  if (Array.isArray(command.adapterArgv)) return command.adapterArgv;
+  return Array.isArray(command.argv) ? command.argv : [];
+}
+
 function validateCapturedCommand(
   errors: string[],
   label: string,
@@ -506,6 +512,15 @@ function validateCapturedCommand(
   if (!Array.isArray(command.argv) || command.argv.some((arg) => typeof arg !== 'string')) {
     errors.push(`${label}.argv must be a string array`);
   }
+  // Optional: present only when an execution adapter (linux-x64-musl Alpine)
+  // spawned the candidate. `argv` stays the candidate's own arguments on every
+  // platform; `adapterArgv` records the real vector handed to `executable`.
+  if (
+    command.adapterArgv !== undefined &&
+    (!Array.isArray(command.adapterArgv) || command.adapterArgv.some((arg) => typeof arg !== 'string'))
+  ) {
+    errors.push(`${label}.adapterArgv must be a string array`);
+  }
   if (typeof command.pid !== 'number' || !Number.isInteger(command.pid) || command.pid <= 0) {
     errors.push(`${label}.pid must be a positive integer`);
   }
@@ -518,7 +533,7 @@ function validateCapturedCommand(
   if (typeof command.stderr !== 'string') errors.push(`${label}.stderr must be a string`);
   return {
     record: command,
-    summary: [String(command.executable), ...(Array.isArray(command.argv) ? command.argv.map(String) : [])].join(' '),
+    summary: [String(command.executable), ...spawnArgv(command).map(String)].join(' '),
     exit: typeof command.exit === 'number' && Number.isInteger(command.exit) ? command.exit : null,
     candidateSha256: command.candidateBinarySha256,
   };
@@ -544,7 +559,8 @@ function validateStandaloneObservation(
   const hasBoard = argv.some((args) => Array.isArray(args) && args.join(' ') === 'board --json');
   if (!hasTask || !hasBoard)
     errors.push(`${label} must contain standalone task list --json and board --json observations`);
-  if (argv.some((args) => Array.isArray(args) && args.some((arg) => String(arg).toLowerCase().includes('mcp')))) {
+  const vectors = commands.flatMap((value) => [value.record.argv, value.record.adapterArgv]);
+  if (vectors.some((args) => Array.isArray(args) && args.some((arg) => String(arg).toLowerCase().includes('mcp')))) {
     errors.push(`${label} must reject retired MCP evidence`);
   }
 }

--- a/tests/support/codex-dogfood-harness.test.ts
+++ b/tests/support/codex-dogfood-harness.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { chmodSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { captureCommand, resolveInvocation } from './codex-dogfood-harness.ts';
+
+const roots: string[] = [];
+
+function fixture(): { root: string; binary: string; adapter: string } {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'dogfood-harness-')));
+  roots.push(root);
+  // Stands in for the authenticated candidate: it echoes the exact argv it was
+  // handed, so the evidence record can be checked against reality.
+  const binary = join(root, 'genie');
+  writeFileSync(binary, '#!/usr/bin/env bash\nprintf \'%s\\n\' "$*"\n');
+  chmodSync(binary, 0o755);
+  // Stands in for scripts/run-musl-dogfood.sh: takes the candidate binary as
+  // its first positional argument and execs it with the remaining argv.
+  const adapter = join(root, 'adapter.sh');
+  writeFileSync(adapter, '#!/usr/bin/env bash\nset -eu\ncandidate=$1\nshift\nexec "$candidate" "$@"\n');
+  chmodSync(adapter, 0o755);
+  return { root, binary, adapter };
+}
+
+afterEach(() => {
+  while (roots.length > 0) rmSync(roots.pop() as string, { recursive: true, force: true });
+});
+
+describe('candidate invocation evidence', () => {
+  test('resolveInvocation keeps argv on the candidate and names the adapter vector separately', () => {
+    expect(resolveInvocation({ binary: '/bin/genie', args: ['board', '--json'] })).toEqual({
+      command: '/bin/genie',
+      argv: ['board', '--json'],
+      spawnArgv: ['board', '--json'],
+    });
+    expect(
+      resolveInvocation({ binary: '/bin/genie', args: ['board', '--json'], executionAdapter: '/bin/adapter' }),
+    ).toEqual({
+      command: '/bin/adapter',
+      argv: ['board', '--json'],
+      adapterArgv: ['/bin/genie', 'board', '--json'],
+      spawnArgv: ['/bin/genie', 'board', '--json'],
+    });
+  });
+
+  test('records the candidate argv unchanged with and without an execution adapter', () => {
+    const { root, binary, adapter } = fixture();
+    const args = ['task', 'list', '--json'];
+    const direct = captureCommand({ root, binary, args, cwd: root, env: { PATH: process.env.PATH ?? '' } });
+    expect(direct.exit).toBe(0);
+    expect(direct.executable).toBe(binary);
+    expect(direct.candidateBinary).toBe(binary);
+    expect(direct.argv).toEqual(args);
+    expect(direct.adapterArgv).toBeUndefined();
+    expect(direct.stdout.trim()).toBe('task list --json');
+
+    const adapted = captureCommand({
+      root,
+      binary,
+      args,
+      cwd: root,
+      env: { PATH: process.env.PATH ?? '' },
+      executionAdapter: adapter,
+    });
+    expect(adapted.exit).toBe(0);
+    // The evidence argv is the candidate's own arguments on BOTH legs: a
+    // linux-x64-musl run must be byte-comparable with every other platform.
+    expect(adapted.argv).toEqual(args);
+    expect(adapted.adapterArgv).toEqual([binary, ...args]);
+    expect(adapted.executable).toBe(adapter);
+    expect(adapted.candidateBinary).toBe(binary);
+    // The candidate really did receive exactly `args` through the adapter.
+    expect(adapted.stdout.trim()).toBe('task list --json');
+  });
+});

--- a/tests/support/codex-dogfood-harness.ts
+++ b/tests/support/codex-dogfood-harness.ts
@@ -183,7 +183,18 @@ interface CapturedCommand {
   executableSha256: string;
   candidateBinary: string | null;
   candidateBinarySha256: string | null;
+  /**
+   * The CANDIDATE's own arguments, never the adapter spawn vector. Evidence
+   * consumers assert on what the genie binary was asked to do, so this stays
+   * identical on every platform whether or not an execution adapter wraps it.
+   */
   argv: string[];
+  /**
+   * Present only when an execution adapter ran the candidate (linux-x64-musl
+   * goes through scripts/run-musl-dogfood.sh): the real argv handed to
+   * `executable`, i.e. [candidateBinary, ...argv].
+   */
+  adapterArgv?: string[];
   pid: number;
   requestedCwd: string;
   cwdIdentity: string;
@@ -776,7 +787,26 @@ function verifyLegacyReleaseProvenance(input: {
   }
 }
 
-function captureCommand(input: {
+/**
+ * Split one candidate invocation into the evidence argv (always the
+ * candidate's own arguments) and the real spawn vector. Without an execution
+ * adapter the two coincide; with one, the adapter takes the candidate binary
+ * as its first positional argument.
+ */
+export function resolveInvocation(input: { binary: string; args: string[]; executionAdapter?: string }): {
+  command: string;
+  argv: string[];
+  adapterArgv?: string[];
+  spawnArgv: string[];
+} {
+  if (input.executionAdapter === undefined) {
+    return { command: input.binary, argv: input.args, spawnArgv: input.args };
+  }
+  const adapterArgv = [input.binary, ...input.args];
+  return { command: input.executionAdapter, argv: input.args, adapterArgv, spawnArgv: adapterArgv };
+}
+
+export function captureCommand(input: {
   root: string;
   binary: string;
   args: string[];
@@ -786,13 +816,12 @@ function captureCommand(input: {
   stdin?: Uint8Array;
   timeoutMs?: number;
 }): CapturedCommand {
-  const command = input.executionAdapter ?? input.binary;
-  const argv = input.executionAdapter === undefined ? input.args : [input.binary, ...input.args];
+  const { command, argv, adapterArgv, spawnArgv } = resolveInvocation(input);
   const env =
     input.executionAdapter === undefined
       ? input.env
       : { ...input.env, DOGFOOD_ROOT: input.root, DOGFOOD_ADAPTER_CWD: realpathSync(input.cwd) };
-  const result = Bun.spawnSync([command, ...argv], {
+  const result = Bun.spawnSync([command, ...spawnArgv], {
     cwd: input.cwd,
     env,
     stdin: input.stdin,
@@ -801,7 +830,7 @@ function captureCommand(input: {
     timeout: input.timeoutMs ?? 120_000,
   });
   if (result.exitedDueToTimeout === true) {
-    throw new Error(`bounded candidate command timed out: ${[command, ...argv].join(' ')}`);
+    throw new Error(`bounded candidate command timed out: ${[command, ...spawnArgv].join(' ')}`);
   }
   const cwdStat = statSync(realpathSync(input.cwd));
   return {
@@ -810,6 +839,7 @@ function captureCommand(input: {
     candidateBinary: realpathSync(input.binary),
     candidateBinarySha256: sha256File(realpathSync(input.binary)),
     argv,
+    ...(adapterArgv === undefined ? {} : { adapterArgv }),
     pid: result.pid,
     requestedCwd: realpathSync(input.cwd),
     cwdIdentity: `${cwdStat.dev}:${cwdStat.ino}`,
@@ -826,11 +856,12 @@ function capturePtySetup(input: {
   env: Record<string, string>;
   executionAdapter?: string;
 }): CapturedCommand {
-  const command = input.executionAdapter ?? input.binary;
-  const commandArgs =
-    input.executionAdapter === undefined
-      ? [input.binary, 'setup', '--codex']
-      : [input.executionAdapter, input.binary, 'setup', '--codex'];
+  const { command, argv, adapterArgv, spawnArgv } = resolveInvocation({
+    binary: input.binary,
+    args: ['setup', '--codex'],
+    executionAdapter: input.executionAdapter,
+  });
+  const commandArgs = [command, ...spawnArgv];
   const env = {
     ...input.env,
     CI: '',
@@ -879,7 +910,8 @@ function capturePtySetup(input: {
     executableSha256: sha256File(realpathSync(command)),
     candidateBinary: realpathSync(input.binary),
     candidateBinarySha256: sha256File(realpathSync(input.binary)),
-    argv: commandArgs.slice(1),
+    argv,
+    ...(adapterArgv === undefined ? {} : { adapterArgv }),
     pid: result.pid,
     requestedCwd: realpathSync(input.cwd),
     cwdIdentity: `${cwdStat.dev}:${cwdStat.ino}`,
@@ -898,7 +930,7 @@ function requireExit(observation: CapturedCommand, expected: number, label: stri
     throw new Error(
       `${label} exited ${observation.exit}, expected ${expected}\n` +
         `  exe: ${observation.executable}\n` +
-        `  argv: ${JSON.stringify(observation.argv)}\n` +
+        `  argv: ${JSON.stringify(observation.adapterArgv ?? observation.argv)}\n` +
         `  stderr[${observation.stderr.length}B]: ${observation.stderr.trim() || '<empty>'}\n` +
         `  stdout[${observation.stdout.length}B]: ${observation.stdout.trim() || '<empty>'}`,
     );
@@ -1119,7 +1151,9 @@ function stage(
   const observation = { schemaVersion: 1 as const, commands };
   return {
     id,
-    command: commands.map((command) => [command.executable, ...command.argv].join(' ')).join(' && '),
+    command: commands
+      .map((command) => [command.executable, ...(command.adapterArgv ?? command.argv)].join(' '))
+      .join(' && '),
     ...projection,
     observationPath: `observations/${id}.json`,
     observationSha256: sha256Bytes(Buffer.from(serializeStageObservation(observation))),


### PR DESCRIPTION
## Problem

Stable release publish fails on **linux-x64-musl only**. Run [33291504929](https://github.com/automagik-dev/genie/actions/runs/33291504929), job `publish / Codex standalone task/board dogfood / linux-x64-musl`:

```
codex-dogfood-entry: FAIL — generated evidence failed validation:
stages[5].standalone must contain standalone task list --json and board --json observations
stages[6].standalone ... stages[7].standalone ...
```

glibc / arm64 / darwin all pass.

## Root cause

musl is the only leg that runs the candidate through an execution adapter (`scripts/run-musl-dogfood.sh`, digest-pinned Alpine in Docker). `captureCommand` in `tests/support/codex-dogfood-harness.ts` folded the adapter's spawn vector into the recorded evidence `argv`:

```ts
const argv = input.executionAdapter === undefined ? input.args : [input.binary, ...input.args];
```

So musl recorded `['<genie binary>', 'task', 'list', '--json']` where every other platform recorded `['task', 'list', '--json']`, and `validateStandaloneObservation` in `scripts/validate-live-dogfood-evidence.ts` requires `argv.join(' ')` to be exactly `task list --json` / `board --json`.

`capturePtySetup` had the identical fold (`argv: commandArgs.slice(1)`, which under an adapter leaves the binary at index 0).

## Fix

Evidence `argv` is now **always the candidate's own arguments**, on every platform. When an adapter wraps the run, the real spawned vector is recorded separately as `adapterArgv: [candidateBinary, ...argv]`; `executable` stays the adapter path and `candidateBinary` the genie binary, both unchanged.

- New shared `resolveInvocation()` helper splits `{ command, argv, adapterArgv, spawnArgv }`; both `captureCommand` and `capturePtySetup` go through it.
- Anything that reconstructs a command line — the `stage()` `command` projection, the `requireExit` diagnostic, and the validator's `summary` — uses `adapterArgv ?? argv`, so the human-readable line remains the true spawned command.
- Validator: accepts the optional `adapterArgv` (rejects a non-string-array), keeps the standalone assertion on `argv`, and extends the retired-MCP rejection to cover **both** vectors. There is no strict key allowlist for command records, so no allowlist change was needed.

Evidence stays honest (the real docker invocation is still recorded, in its own field) and the validator stays strict.

## Tests

- `scripts/validate-live-dogfood-evidence.test.ts` — new case reshapes every stage observation into adapter form (adapter as `executable`, `adapterArgv = [binary, ...argv]`, `argv` = candidate args) and asserts it validates clean; the pre-fix binary-prefixed shape still fails with the exact production message for stages 5/6/7; a non-string `adapterArgv` is rejected; an MCP token smuggled into `adapterArgv` is rejected.
- `tests/support/codex-dogfood-harness.test.ts` (new) — unit-covers `resolveInvocation`, then really spawns through a tiny fake adapter script (`exec "$candidate" "$@"`) and proves `argv == candidate args`, `adapterArgv == [binary, ...args]`, `executable == adapter`, `candidateBinary == binary`, and that the candidate's echoed argv matches.

```
bun test scripts/validate-live-dogfood-evidence.test.ts scripts/release-docs.test.ts \
  scripts/run-musl-dogfood.test.ts scripts/candidate-dogfood-matrix.test.ts \
  scripts/validate-dogfood-matrix-evidence.test.ts tests/support/codex-dogfood-harness.test.ts
# 70 pass, 0 fail, 967 expect() calls
```

Gates: `bun run typecheck` ✅ · `bun run lint` ✅ (3 pre-existing `src/` complexity warnings, untouched) · `bun run dead-code` ✅ · `bun run lint:complexity-budget` ✅ (`OK: budget intact`). Pre-push hooks ran clean.

## Rollout note

The release-publish workflow checks out this harness and validator from **`main`** (at `github.sha`), so this fix only takes effect after the next `dev` → `main` promotion. **Until that promotion lands, every stable release will keep failing at the musl dogfood gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gGxGgKskzyzr1HRUB6cV3
