### PR TITLE
fix(doctor): read the JSON-quoted council.js LENS_ROOT stamp

### DIFF
--- a/src/genie-commands/doctor.test.ts
+++ b/src/genie-commands/doctor.test.ts
@@ -1010,11 +1010,16 @@ describe('checkAgentSync', () => {
     );
   }
 
-  function stampCouncil(lensRoot: string): void {
+  // Mirrors agent-sync `stampWorkflowTemplate`: the placeholder is replaced with
+  // `JSON.stringify(pluginRoot)`, i.e. a DOUBLE-quoted literal. Keep this in
+  // lockstep with the stamper — a single-quoted fixture once hid a doctor regex
+  // that reported every real stamp as `stale (LENS_ROOT unreadable)`.
+  function stampCouncil(lensRoot: string, quote: 'json' | 'legacy-single' = 'json'): void {
     mkdirSync(join(claudeDir, 'workflows'), { recursive: true });
+    const literal = quote === 'json' ? JSON.stringify(lensRoot) : `'${lensRoot}'`;
     writeFileSync(
       join(claudeDir, 'workflows', 'council.js'),
-      `export const meta = { name: 'council' };\nconst LENS_ROOT = '${lensRoot}';\n`,
+      `export const meta = { name: 'council' };\nconst LENS_ROOT = ${literal};\n`,
       'utf8',
     );
   }
@@ -1168,6 +1173,24 @@ describe('checkAgentSync', () => {
     expect(claude?.detail).toContain('1 stale');
     expect(claude?.detail).toContain('council.js stale');
     expect(claude?.suggestion).toContain('genie update');
+  });
+
+  test('legacy single-quoted council stamp for the current root reads as current, not unreadable', () => {
+    seedManaged(join(pluginRoot, 'skills', 'wish'), join(claudeDir, 'skills', 'wish'));
+    stampCouncil(pluginRoot, 'legacy-single');
+
+    const claude = find(checkAgentSync(paths()), 'agent sync: claude');
+    expect(claude?.detail).toContain('council.js current');
+    expect(claude?.detail).not.toContain('unreadable');
+  });
+
+  test('wrong-root council stamp names the stamped root instead of unreadable', () => {
+    seedManaged(join(pluginRoot, 'skills', 'wish'), join(claudeDir, 'skills', 'wish'));
+    stampCouncil('/old/plugin/root');
+
+    const claude = find(checkAgentSync(paths()), 'agent sync: claude');
+    expect(claude?.status).toBe('warn');
+    expect(claude?.detail).toContain('council.js stale (LENS_ROOT /old/plugin/root)');
   });
 
   test('unmanaged skill dirs are never counted (genie only speaks for what it shipped)', () => {

--- a/src/genie-commands/doctor.ts
+++ b/src/genie-commands/doctor.ts
@@ -1188,6 +1188,27 @@ function skillsFreshness(summary: ManagedSkillsSummary): { detail: string; stale
   return { detail: `${summary.current}/${summary.sourceCount} source skills current${staleNote}`, stale };
 }
 
+/**
+ * Extract the stamped `LENS_ROOT` literal from a council.js body. The stamper
+ * (`agent-sync` `stampWorkflowTemplate`) writes `JSON.stringify(pluginRoot)` —
+ * a double-quoted JSON string — so that form is authoritative; the historical
+ * single-quoted spelling stays readable so older stamps classify as stale with a
+ * root instead of `unreadable`.
+ */
+function readStampedLensRoot(content: string): string | null {
+  const json = content.match(/const LENS_ROOT = ("(?:[^"\\]|\\.)*");/);
+  if (json) {
+    try {
+      const parsed: unknown = JSON.parse(json[1]);
+      return typeof parsed === 'string' ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+  const legacy = content.match(/const LENS_ROOT = '([^']*)';?/);
+  return legacy ? legacy[1] : null;
+}
+
 /** Whether `<claudeDir>/workflows/council.js` is stamped for the current stable source root. */
 function councilStampState(councilPath: string, pluginRoot: string): { stale: boolean; label: string } {
   let content: string;
@@ -1196,8 +1217,7 @@ function councilStampState(councilPath: string, pluginRoot: string): { stale: bo
   } catch {
     return { stale: true, label: 'absent' };
   }
-  const match = content.match(/const LENS_ROOT = '([^']*)'/);
-  const root = match ? match[1] : null;
+  const root = readStampedLensRoot(content);
   if (root === pluginRoot) return { stale: false, label: 'current' };
   return { stale: true, label: `stale (LENS_ROOT ${root ?? 'unreadable'})` };
 }


### PR DESCRIPTION
## What

`genie doctor` reported `agent sync: claude — … council.js stale (LENS_ROOT unreadable)` on a host running the fresh stable **v5.260830.16**, and its own remedy (`genie update`) could never clear it.

**Root cause:** `agent-sync`'s `stampWorkflowTemplate` writes the stamp as `JSON.stringify(pluginRoot)` → `const LENS_ROOT = "/home/…/plugins/genie";` (double quotes). Doctor's `councilStampState` regex only matched `const LENS_ROOT = '…'` (single quotes), so **every correctly stamped council.js** was classified as unreadable/stale. The doctor test never caught it because its fixture hand-wrote the single-quoted form the stamper never produces.

## Change

- `doctor.ts`: new `readStampedLensRoot()` — parses the JSON (double-quoted) form first, falls back to the legacy single-quoted form so historical stamps report their actual root instead of `unreadable`.
- `doctor.test.ts`: the `stampCouncil` fixture now stamps exactly like the stamper (`JSON.stringify`), with an opt-in `legacy-single` mode; two new tests cover the legacy-current case and the wrong-root label.

## Evidence

- `bun test src/genie-commands/doctor.test.ts` → 145 pass / 0 fail
- `bun run typecheck` → clean
- Real host (stable 5.260830.16, stamp from 2026-08-15, digest `managed-clean`): before → `council.js stale (LENS_ROOT unreadable)`; with this patch (`bun src/genie.ts doctor`) → `council.js current`.
- biome: only the two pre-existing `noExcessiveCognitiveComplexity` hotspots in doctor.ts (`codexPluginSurfaceChecks` 27, `doctorCommand` 37) — untouched by this PR.

Found while dogfooding the v5.260830.16 stable release (run 33294952654).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gGxGgKskzyzr1HRUB6cV3
