### PR TITLE
refactor(retirement): rehome the surviving primitives and harden retirement (skills-everywhere-b G2)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -55,6 +55,8 @@
       ".claude",
       "plugins/genie/scripts",
       "plugins/genie/workflows",
+      "scripts/validate-wish.ts",
+      "scripts/wish-template-text.d.ts",
       ".docs-vendor",
       "docs",
       ".well-known",

--- a/scripts/validate-wish.ts
+++ b/scripts/validate-wish.ts
@@ -1,0 +1,503 @@
+#!/usr/bin/env node
+/**
+ * Validate a wish document against the canonical template before writing.
+ * Used by the PreToolUse/PostToolUse hooks to catch broken wish structure.
+ *
+ * Template-derived, not vibecode: every structural rule is parsed from the
+ * canonical template fixture (skills/wish/templates/wish-template.md),
+ * embedded in this bundle at build time by esbuild's text loader. When the
+ * template changes, the next `bun scripts/hook-bundle-parity.ts --write`
+ * regen bakes the new shapes in, and the bundle-parity gate fails CI until
+ * that regen lands — so template drift cannot silently wedge wish writes.
+ *
+ * The read is bounded and refuses symlinks (readBoundedWishFile, the same
+ * primitive the board and session-context use) with a 256 KiB size cap.
+ *
+ * Pure Node.js - no Bun dependency.
+ *
+ * Usage:
+ *   node validate-wish.cjs --file <path-to-wish.md>
+ *   node validate-wish.cjs --help
+ *
+ * Hook integration: receives JSON on stdin from the PreToolUse/PostToolUse
+ * event. PreToolUse validates the PROPOSED content (Write tool_input.content,
+ * or the simulated result of an Edit), so fixing a broken doc is never
+ * blocked — only writes whose RESULT is broken are.
+ *
+ * Exit codes:
+ *   0  Validation passed (or not a wish file, or a new wish being created)
+ *   1  --file mode: validation failed (template structure violated, or a
+ *      symlink/size-cap refusal) — the documented CLI contract
+ *   2  Hook mode (stdin JSON): validation failed. Claude Code only treats
+ *      command-hook exit 2 as a BLOCKING failure (dispatch-runtime.cjs
+ *      "Claude Code only treats command-hook exit 2 as a blocking failure"),
+ *      so hook-driven paths exit 2 — this is what keeps the write check
+ *      blocking. PostToolUse exit 2 is correct: its stderr feeds back to the
+ *      agent after the write already happened.
+ */
+
+/// <reference path="./wish-template-text.d.ts" />
+import { lstatSync, readFileSync } from 'node:fs';
+import { parseArgs as parseArgsUtil } from 'node:util';
+import { readBoundedWishFile, extractLegacyStatusValue, extractStatusCell } from '../src/lib/wish-status.js';
+import wishTemplate from '../skills/wish/templates/wish-template.md' with { type: 'text' };
+
+/** The bounded-read size cap for wish documents (matches the board's budget). */
+export const WISH_FILE_SIZE_CAP = 256 * 1024;
+
+export interface WishValidationIssue {
+  line: number;
+  message: string;
+}
+
+export interface WishValidationResult {
+  passed: boolean;
+  issues: WishValidationIssue[];
+}
+
+export type WishFileRead =
+  | { kind: 'content'; content: string }
+  | { kind: 'missing' }
+  | { kind: 'error'; reason: string };
+
+export interface TemplateContract {
+  sections: string[];
+  subsections: string[];
+  groupHeadingSource: string;
+  groupHeadingPattern: RegExp;
+  checkboxPattern: RegExp;
+  titlePattern: RegExp;
+}
+
+/**
+ * Parse the structural contract out of the canonical template fixture.
+ * Everything the validator requires must come from here, so the template is
+ * the single source of truth and this file carries no free-standing shapes.
+ */
+export function parseWishTemplateContract(template: string): TemplateContract {
+  const lines = template.split('\n');
+  const sections: string[] = [];
+  const subsections: string[] = [];
+  let groupHeadingSource = '';
+  let titlePattern: RegExp | null = null;
+  let inScope = false;
+  let inFence = false;
+  for (const line of lines) {
+    if (titlePattern === null) {
+      const h1 = /^#\s+(.+?)\s*$/.exec(line);
+      if (h1) {
+        // "# Wish: <title>" generalises to any "# Wish:"-prefixed title.
+        const prefix = /^Wish:/.exec(h1[1].trim());
+        if (prefix) titlePattern = /^#\s+Wish:/m;
+        continue;
+      }
+    }
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const h2 = /^##\s+(.+?)\s*$/.exec(line);
+    if (h2) {
+      sections.push(h2[1].trim());
+      inScope = h2[1].trim() === 'Scope';
+      continue;
+    }
+    const h3 = /^###\s+(.+?)\s*$/.exec(line);
+    if (h3) {
+      const heading = h3[1].trim();
+      const groupHeading = /^Group\s+(\S+):/.exec(heading);
+      if (groupHeading) {
+        if (groupHeadingSource === '') groupHeadingSource = `Group ${groupHeading[1]}:`;
+        continue;
+      }
+      // Only the subsections the template nests under ## Scope (IN/OUT) are
+      // part of the structural contract.
+      if (inScope) subsections.push(heading);
+      continue;
+    }
+  }
+  if (sections.length === 0 || groupHeadingSource === '' || titlePattern === null) {
+    throw new Error('wish template fixture must define ## sections, a "# Wish:" title, and a "### Group N:" heading');
+  }
+  // The template's group heading ("### Group 1: <title>") generalises to any
+  // non-space group identifier: digit groups (the template's own form) and
+  // named groups both occur in current wishes.
+  const groupHeadingPattern = new RegExp(`^###\\s+Group\\s+\\S+:`);
+  const checkboxPattern = /^-\s+\[[ xX]\]/;
+  return { sections, subsections, groupHeadingSource, groupHeadingPattern, checkboxPattern, titlePattern };
+}
+
+const CONTRACT = parseWishTemplateContract(wishTemplate);
+
+/**
+ * The date the current template form shipped — the template's most recent
+ * revision (b0e77cd15, 2026-07-29). Wishes dated on or after it are held to
+ * the full template-derived contract; earlier documents are legacy formats
+ * and are tolerated. Measured 2026-08-13: every current wish in both corpora
+ * dated on/after this boundary conforms (24 docs), so the gate can arm over
+ * the corpus as it stands.
+ */
+export const TEMPLATE_CONTRACT_DATE = '2026-07-29';
+
+/** Terminal statuses — a doc in one of these is completed. */
+const COMPLETED_STATUSES = new Set(['SHIPPED', 'DONE', 'EXECUTED']);
+
+/** Normalise a status cell the way the corpus linter does: first token, annotations stripped. */
+export function normaliseStatus(raw: string | null | undefined): string | null {
+  if (raw === null || raw === undefined) return null;
+  const token = raw.split(/\s+[—-]\s+/)[0].replace(/\s+\([^)]*\)\s*$/, '').trim();
+  return token === '' ? null : token;
+}
+
+/**
+ * Where a wish's status lives, in precedence order: the canonical metadata
+ * table row (template-derived), then the legacy `**Status:** ...` line.
+ */
+export function readWishStatus(content: string): string | null {
+  const cell = extractStatusCell(content, 'row-end');
+  if (cell !== null) return normaliseStatus(cell);
+  return normaliseStatus(extractLegacyStatusValue(content));
+}
+
+/** A wish's Date, in the same precedence order: template table row, then the legacy `**Date:**` line. */
+export function readWishDate(content: string): string | null {
+  const row = /^\|\s*\*\*Date\*\*\s*\|\s*(\S*?)\s*\|\s*$/m.exec(content);
+  if (row) return row[1].trim();
+  const legacy = /^\*\*Date:\*\*(\s*.*)$/m.exec(content);
+  if (legacy) return legacy[1].trim();
+  return null;
+}
+
+/**
+ * Legacy tolerance is date-gated, the same shape as the corpus linter's
+ * lifecycle thresholds: a wish dated before the current template form is a
+ * legacy format and is validated leniently instead of being rewritten. A
+ * missing or invalid date cannot bypass the contract — it is treated as new.
+ */
+export function isLegacyWish(content: string): boolean {
+  const date = readWishDate(content);
+  if (date === null || !/^\d{4}-\d{2}-\d{2}$/.test(date)) return false;
+  return date < TEMPLATE_CONTRACT_DATE;
+}
+
+interface SectionRange {
+  start: number;
+  end: number;
+}
+
+function sectionRange(lines: string[], headingIndex: number): SectionRange {
+  const end = lines.findIndex((line, index) => index > headingIndex && /^##\s+/.test(line));
+  return { start: headingIndex + 1, end: end < 0 ? lines.length : end };
+}
+
+function findHeading(lines: string[], pattern: RegExp): number {
+  return lines.findIndex((line) => pattern.test(line));
+}
+
+function checkCheckboxes(lines: string[], successHeading: number, contract: TemplateContract): WishValidationIssue[] {
+  const issues: WishValidationIssue[] = [];
+  const { start, end } = sectionRange(lines, successHeading);
+  const bodyLines = lines.slice(start, end);
+  if (!bodyLines.some((line) => contract.checkboxPattern.test(line))) {
+    issues.push({
+      line: successHeading + 2,
+      message: 'Success Criteria should have checkbox items (- [ ] or - [x])',
+    });
+  }
+  return issues;
+}
+
+function checkGroupSections(lines: string[], execHeading: number, contract: TemplateContract): WishValidationIssue[] {
+  const issues: WishValidationIssue[] = [];
+  const { start, end } = sectionRange(lines, execHeading);
+  const groupLines = lines
+    .slice(start, end)
+    .map((line, offset) => ({ line, index: start + offset }))
+    .filter((entry) => contract.groupHeadingPattern.test(entry.line));
+  if (groupLines.length === 0) {
+    issues.push({
+      line: execHeading + 2,
+      message: `Execution Groups must contain at least one group heading matching the template ("${contract.groupHeadingSource}", e.g. "### Group 1:")`,
+    });
+    return issues;
+  }
+  for (let i = 0; i < groupLines.length; i++) {
+    const groupStart = groupLines[i].index;
+    const groupEnd = i + 1 < groupLines.length ? groupLines[i + 1].index : end;
+    const body = lines.slice(groupStart, groupEnd).join('\n');
+    const line = groupStart + 1;
+    if (!body.includes('**Acceptance Criteria:**')) {
+      issues.push({ line, message: 'execution group is missing its **Acceptance Criteria:** section' });
+    }
+    if (!body.includes('**Validation:**')) {
+      issues.push({ line, message: 'execution group is missing its **Validation:** command section' });
+    }
+  }
+  return issues;
+}
+
+function checkOutScope(lines: string[], outHeading: number): WishValidationIssue[] {
+  const issues: WishValidationIssue[] = [];
+  const { start, end } = sectionRange(lines, outHeading);
+  const bullets = lines.slice(start, end).filter((line) => /^\s*-\s+\S/.test(line));
+  if (bullets.length === 0) {
+    issues.push({ line: outHeading + 2, message: 'OUT scope should not be empty - add explicit exclusions' });
+  }
+  return issues;
+}
+
+/**
+ * The template-derived structural check. Wishes dated on/after the current
+ * template form are held to the full template contract; legacy documents are
+ * tolerated with a minimal wish signature, so the historical corpus passes
+ * without being rewritten.
+ */
+export function validateWish(content: string): WishValidationResult {
+  const issues: WishValidationIssue[] = [];
+  if (isLegacyWish(content)) {
+    // Legacy formats tolerated: a recorded Status is the whole signature.
+    if (readWishStatus(content) === null) {
+      issues.push({ line: 1, message: 'wish document must record a Status (metadata table row or **Status:** line)' });
+    }
+    return { passed: issues.length === 0, issues };
+  }
+
+  const lines = content.split('\n');
+  const status = readWishStatus(content);
+  const completed = status !== null && COMPLETED_STATUSES.has(status);
+
+  if (status === null) {
+    issues.push({ line: 1, message: 'wish document must record a Status (metadata table row or **Status:** line)' });
+  }
+  if (!CONTRACT.titlePattern.test(content)) {
+    issues.push({ line: 1, message: 'Missing required section: # Wish: title' });
+  }
+
+  for (const section of CONTRACT.sections) {
+    if (!new RegExp(`^##\\s+${escapeRegExp(section)}\\s*$`, 'm').test(content)) {
+      issues.push({ line: 1, message: `Missing required section: ## ${section}` });
+    }
+  }
+  for (const subsection of CONTRACT.subsections) {
+    if (!new RegExp(`^###\\s+${escapeRegExp(subsection)}\\s*$`, 'm').test(content)) {
+      issues.push({ line: 1, message: `Missing required section: ### ${subsection}` });
+    }
+  }
+
+  const outHeading = findHeading(lines, /^###\s+OUT\s*$/i);
+  if (outHeading >= 0) issues.push(...checkOutScope(lines, outHeading));
+
+  const execHeading = findHeading(lines, /^##\s+Execution Groups\s*$/i);
+  if (execHeading >= 0) issues.push(...checkGroupSections(lines, execHeading, CONTRACT));
+
+  const successHeading = findHeading(lines, /^##\s+Success Criteria\s*$/i);
+  if (successHeading >= 0 && !completed) issues.push(...checkCheckboxes(lines, successHeading, CONTRACT));
+
+  return { passed: issues.length === 0, issues };
+}
+
+function escapeRegExp(source: string): string {
+  return source.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Read a wish file under the safety contract: refuse symlinks and files over
+ * the size cap with a named error, distinguish a missing file (a new wish
+ * being created) so the caller can skip validation.
+ */
+export function readWishFile(path: string): WishFileRead {
+  let stats;
+  try {
+    // lstat (not stat) so a symlink is seen as itself and rejected.
+    stats = lstatSync(path);
+  } catch (error) {
+    // Only a genuinely absent path is "missing" (a new wish being created).
+    // Every other stat failure — EACCES, ELOOP, I/O errors — is a refusal, so
+    // the blocking check cannot fail open on an unreadable wish path.
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return { kind: 'missing' };
+    return { kind: 'error', reason: `unable to stat wish file (${code ?? 'unknown error'})` };
+  }
+  if (stats.isSymbolicLink()) {
+    return { kind: 'error', reason: 'refusing to read a wish file that is a symbolic link' };
+  }
+  if (!stats.isFile()) {
+    return { kind: 'error', reason: 'wish path is not a regular file' };
+  }
+  if (stats.size > WISH_FILE_SIZE_CAP) {
+    return { kind: 'error', reason: `wish file exceeds the ${WISH_FILE_SIZE_CAP}-byte size cap` };
+  }
+  const content = readBoundedWishFile(path, WISH_FILE_SIZE_CAP);
+  if (content === null) {
+    return { kind: 'error', reason: 'unable to read wish file' };
+  }
+  return { kind: 'content', content };
+}
+
+export interface HookInput {
+  eventName: string | null;
+  filePath: string | null;
+  proposedContent: string | null | undefined;
+  editOldString: string | null | undefined;
+  editNewString: string | null | undefined;
+  replaceAll: boolean | null | undefined;
+}
+
+/** Parse the hook event JSON from stdin; null when stdin is not hook JSON. */
+export function parseHookInput(raw: string): HookInput | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return null;
+  const input = parsed as Record<string, unknown>;
+  const toolInput = (input.tool_input ?? {}) as Record<string, unknown>;
+  const filePath = typeof toolInput.file_path === 'string' ? toolInput.file_path : null;
+  if (filePath === null) return null;
+  return {
+    eventName: typeof input.hook_event_name === 'string' ? input.hook_event_name : null,
+    filePath,
+    proposedContent: typeof toolInput.content === 'string' ? toolInput.content : undefined,
+    editOldString: typeof toolInput.old_string === 'string' ? toolInput.old_string : undefined,
+    editNewString: typeof toolInput.new_string === 'string' ? toolInput.new_string : undefined,
+    replaceAll: typeof toolInput.replace_all === 'boolean' ? toolInput.replace_all : undefined,
+  };
+}
+
+/** The content the hook should validate for a PreToolUse event. */
+export function proposedWishContent(current: string, hook: HookInput): string | null {
+  if (hook.proposedContent !== undefined && hook.proposedContent !== null) return hook.proposedContent;
+  if (hook.editOldString !== undefined && hook.editOldString !== null && hook.editNewString !== undefined && hook.editNewString !== null) {
+    if (hook.replaceAll === true) {
+      return current.split(hook.editOldString).join(hook.editNewString);
+    }
+    return current.replace(hook.editOldString, hook.editNewString);
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+
+interface CliValues {
+  file?: string;
+  help?: boolean;
+}
+
+function parseCliArgs(argv: string[]): CliValues {
+  let values: Record<string, unknown> = {};
+  try {
+    values = parseArgsUtil({
+      args: argv,
+      options: {
+        file: { type: 'string', short: 'f' },
+        help: { type: 'boolean', short: 'h' },
+      },
+      strict: false, // allow unknown flags from hook runners
+    }).values;
+  } catch {
+    const fallback: Record<string, unknown> = {};
+    for (let i = 0; i < argv.length; i++) {
+      if ((argv[i] === '--file' || argv[i] === '-f') && argv[i + 1]) fallback.file = argv[++i];
+      else if (argv[i] === '--help' || argv[i] === '-h') fallback.help = true;
+    }
+    values = fallback;
+  }
+  return { file: typeof values.file === 'string' ? values.file : undefined, help: values.help === true };
+}
+
+function printHelp(): void {
+  console.log(`
+validate-wish - Validate wish document structure against the canonical template
+
+Usage:
+  node validate-wish.cjs --file <path-to-wish.md>
+  node validate-wish.cjs --help
+
+As a PreToolUse/PostToolUse hook, receives JSON on stdin with
+hook_event_name and tool_input.file_path.
+
+Options:
+  -f, --file   Path to wish document to validate
+  -h, --help   Show this help message
+
+Exit codes:
+  0  Validation passed (or not a wish file, or a new wish being created)
+  1  --file mode: validation failed (template structure violated, symlink or size cap)
+  2  Hook mode (stdin JSON): validation failed — command-hook exit 2 is the blocking failure
+`);
+}
+
+function isWishPath(filePath: string): boolean {
+  return filePath.includes('.genie/wishes/') && filePath.endsWith('.md');
+}
+
+function report(result: WishValidationResult, failureExit: number): number {
+  if (result.passed) {
+    console.error('\u2713 Wish document validation passed');
+    return 0;
+  }
+  console.error('\u26A0 Wish document validation issues:');
+  for (const issue of result.issues) {
+    console.error(`  - line ${issue.line}: ${issue.message}`);
+  }
+  return failureExit;
+}
+
+function main(): number {
+  const argv = process.argv.slice(2);
+  const cli = parseCliArgs(argv);
+  if (cli.help) {
+    printHelp();
+    return 0;
+  }
+
+  let hook: HookInput | null = null;
+  if (cli.file === undefined) {
+    try {
+      const stdinData = readFileSync(0, 'utf-8');
+      hook = parseHookInput(stdinData);
+    } catch {
+      // stdin unavailable or not hook JSON - pass silently.
+    }
+  }
+
+  const filePath = cli.file ?? hook?.filePath ?? null;
+  if (!filePath) return 0; // Not a Write/Edit hook event; pass.
+  if (!isWishPath(filePath)) return 0;
+
+  // Hook runners block on exit 2; the --file CLI contract is exit 1.
+  const hookDriven = hook !== null;
+  const failureExit = hookDriven ? 2 : 1;
+
+  const read = readWishFile(filePath);
+  if (read.kind === 'missing') {
+    // A wish being created (or deleted) — nothing to validate.
+    console.error('Wish file not found, skipping validation (new wish)');
+    return 0;
+  }
+  if (read.kind === 'error') {
+    console.error(`\u26A0 ${read.reason}: ${filePath}`);
+    return failureExit;
+  }
+
+  let content = read.content;
+  if (hook !== null && hook.eventName === 'PreToolUse') {
+    const proposed = proposedWishContent(read.content, hook);
+    if (proposed !== null) content = proposed;
+  }
+  return report(validateWish(content), failureExit);
+}
+
+// The .cjs bundle is required by tests and by the lint; only run the CLI when
+// this module is the invoked entry point (argv[1] names the script itself).
+const invokedScript = process.argv[1] ?? '';
+const scriptName = invokedScript.split(/[\\/]/).pop() ?? '';
+if (scriptName === 'validate-wish.cjs' || scriptName === 'validate-wish.ts') {
+  process.exit(main());
+}

--- a/scripts/wish-template-text.d.ts
+++ b/scripts/wish-template-text.d.ts
@@ -1,0 +1,4 @@
+declare module '*.md' {
+  const content: string;
+  export default content;
+}

--- a/scripts/wishes-lint.ts
+++ b/scripts/wishes-lint.ts
@@ -9,9 +9,14 @@
 
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { basename, dirname, join, relative, resolve } from 'node:path';
-import { validateWish } from '../plugins/genie/scripts/src/validate-wish.js';
 import { designReviewViolations } from '../skills/brainstorm/references/design-review-evidence.mjs';
 import { WISH_SLUG_PATTERN, WISH_SLUG_SOURCE } from '../src/lib/wish-status.js';
+// Maintained verbatim mirror of `plugins/genie/scripts/src/validate-wish.ts`
+// (that tree is deleted by wish `skills-everywhere-b` Group 4). The two copies
+// differ only in the two relative import specifiers the depth change forces; the
+// mirror is biome-ignored exactly as `plugins/genie/scripts` is, so the parity
+// stays a byte fact rather than a formatting negotiation.
+import { validateWish } from './validate-wish.js';
 
 const ROOT = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
 const DEFAULT_WISHES_DIR = join(ROOT, '.genie/wishes');

--- a/src/genie-commands/__tests__/update.test.ts
+++ b/src/genie-commands/__tests__/update.test.ts
@@ -4397,6 +4397,7 @@ describe('runManualUpdateConvergence — plugin-era retirement runs last, behind
       'codex-plugin-cache',
       'codex-plugin-registration',
       'codex-role-agent',
+      'codex-role-agent-inventory',
       'hermes-plugin-link',
       'hermes-skills-external-dir',
       'pi-extension-link',

--- a/src/lib/agent-sync.test.ts
+++ b/src/lib/agent-sync.test.ts
@@ -1944,69 +1944,6 @@ describe('partial report preservation on late failure', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Digest properties
-// ---------------------------------------------------------------------------
-
-describe('computeDirDigest', () => {
-  test('is stable regardless of directory entry creation order', () => {
-    const dirA = join(fixture.root, 'digest-a');
-    writeFile(join(dirA, 'b.md'), 'B');
-    writeFile(join(dirA, 'a.md'), 'A');
-    writeFile(join(dirA, 'nested', 'c.md'), 'C');
-
-    const dirB = join(fixture.root, 'digest-b');
-    writeFile(join(dirB, 'nested', 'c.md'), 'C');
-    writeFile(join(dirB, 'a.md'), 'A');
-    writeFile(join(dirB, 'b.md'), 'B');
-
-    expect(computeDirDigest(dirA)).toBe(computeDirDigest(dirB));
-  });
-
-  test('excludes the manifest so a manifest does not change the digest', () => {
-    const dir = join(fixture.root, 'digest-manifest');
-    writeFile(join(dir, 'SKILL.md'), 'body');
-    const before = computeDirDigest(dir);
-    writeFile(join(dir, MANIFEST_NAME), '{"managedBy":"genie-agent-sync","digest":"x"}');
-    expect(computeDirDigest(dir)).toBe(before);
-  });
-
-  test('changes when file content changes', () => {
-    const dir = join(fixture.root, 'digest-content');
-    writeFile(join(dir, 'SKILL.md'), 'one');
-    const before = computeDirDigest(dir);
-    writeFile(join(dir, 'SKILL.md'), 'two');
-    expect(computeDirDigest(dir)).not.toBe(before);
-  });
-
-  test('identifies symlink kind and target without following external content', () => {
-    const dir = join(fixture.root, 'physical-symlink');
-    const external = join(fixture.root, 'external.txt');
-    writeFile(external, 'one\n');
-    mkdirSync(dir, { recursive: true });
-    symlinkSync(external, join(dir, 'entry'));
-    const linked = computeDirDigest(dir);
-
-    writeFile(external, 'two\n');
-    expect(computeDirDigest(dir)).toBe(linked);
-    rmSync(join(dir, 'entry'));
-    writeFile(join(dir, 'entry'), 'two\n');
-    expect(computeDirDigest(dir)).not.toBe(linked);
-    rmSync(join(dir, 'entry'));
-    symlinkSync('different-target', join(dir, 'entry'));
-    expect(computeDirDigest(dir)).not.toBe(linked);
-  });
-
-  test('identifies entry modes and broken symlinks', () => {
-    const dir = join(fixture.root, 'physical-modes');
-    writeFile(join(dir, 'tool'), '#!/bin/sh\n');
-    symlinkSync('missing-target', join(dir, 'broken'));
-    const before = computeDirDigest(dir);
-    chmodSync(join(dir, 'tool'), 0o755);
-    expect(computeDirDigest(dir)).not.toBe(before);
-  });
-});
-
-// ---------------------------------------------------------------------------
 // Crash-recovery staging
 // ---------------------------------------------------------------------------
 

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -52,13 +52,21 @@ import { homedir } from 'node:os';
 import { basename, dirname, join, relative, resolve, sep } from 'node:path';
 import historicalCodexFallbackAllowlist from '../fixtures/codex-fallback-allowlist.json';
 import {
+  MANIFEST_NAME,
   ManagedArtifactConflictError,
   type NoClobberDeps,
   NoClobberPublishError,
+  PHYSICAL_TREE_IDENTITY_VERSION,
+  type PhysicalTreeEntry,
   type Renameat2,
   atomicRenameDirectoryNoClobber,
+  computeDirDigest,
+  computeExactDirDigest,
+  computeFileDigest,
+  computeLegacyRegularTreeDigest,
   fsyncPath,
   lstatSafe,
+  physicalEntryKind,
   probeLinuxRenameat2,
   publishRegularFileNoClobber,
   readTrimmed,
@@ -118,6 +126,12 @@ export {
 } from './lifecycle-lease.js';
 /** @public Stable compatibility facade for the lease types that moved to './lifecycle-lease.js'. */
 export type { LifecycleLease, LifecycleLeaseSkip } from './lifecycle-lease.js';
+/**
+ * The physical-tree digest primitives moved to `atomic-fs.ts` (wish
+ * `skills-everywhere-b` Group 2). Re-exported here so doctor, uninstall,
+ * runtime-integrations and the retirement module keep their current import.
+ */
+export { MANIFEST_NAME, PHYSICAL_TREE_IDENTITY_VERSION, computeDirDigest, computeFileDigest };
 
 // ============================================================================
 // Constants
@@ -131,8 +145,6 @@ export const TARGET_NAME = 'council.js';
 export const WORKFLOW_MANIFEST_NAME = `${TARGET_NAME}.genie-sync.json`;
 /** Deterministic physical mode for both stamped council artifacts. */
 const WORKFLOW_FILE_MODE = 0o644;
-/** Manifest marker written into every managed skill dir. Exported: single source of truth. */
-export const MANIFEST_NAME = '.genie-sync.json';
 /** `managedBy` value that certifies a dir as one this engine owns. Exported: single source of truth. */
 export const MANAGED_BY = 'genie-agent-sync';
 /**
@@ -180,8 +192,6 @@ const SKILL_TRANSACTION_ROOT = '.genie-sync-transactions';
 const SKILL_TRANSACTION_STAGING_PREFIX = '.staging-';
 const SKILL_TRANSACTION_PREFIX = 'txn-';
 const SKILL_REMOVAL_PREFIX = 'delete-';
-/** Physical-tree digest schema. Version 1 was the legacy regular-file content digest. */
-export const PHYSICAL_TREE_IDENTITY_VERSION = 2;
 /** Hidden retained transaction root used only by the explicit fallback-retirement primitive. */
 export const CODEX_FALLBACK_RETIREMENT_ROOT = '.genie-codex-fallback-retirement';
 /** Single-writer lock scoped to each fallbackSkillsDir's retirement root; lives directly in it, ignored by the txn-* scan. */
@@ -538,143 +548,6 @@ function firstExisting(paths: string[]): string | null {
   return null;
 }
 
-// ============================================================================
-// Digest — a stable fingerprint of a physical directory tree
-// ============================================================================
-
-/**
- * Version-2 SHA-256 identity over the root and every physical entry. Each entry
- * contributes its normalized relative path, exact lstat kind, permission mode,
- * and kind-specific payload (regular-file content hash or raw symlink target).
- * Symlinks are never followed; FIFOs, sockets, devices, and other non-regular
- * entries are represented rather than silently skipped. The manifest is always
- * excluded because its digest field would otherwise be self-referential.
- */
-export function computeDirDigest(dir: string, exclude?: Set<string>): string {
-  const excluded = new Set([...(exclude ?? [])].map(normalizePhysicalRelPath));
-  excluded.add(MANIFEST_NAME);
-  return computePhysicalTreeDigest(dir, excluded);
-}
-
-function computeExactDirDigest(dir: string): string {
-  return computePhysicalTreeDigest(dir, new Set());
-}
-
-function computePhysicalTreeDigest(dir: string, excluded: Set<string>): string {
-  const rootStat = lstatSync(dir);
-  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
-    throw new Error(`physical tree root is not a directory: ${dir}`);
-  }
-  const entries: PhysicalTreeEntry[] = [physicalTreeEntry('.', rootStat, dir)];
-  collectPhysicalTreeEntries(dir, dir, excluded, entries);
-  entries.sort(byRel);
-  const digest = createHash('sha256');
-  digest.update(`genie-physical-tree-v${PHYSICAL_TREE_IDENTITY_VERSION}\0`);
-  for (const entry of entries) {
-    updateLengthPrefixed(digest, entry.rel);
-    updateLengthPrefixed(digest, entry.kind);
-    updateLengthPrefixed(digest, entry.mode.toString(8));
-    updateLengthPrefixed(digest, entry.payload);
-  }
-  return digest.digest('hex');
-}
-
-interface PhysicalTreeEntry {
-  rel: string;
-  kind: 'directory' | 'file' | 'symlink' | 'fifo' | 'socket' | 'block-device' | 'character-device' | 'other';
-  mode: number;
-  payload: string;
-}
-
-function byRel(a: { rel: string }, b: { rel: string }): number {
-  if (a.rel < b.rel) return -1;
-  if (a.rel > b.rel) return 1;
-  return 0;
-}
-
-function normalizePhysicalRelPath(path: string): string {
-  return path.split(sep).join('/');
-}
-
-function physicalEntryKind(stat: Stats): PhysicalTreeEntry['kind'] {
-  if (stat.isSymbolicLink()) return 'symlink';
-  if (stat.isDirectory()) return 'directory';
-  if (stat.isFile()) return 'file';
-  if (stat.isFIFO()) return 'fifo';
-  if (stat.isSocket()) return 'socket';
-  if (stat.isBlockDevice()) return 'block-device';
-  if (stat.isCharacterDevice()) return 'character-device';
-  return 'other';
-}
-
-function physicalTreeEntry(rel: string, stat: Stats, absolute: string): PhysicalTreeEntry {
-  const kind = physicalEntryKind(stat);
-  const payload = kind === 'file' ? hashFile(absolute) : kind === 'symlink' ? readlinkSync(absolute) : '';
-  return { rel, kind, mode: stat.mode & 0o7777, payload };
-}
-
-function collectPhysicalTreeEntries(
-  root: string,
-  current: string,
-  excluded: Set<string>,
-  out: PhysicalTreeEntry[],
-): void {
-  for (const name of readdirSync(current)) {
-    const abs = join(current, name);
-    const rel = normalizePhysicalRelPath(relative(root, abs));
-    if (excluded.has(rel)) continue;
-    const stat = lstatSync(abs);
-    const entry = physicalTreeEntry(rel, stat, abs);
-    out.push(entry);
-    if (entry.kind === 'directory') collectPhysicalTreeEntries(root, abs, excluded, out);
-  }
-}
-
-function updateLengthPrefixed(digest: ReturnType<typeof createHash>, value: string): void {
-  const bytes = Buffer.from(value);
-  digest.update(String(bytes.length));
-  digest.update(':');
-  digest.update(bytes);
-  digest.update('\0');
-}
-
-/**
- * Legacy v1 digest, accepted only when every physical entry is a regular file
- * or directory. A symlink or special entry in an old tree therefore revokes
- * deletion/update authority instead of recreating the legacy follow/skip bug.
- */
-function computeLegacyRegularTreeDigest(dir: string): string | null {
-  const rootStat = lstatSync(dir);
-  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) return null;
-  const files: Array<{ rel: string; hash: string }> = [];
-  const visit = (current: string): boolean => {
-    for (const name of readdirSync(current)) {
-      const absolute = join(current, name);
-      const rel = relative(dir, absolute);
-      if (rel === MANIFEST_NAME) continue;
-      const stat = lstatSync(absolute);
-      if (stat.isDirectory() && !stat.isSymbolicLink()) {
-        if (!visit(absolute)) return false;
-      } else if (stat.isFile() && !stat.isSymbolicLink()) {
-        files.push({ rel, hash: hashFile(absolute) });
-      } else {
-        return false;
-      }
-    }
-    return true;
-  };
-  if (!visit(dir)) return null;
-  files.sort(byRel);
-  const digest = createHash('sha256');
-  for (const file of files) {
-    digest.update(file.rel);
-    digest.update('\0');
-    digest.update(file.hash);
-    digest.update('\0');
-  }
-  return digest.digest('hex');
-}
-
 /** Resolve a dirent to file/dir/skip, following symlinks and dropping broken ones. */
 function classifyEntry(abs: string, entry: Dirent): 'file' | 'dir' | 'skip' {
   if (entry.isFile()) return 'file';
@@ -687,14 +560,6 @@ function classifyEntry(abs: string, entry: Dirent): 'file' | 'dir' | 'skip' {
     }
   }
   return 'skip';
-}
-
-function hashFile(path: string): string {
-  return createHash('sha256').update(readFileSync(path)).digest('hex');
-}
-
-export function computeFileDigest(path: string): string {
-  return hashFile(path);
 }
 
 // ============================================================================
@@ -4688,7 +4553,7 @@ function regularFileDigest(path: string): string | null {
   const stat = lstatSafe(path);
   if (stat === null || !stat.isFile() || stat.isSymbolicLink()) return null;
   try {
-    return hashFile(path);
+    return computeFileDigest(path);
   } catch {
     return null;
   }
@@ -4727,7 +4592,7 @@ function physicalFileIdentity(path: string): PhysicalFileIdentity {
   if (stat.isDirectory()) return { kind: 'directory', mode };
   if (!stat.isFile()) return { kind: 'other', mode, entry: physicalEntryKind(stat) };
   try {
-    return { kind: 'regular', mode, digest: hashFile(path) };
+    return { kind: 'regular', mode, digest: computeFileDigest(path) };
   } catch (error) {
     return { kind: 'unreadable', code: (error as NodeJS.ErrnoException).code ?? 'UNKNOWN' };
   }

--- a/src/lib/atomic-fs.test.ts
+++ b/src/lib/atomic-fs.test.ts
@@ -9,28 +9,39 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { createHash } from 'node:crypto';
 import {
+  chmodSync,
   closeSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   openSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   renameSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
   writeSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { computeDirDigest } from './agent-sync';
 import {
   type FsyncPathDeps,
+  MANIFEST_NAME,
   atomicRenameDirectoryNoClobber,
+  atomicWriteFileSync,
+  computeDirDigest,
+  computeFileDigest,
+  fsyncParentDir,
   fsyncPathForTest,
   publishDirectoryViaNameClaim,
+  readBoundedRegularFile,
   resolveLinuxRenameat2,
+  unlinkWithParentFsync,
   writeAllSync,
 } from './atomic-fs';
 
@@ -250,5 +261,144 @@ describe('fsyncPath directory-metadata flush tolerance (Fix 4)', () => {
 
   test('a healthy directory fsync succeeds through the real syscalls', () => {
     expect(() => fsyncPathForTest(dir('fsync-dir-ok'))).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Digest properties
+// ---------------------------------------------------------------------------
+
+describe('computeDirDigest', () => {
+  test('is stable regardless of directory entry creation order', () => {
+    const dirA = join(fixture.root, 'digest-a');
+    writeFile(join(dirA, 'b.md'), 'B');
+    writeFile(join(dirA, 'a.md'), 'A');
+    writeFile(join(dirA, 'nested', 'c.md'), 'C');
+
+    const dirB = join(fixture.root, 'digest-b');
+    writeFile(join(dirB, 'nested', 'c.md'), 'C');
+    writeFile(join(dirB, 'a.md'), 'A');
+    writeFile(join(dirB, 'b.md'), 'B');
+
+    expect(computeDirDigest(dirA)).toBe(computeDirDigest(dirB));
+  });
+
+  test('excludes the manifest so a manifest does not change the digest', () => {
+    const dir = join(fixture.root, 'digest-manifest');
+    writeFile(join(dir, 'SKILL.md'), 'body');
+    const before = computeDirDigest(dir);
+    writeFile(join(dir, MANIFEST_NAME), '{"managedBy":"genie-agent-sync","digest":"x"}');
+    expect(computeDirDigest(dir)).toBe(before);
+  });
+
+  test('changes when file content changes', () => {
+    const dir = join(fixture.root, 'digest-content');
+    writeFile(join(dir, 'SKILL.md'), 'one');
+    const before = computeDirDigest(dir);
+    writeFile(join(dir, 'SKILL.md'), 'two');
+    expect(computeDirDigest(dir)).not.toBe(before);
+  });
+
+  test('identifies symlink kind and target without following external content', () => {
+    const dir = join(fixture.root, 'physical-symlink');
+    const external = join(fixture.root, 'external.txt');
+    writeFile(external, 'one\n');
+    mkdirSync(dir, { recursive: true });
+    symlinkSync(external, join(dir, 'entry'));
+    const linked = computeDirDigest(dir);
+
+    writeFile(external, 'two\n');
+    expect(computeDirDigest(dir)).toBe(linked);
+    rmSync(join(dir, 'entry'));
+    writeFile(join(dir, 'entry'), 'two\n');
+    expect(computeDirDigest(dir)).not.toBe(linked);
+    rmSync(join(dir, 'entry'));
+    symlinkSync('different-target', join(dir, 'entry'));
+    expect(computeDirDigest(dir)).not.toBe(linked);
+  });
+
+  test('identifies entry modes and broken symlinks', () => {
+    const dir = join(fixture.root, 'physical-modes');
+    writeFile(join(dir, 'tool'), '#!/bin/sh\n');
+    symlinkSync('missing-target', join(dir, 'broken'));
+    const before = computeDirDigest(dir);
+    chmodSync(join(dir, 'tool'), 0o755);
+    expect(computeDirDigest(dir)).not.toBe(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bounded reads + durable writes (moved in from codex-activation-persistence.ts)
+// ---------------------------------------------------------------------------
+
+describe('readBoundedRegularFile', () => {
+  test('reads a regular file within the cap', () => {
+    const path = join(fixture.root, 'bounded-ok');
+    writeFileSync(path, 'payload', 'utf8');
+    expect(readBoundedRegularFile(path, 1024)).toEqual({ status: 'ok', content: 'payload', size: 7 });
+  });
+
+  test('distinguishes absent, symlink, non-regular and oversized without mutating', () => {
+    expect(readBoundedRegularFile(join(fixture.root, 'nope'), 1024)).toEqual({ status: 'absent' });
+
+    const target = join(fixture.root, 'link-target');
+    writeFileSync(target, 'x', 'utf8');
+    const link = join(fixture.root, 'a-symlink');
+    symlinkSync(target, link);
+    expect(readBoundedRegularFile(link, 1024)).toEqual({ status: 'symlink' });
+
+    const dir = join(fixture.root, 'a-directory');
+    mkdirSync(dir);
+    expect(readBoundedRegularFile(dir, 1024)).toEqual({ status: 'non-regular' });
+
+    const big = join(fixture.root, 'oversized');
+    writeFileSync(big, 'abcdefghij', 'utf8');
+    expect(readBoundedRegularFile(big, 4)).toEqual({ status: 'oversized', size: 10 });
+    expect(readFileSync(big, 'utf8')).toBe('abcdefghij');
+  });
+});
+
+describe('atomicWriteFileSync', () => {
+  test('publishes content at the requested mode and leaves no staging residue', () => {
+    const path = join(fixture.root, 'nested', 'state.json');
+    atomicWriteFileSync(path, '{"a":1}', { mode: 0o640 });
+    expect(readFileSync(path, 'utf8')).toBe('{"a":1}');
+    expect(lstatSync(path).mode & 0o777).toBe(0o640);
+    expect(readdirSync(dirname(path)).filter((name) => name.includes('.staging-'))).toEqual([]);
+  });
+
+  test('backs the prior regular file up before replacing it when asked', () => {
+    const path = join(fixture.root, 'backed-up.json');
+    atomicWriteFileSync(path, 'first');
+    atomicWriteFileSync(path, 'second', { backup: true });
+    expect(readFileSync(path, 'utf8')).toBe('second');
+    const backups = readdirSync(fixture.root).filter((name) => name.includes('.genie-backup-'));
+    expect(backups).toHaveLength(1);
+    expect(readFileSync(join(fixture.root, backups[0]), 'utf8')).toBe('first');
+  });
+});
+
+describe('unlinkWithParentFsync and fsyncParentDir', () => {
+  test('removing an absent path is a no-op rather than a throw', () => {
+    const path = join(fixture.root, 'already-gone');
+    writeFileSync(path, 'x', 'utf8');
+    unlinkWithParentFsync(path);
+    expect(existsSync(path)).toBe(false);
+    expect(() => unlinkWithParentFsync(path)).not.toThrow();
+  });
+
+  test('a parent-directory fsync never throws, even for a path that does not exist', () => {
+    expect(() => fsyncParentDir(join(fixture.root, 'missing', 'deeper', 'file'))).not.toThrow();
+  });
+});
+
+describe('computeFileDigest', () => {
+  test('is the sha256 of the file bytes and changes with content', () => {
+    const path = join(fixture.root, 'digest-me');
+    writeFileSync(path, 'one', 'utf8');
+    const before = computeFileDigest(path);
+    expect(before).toBe(createHash('sha256').update(Buffer.from('one')).digest('hex'));
+    writeFileSync(path, 'two', 'utf8');
+    expect(computeFileDigest(path)).not.toBe(before);
   });
 });

--- a/src/lib/atomic-fs.ts
+++ b/src/lib/atomic-fs.ts
@@ -8,7 +8,7 @@
  */
 
 import { dlopen } from 'bun:ffi';
-import { randomBytes } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import {
   constants,
   type Stats,
@@ -21,12 +21,22 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  readSync,
   readdirSync,
+  readlinkSync,
   renameSync,
   rmSync,
   statSync,
+  unlinkSync,
   writeSync,
 } from 'node:fs';
+import { dirname, join, relative, sep } from 'node:path';
+
+/**
+ * `constants` under the name the persistence primitives moved in from
+ * `codex-activation-persistence.ts` already used, so those blocks read verbatim.
+ */
+const fsConstants = constants;
 
 /** Feature-detected glibc/musl sonames for the Linux renameat2 no-clobber fast path (x86_64). */
 const LINUX_LIBC_CANDIDATES = ['libc.so.6', 'ld-musl-x86_64.so.1', 'libc.musl-x86_64.so.1'] as const;
@@ -332,6 +342,325 @@ export function atomicRenameDirectoryNoClobber(stagedDir: string, targetDir: str
 
 function selectedNoClobberPlatform(deps: NoClobberDeps): NodeJS.Platform {
   return deps.platform ?? (deps.darwinOpener === undefined ? process.platform : 'darwin');
+}
+
+// ============================================================================
+// Physical-tree digest — moved verbatim out of `agent-sync.ts`
+// ============================================================================
+//
+// `computeDirDigest` / `computeFileDigest` are the verification primitive
+// `atomic-fs.test.ts` already used, and the only pieces of this cluster that
+// survive wish `skills-everywhere-b`. The private helpers travel with them
+// (a digest is defined by its traversal), and `MANIFEST_NAME` /
+// `PHYSICAL_TREE_IDENTITY_VERSION` come along because the digest grammar is
+// defined in terms of both. `agent-sync.ts` re-exports the public four and
+// imports back the four this move made non-private (`computeExactDirDigest`,
+// `computeLegacyRegularTreeDigest`, `physicalEntryKind`, `PhysicalTreeEntry`),
+// so no other consumer changes this wave.
+
+/** Manifest marker written into every managed skill dir. Exported: single source of truth. */
+export const MANIFEST_NAME = '.genie-sync.json';
+/** Physical-tree digest schema. Version 1 was the legacy regular-file content digest. */
+export const PHYSICAL_TREE_IDENTITY_VERSION = 2;
+// ============================================================================
+// Digest — a stable fingerprint of a physical directory tree
+// ============================================================================
+
+/**
+ * Version-2 SHA-256 identity over the root and every physical entry. Each entry
+ * contributes its normalized relative path, exact lstat kind, permission mode,
+ * and kind-specific payload (regular-file content hash or raw symlink target).
+ * Symlinks are never followed; FIFOs, sockets, devices, and other non-regular
+ * entries are represented rather than silently skipped. The manifest is always
+ * excluded because its digest field would otherwise be self-referential.
+ */
+export function computeDirDigest(dir: string, exclude?: Set<string>): string {
+  const excluded = new Set([...(exclude ?? [])].map(normalizePhysicalRelPath));
+  excluded.add(MANIFEST_NAME);
+  return computePhysicalTreeDigest(dir, excluded);
+}
+
+export function computeExactDirDigest(dir: string): string {
+  return computePhysicalTreeDigest(dir, new Set());
+}
+
+function computePhysicalTreeDigest(dir: string, excluded: Set<string>): string {
+  const rootStat = lstatSync(dir);
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    throw new Error(`physical tree root is not a directory: ${dir}`);
+  }
+  const entries: PhysicalTreeEntry[] = [physicalTreeEntry('.', rootStat, dir)];
+  collectPhysicalTreeEntries(dir, dir, excluded, entries);
+  entries.sort(byRel);
+  const digest = createHash('sha256');
+  digest.update(`genie-physical-tree-v${PHYSICAL_TREE_IDENTITY_VERSION}\0`);
+  for (const entry of entries) {
+    updateLengthPrefixed(digest, entry.rel);
+    updateLengthPrefixed(digest, entry.kind);
+    updateLengthPrefixed(digest, entry.mode.toString(8));
+    updateLengthPrefixed(digest, entry.payload);
+  }
+  return digest.digest('hex');
+}
+
+export interface PhysicalTreeEntry {
+  rel: string;
+  kind: 'directory' | 'file' | 'symlink' | 'fifo' | 'socket' | 'block-device' | 'character-device' | 'other';
+  mode: number;
+  payload: string;
+}
+
+function byRel(a: { rel: string }, b: { rel: string }): number {
+  if (a.rel < b.rel) return -1;
+  if (a.rel > b.rel) return 1;
+  return 0;
+}
+
+function normalizePhysicalRelPath(path: string): string {
+  return path.split(sep).join('/');
+}
+
+export function physicalEntryKind(stat: Stats): PhysicalTreeEntry['kind'] {
+  if (stat.isSymbolicLink()) return 'symlink';
+  if (stat.isDirectory()) return 'directory';
+  if (stat.isFile()) return 'file';
+  if (stat.isFIFO()) return 'fifo';
+  if (stat.isSocket()) return 'socket';
+  if (stat.isBlockDevice()) return 'block-device';
+  if (stat.isCharacterDevice()) return 'character-device';
+  return 'other';
+}
+
+function physicalTreeEntry(rel: string, stat: Stats, absolute: string): PhysicalTreeEntry {
+  const kind = physicalEntryKind(stat);
+  const payload = kind === 'file' ? hashFile(absolute) : kind === 'symlink' ? readlinkSync(absolute) : '';
+  return { rel, kind, mode: stat.mode & 0o7777, payload };
+}
+
+function collectPhysicalTreeEntries(
+  root: string,
+  current: string,
+  excluded: Set<string>,
+  out: PhysicalTreeEntry[],
+): void {
+  for (const name of readdirSync(current)) {
+    const abs = join(current, name);
+    const rel = normalizePhysicalRelPath(relative(root, abs));
+    if (excluded.has(rel)) continue;
+    const stat = lstatSync(abs);
+    const entry = physicalTreeEntry(rel, stat, abs);
+    out.push(entry);
+    if (entry.kind === 'directory') collectPhysicalTreeEntries(root, abs, excluded, out);
+  }
+}
+
+function updateLengthPrefixed(digest: ReturnType<typeof createHash>, value: string): void {
+  const bytes = Buffer.from(value);
+  digest.update(String(bytes.length));
+  digest.update(':');
+  digest.update(bytes);
+  digest.update('\0');
+}
+
+/**
+ * Legacy v1 digest, accepted only when every physical entry is a regular file
+ * or directory. A symlink or special entry in an old tree therefore revokes
+ * deletion/update authority instead of recreating the legacy follow/skip bug.
+ */
+export function computeLegacyRegularTreeDigest(dir: string): string | null {
+  const rootStat = lstatSync(dir);
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) return null;
+  const files: Array<{ rel: string; hash: string }> = [];
+  const visit = (current: string): boolean => {
+    for (const name of readdirSync(current)) {
+      const absolute = join(current, name);
+      const rel = relative(dir, absolute);
+      if (rel === MANIFEST_NAME) continue;
+      const stat = lstatSync(absolute);
+      if (stat.isDirectory() && !stat.isSymbolicLink()) {
+        if (!visit(absolute)) return false;
+      } else if (stat.isFile() && !stat.isSymbolicLink()) {
+        files.push({ rel, hash: hashFile(absolute) });
+      } else {
+        return false;
+      }
+    }
+    return true;
+  };
+  if (!visit(dir)) return null;
+  files.sort(byRel);
+  const digest = createHash('sha256');
+  for (const file of files) {
+    digest.update(file.rel);
+    digest.update('\0');
+    digest.update(file.hash);
+    digest.update('\0');
+  }
+  return digest.digest('hex');
+}
+
+function hashFile(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+export function computeFileDigest(path: string): string {
+  return hashFile(path);
+}
+
+// ============================================================================
+// Bounded reads + durable writes — moved verbatim out of
+// `codex-activation-persistence.ts`
+// ============================================================================
+//
+// Nothing in these four primitives is Codex-specific: they are bounded
+// regular-file reads that fail closed on symlink/oversize, a best-effort
+// parent-directory fsync, an atomic backup-first write, and an idempotent
+// unlink. Wish `skills-everywhere-b` Group 3 deletes their old home, and two
+// consumers that survive it -- `install-version-marker.ts` and
+// `update-capabilities.ts` -- depend on them, so they live here with the rest
+// of the crash-safety contract. The old module re-exports them for this wave.
+
+/** O_NOFOLLOW is POSIX-only; degrade to 0 on platforms that lack it. */
+const O_NOFOLLOW = (fsConstants.O_NOFOLLOW ?? 0) as number;
+
+export type BoundedFileRead =
+  | { status: 'ok'; content: string; size: number }
+  | { status: 'absent' }
+  | { status: 'symlink' }
+  | { status: 'non-regular' }
+  | { status: 'oversized'; size: number }
+  | { status: 'unreadable'; detail: string };
+
+/**
+ * Read a regular file bounded to `maxBytes`, following no symlink at the final
+ * component. A symlink, non-regular kind, or oversize is a distinct fail-closed
+ * category the caller must handle explicitly; nothing here is mutated.
+ */
+export function readBoundedRegularFile(path: string, maxBytes: number): BoundedFileRead {
+  let stat: Stats;
+  try {
+    stat = lstatSync(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { status: 'absent' };
+    return { status: 'unreadable', detail: errorText(error) };
+  }
+  if (stat.isSymbolicLink()) return { status: 'symlink' };
+  if (!stat.isFile()) return { status: 'non-regular' };
+  if (stat.size > maxBytes) return { status: 'oversized', size: stat.size };
+  try {
+    const fd = openSync(path, fsConstants.O_RDONLY | O_NOFOLLOW);
+    try {
+      const buffer = Buffer.alloc(stat.size);
+      let read = 0;
+      while (read < stat.size) {
+        const chunk = readSync(fd, buffer, read, stat.size - read, read);
+        if (chunk <= 0) break;
+        read += chunk;
+      }
+      return { status: 'ok', content: buffer.subarray(0, read).toString('utf8'), size: read };
+    } finally {
+      closeSync(fd);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ELOOP') return { status: 'symlink' };
+    return { status: 'unreadable', detail: errorText(error) };
+  }
+}
+
+/** Best-effort parent-directory fsync; unsupported filesystems degrade silently. */
+export function fsyncParentDir(path: string): void {
+  try {
+    const dirFd = openSync(dirname(path), 'r');
+    try {
+      fsyncSync(dirFd);
+    } finally {
+      closeSync(dirFd);
+    }
+  } catch {
+    // Directory fsync is not portable; the file fsync + atomic rename remain sound.
+  }
+}
+
+export interface AtomicWriteOptions {
+  mode?: number;
+  /** Copy an existing regular target to a timestamped sidecar before replacing it. */
+  backup?: boolean;
+}
+
+/**
+ * Atomically publish `content` to `path`: create the parent, back up any prior
+ * regular file, write a private staging sibling, fsync it, rename over the
+ * target, and fsync the parent directory. The rename is the commit point, so a
+ * crash before it leaves the prior file intact.
+ */
+export function atomicWriteFileSync(path: string, content: string, options: AtomicWriteOptions = {}): void {
+  const mode = options.mode ?? 0o600;
+  const dir = dirname(path);
+  // Every caller writes under GENIE_HOME — the activation store's paths derive
+  // from `resolveGenieHome()`, delivery evidence sits under
+  // `<GENIE_HOME>/<evidence>`, and the capability sidecar lands beside the
+  // prior binary in `<GENIE_HOME>/bin/.previous`. A direct mode is therefore
+  // correct here; no caller opt-in is needed.
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  if (options.backup) backupExistingRegularFile(path);
+  const staging = join(dir, `.${basenameOf(path)}.staging-${process.pid}-${uniqueSuffix()}`);
+  const fd = openSync(staging, fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL, mode);
+  try {
+    const buffer = Buffer.from(content, 'utf8');
+    let written = 0;
+    while (written < buffer.length) {
+      written += writeSync(fd, buffer, written, buffer.length - written, null);
+    }
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+  renameSync(staging, path);
+  fsyncParentDir(path);
+}
+
+/** Delete a file and fsync its parent; ENOENT is treated as already-released. */
+export function unlinkWithParentFsync(path: string): void {
+  try {
+    unlinkSync(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  fsyncParentDir(path);
+}
+
+function backupExistingRegularFile(path: string): void {
+  let stat: Stats;
+  try {
+    stat = lstatSync(path);
+  } catch {
+    return;
+  }
+  if (!stat.isFile() || stat.isSymbolicLink()) return;
+  const backup = `${path}.genie-backup-${timestamp()}-${uniqueSuffix()}`;
+  try {
+    copyFileSync(path, backup);
+    fsyncParentDir(backup);
+  } catch {
+    // A best-effort backup failure must not block the durable write itself.
+  }
+}
+
+function basenameOf(path: string): string {
+  const parts = path.split(/[\\/]/);
+  return parts[parts.length - 1] || 'state';
+}
+
+function timestamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+function uniqueSuffix(): string {
+  return randomBytes(6).toString('hex');
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 export {

--- a/src/lib/codex-activation-persistence.ts
+++ b/src/lib/codex-activation-persistence.ts
@@ -12,124 +12,24 @@
  * distinguish physical fault categories (absent / symlink / non-regular /
  * oversized / unreadable) without mutation, so callers can fail closed on an
  * exact category rather than collapsing every fault into "missing".
+ *
+ * The four generic primitives -- `readBoundedRegularFile`, `fsyncParentDir`,
+ * `atomicWriteFileSync` and `unlinkWithParentFsync` -- now live in
+ * `atomic-fs.ts`: two of their consumers (`install-version-marker.ts`,
+ * `update-capabilities.ts`) survive wish `skills-everywhere-b`, which deletes
+ * this module in Group 3. They are re-exported here so no caller changes this
+ * wave; `renameNonOverwriting` stays because only Codex activation uses it.
+ *
+ * The `BoundedFileRead` and `AtomicWriteOptions` types are NOT re-exported: no
+ * module outside this one ever imported them (they were reachable only because
+ * this file used them locally), and a pure type re-export with no importer is a
+ * knip failure. Both are still exported from `atomic-fs.ts`.
  */
 
-import { randomBytes } from 'node:crypto';
-import {
-  type Stats,
-  closeSync,
-  copyFileSync,
-  constants as fsConstants,
-  fsyncSync,
-  linkSync,
-  lstatSync,
-  mkdirSync,
-  openSync,
-  readSync,
-  renameSync,
-  unlinkSync,
-  writeSync,
-} from 'node:fs';
-import { dirname, join } from 'node:path';
+import { linkSync, unlinkSync } from 'node:fs';
+import { atomicWriteFileSync, fsyncParentDir, readBoundedRegularFile, unlinkWithParentFsync } from './atomic-fs.js';
 
-/** O_NOFOLLOW is POSIX-only; degrade to 0 on platforms that lack it. */
-const O_NOFOLLOW = (fsConstants.O_NOFOLLOW ?? 0) as number;
-
-export type BoundedFileRead =
-  | { status: 'ok'; content: string; size: number }
-  | { status: 'absent' }
-  | { status: 'symlink' }
-  | { status: 'non-regular' }
-  | { status: 'oversized'; size: number }
-  | { status: 'unreadable'; detail: string };
-
-/**
- * Read a regular file bounded to `maxBytes`, following no symlink at the final
- * component. A symlink, non-regular kind, or oversize is a distinct fail-closed
- * category the caller must handle explicitly; nothing here is mutated.
- */
-export function readBoundedRegularFile(path: string, maxBytes: number): BoundedFileRead {
-  let stat: Stats;
-  try {
-    stat = lstatSync(path);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { status: 'absent' };
-    return { status: 'unreadable', detail: errorText(error) };
-  }
-  if (stat.isSymbolicLink()) return { status: 'symlink' };
-  if (!stat.isFile()) return { status: 'non-regular' };
-  if (stat.size > maxBytes) return { status: 'oversized', size: stat.size };
-  try {
-    const fd = openSync(path, fsConstants.O_RDONLY | O_NOFOLLOW);
-    try {
-      const buffer = Buffer.alloc(stat.size);
-      let read = 0;
-      while (read < stat.size) {
-        const chunk = readSync(fd, buffer, read, stat.size - read, read);
-        if (chunk <= 0) break;
-        read += chunk;
-      }
-      return { status: 'ok', content: buffer.subarray(0, read).toString('utf8'), size: read };
-    } finally {
-      closeSync(fd);
-    }
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ELOOP') return { status: 'symlink' };
-    return { status: 'unreadable', detail: errorText(error) };
-  }
-}
-
-/** Best-effort parent-directory fsync; unsupported filesystems degrade silently. */
-export function fsyncParentDir(path: string): void {
-  try {
-    const dirFd = openSync(dirname(path), 'r');
-    try {
-      fsyncSync(dirFd);
-    } finally {
-      closeSync(dirFd);
-    }
-  } catch {
-    // Directory fsync is not portable; the file fsync + atomic rename remain sound.
-  }
-}
-
-export interface AtomicWriteOptions {
-  mode?: number;
-  /** Copy an existing regular target to a timestamped sidecar before replacing it. */
-  backup?: boolean;
-}
-
-/**
- * Atomically publish `content` to `path`: create the parent, back up any prior
- * regular file, write a private staging sibling, fsync it, rename over the
- * target, and fsync the parent directory. The rename is the commit point, so a
- * crash before it leaves the prior file intact.
- */
-export function atomicWriteFileSync(path: string, content: string, options: AtomicWriteOptions = {}): void {
-  const mode = options.mode ?? 0o600;
-  const dir = dirname(path);
-  // Every caller writes under GENIE_HOME — the activation store's paths derive
-  // from `resolveGenieHome()`, delivery evidence sits under
-  // `<GENIE_HOME>/<evidence>`, and the capability sidecar lands beside the
-  // prior binary in `<GENIE_HOME>/bin/.previous`. A direct mode is therefore
-  // correct here; no caller opt-in is needed.
-  mkdirSync(dir, { recursive: true, mode: 0o700 });
-  if (options.backup) backupExistingRegularFile(path);
-  const staging = join(dir, `.${basenameOf(path)}.staging-${process.pid}-${uniqueSuffix()}`);
-  const fd = openSync(staging, fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL, mode);
-  try {
-    const buffer = Buffer.from(content, 'utf8');
-    let written = 0;
-    while (written < buffer.length) {
-      written += writeSync(fd, buffer, written, buffer.length - written, null);
-    }
-    fsyncSync(fd);
-  } finally {
-    closeSync(fd);
-  }
-  renameSync(staging, path);
-  fsyncParentDir(path);
-}
+export { atomicWriteFileSync, fsyncParentDir, readBoundedRegularFile, unlinkWithParentFsync };
 
 /**
  * Rename `from` to `to` without ever overwriting an existing `to`. Used for
@@ -158,16 +58,6 @@ export function renameNonOverwriting(from: string, to: string): { moved: boolean
   }
 }
 
-/** Delete a file and fsync its parent; ENOENT is treated as already-released. */
-export function unlinkWithParentFsync(path: string): void {
-  try {
-    unlinkSync(path);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
-  }
-  fsyncParentDir(path);
-}
-
 function linkAndUnlink(from: string, to: string): void {
   // renameSync overwrites on POSIX, so use link (fails EEXIST) then unlink the
   // source. This preserves the "never overwrite" invariant atomically.
@@ -177,38 +67,4 @@ function linkAndUnlink(from: string, to: string): void {
   } catch {
     // The hard link is committed; a lingering source is harmless.
   }
-}
-
-function backupExistingRegularFile(path: string): void {
-  let stat: Stats;
-  try {
-    stat = lstatSync(path);
-  } catch {
-    return;
-  }
-  if (!stat.isFile() || stat.isSymbolicLink()) return;
-  const backup = `${path}.genie-backup-${timestamp()}-${uniqueSuffix()}`;
-  try {
-    copyFileSync(path, backup);
-    fsyncParentDir(backup);
-  } catch {
-    // A best-effort backup failure must not block the durable write itself.
-  }
-}
-
-function basenameOf(path: string): string {
-  const parts = path.split(/[\\/]/);
-  return parts[parts.length - 1] || 'state';
-}
-
-function timestamp(): string {
-  return new Date().toISOString().replace(/[:.]/g, '-');
-}
-
-function uniqueSuffix(): string {
-  return randomBytes(6).toString('hex');
-}
-
-function errorText(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/src/lib/genie-home-permissions.test.ts
+++ b/src/lib/genie-home-permissions.test.ts
@@ -177,6 +177,15 @@ describe('GENIE_HOME first-creation permissions', () => {
     expect(offenders).toEqual([]);
   });
 
+  test('every SCAN_EXEMPTIONS entry still matches exactly one real call site', () => {
+    // A content-anchored exemption that stops matching is the failure mode the
+    // line-anchored key hid: it silently re-classified the call as compliant.
+    const consumed = new Set<number>();
+    scanUnsafeGenieHomeMkdirs(REPO_ROOT, consumed);
+    const stale = SCAN_EXEMPTIONS.filter((_, index) => !consumed.has(index)).map((entry) => entry.call);
+    expect(stale, 'stale SCAN_EXEMPTIONS entries — re-point or delete them').toEqual([]);
+  });
+
   test('GENIE_HOME creators the scan cannot see keep an explicit safe mode', () => {
     // The scan reads expressions, so it only sees GENIE_HOME when a token
     // survives local const expansion. These sites receive the path as a
@@ -188,11 +197,7 @@ describe('GENIE_HOME first-creation permissions', () => {
       ['src/lib/genie-config.ts', 'mkdirSync(dir, {', 'GENIE_HOME via getGenieDir()'],
       ['src/genie-commands/auxiliary-trees.ts', 'mkdirSync(dirname(options.destination), {', 'GENIE_HOME parent'],
       ['src/lib/codex-lifecycle-lease.ts', 'mkdirSync(dirOf(path), {', 'GENIE_HOME via the lease path'],
-      [
-        'src/lib/codex-activation-persistence.ts',
-        'mkdirSync(dir, {',
-        'atomicWriteFileSync — every caller writes under GENIE_HOME',
-      ],
+      ['src/lib/atomic-fs.ts', 'mkdirSync(dir, {', 'atomicWriteFileSync — every caller writes under GENIE_HOME'],
     ];
 
     for (const [file, marker, why] of pinned) {
@@ -232,25 +237,50 @@ const SAFE_MODE = /mode:\s*0o[0-7]?[0-7][0145][0145]\b/;
  */
 const MKDIR_CALL = /mkdirSync\(\s*([^;]+?),\s*\{([^;]*?)\}\s*,?\s*\)/g;
 
+/** One reviewed call the token heuristic over-matches, pinned by content. */
+interface ScanExemption {
+  /** Repo-relative source file the exempt call lives in. */
+  file: string;
+  /** The exempt `mkdirSync(...)` call itself, whitespace-normalized. */
+  call: string;
+  /** A second literal from the same file that pins WHICH call this is. */
+  anchor: string;
+  /** Why this call provably never creates GENIE_HOME. */
+  reason: string;
+}
+
 /**
  * Verified NOT to create GENIE_HOME, despite matching the token heuristic.
- * Keyed by `<path>:<line>` with the reason it is exempt.
+ *
+ * Content-anchored, never line-anchored: the previous `<path>:<line>` key had
+ * already been re-pointed once by an unrelated rehome, and a drifted key fails
+ * OPEN — it stops matching, the real exemption disappears, and the only signal
+ * is a new offender nobody connects to the move. Here a stale entry fails
+ * CLOSED instead: `every exemption matches exactly one call` asserts each entry
+ * still fires, so a moved or edited call site is a named test failure rather
+ * than a silent re-classification.
  */
-const SCAN_EXEMPTIONS = new Map<string, string>([
-  [
-    // NOTE: this key is LINE-anchored, so it must be re-pointed whenever
-    // agent-sync.ts grows or shrinks above the call (it last moved when the
-    // atomic-fs / lifecycle-lease rehome shortened the file).
-    'src/lib/agent-sync.ts:4962',
+const SCAN_EXEMPTIONS: ScanExemption[] = [
+  {
+    file: 'src/lib/agent-sync.ts',
+    call: 'mkdirSync(before, { recursive: true })',
+    anchor: "const before = join(transactionDir, 'before');",
     // Triggered by the identifier `before`: the scan's file-scoped const map
     // resolves it to the file's FIRST `const before = lstatSync(path)`,
     // whose `path` cascades into a genieHome token. The
     // real target here is `join(transactionDir, 'before')` inside a council
     // workflow transaction dir the preceding renameSync already published, so
     // GENIE_HOME is never created.
-    'council workflow transaction dir, not GENIE_HOME (scan token collision)',
-  ],
-]);
+    reason: 'council workflow transaction dir, not GENIE_HOME (scan token collision)',
+  },
+];
+
+/** Index of every exemption the last scan actually consumed. */
+function exemptionIndex(file: string, call: string): number {
+  return SCAN_EXEMPTIONS.findIndex(
+    (exemption) => exemption.file === file && exemption.call === call.replace(/\s+/g, ' '),
+  );
+}
 
 interface UnsafeMkdir {
   site: string;
@@ -268,10 +298,11 @@ interface UnsafeMkdir {
  * deliberate: over-matching costs one reviewed SCAN_EXEMPTIONS entry, while
  * under-matching would silently ship the bug this file exists to prevent.
  */
-function scanUnsafeGenieHomeMkdirs(repoRoot: string): UnsafeMkdir[] {
+function scanUnsafeGenieHomeMkdirs(repoRoot: string, consumed = new Set<number>()): UnsafeMkdir[] {
   const offenders: UnsafeMkdir[] = [];
   for (const file of sourceFiles(join(repoRoot, 'src'))) {
     const source = readFileSync(file, 'utf8');
+    const relativeFile = relative(repoRoot, file);
     const consts = new Map<string, string>();
     for (const line of source.split('\n')) {
       const declaration = /^\s*(?:const|let)\s+([A-Za-z_$][\w$]*)\s*=\s*(.+?);?\s*$/.exec(line);
@@ -283,8 +314,15 @@ function scanUnsafeGenieHomeMkdirs(repoRoot: string): UnsafeMkdir[] {
       const target = call[1].replace(/\s+/g, ' ');
       if (!GENIE_HOME_TOKENS.test(expandIdentifiers(target, consts))) continue;
       const line = source.slice(0, call.index).split('\n').length;
-      const site = `${relative(repoRoot, file)}:${line}`;
-      if (!SCAN_EXEMPTIONS.has(site)) offenders.push({ site, target });
+      const site = `${relativeFile}:${line}`;
+      const exempt = exemptionIndex(relativeFile, call[0]);
+      // The anchor must still be present, or the call moved to a site the
+      // reviewed rationale no longer describes and the exemption is void.
+      if (exempt >= 0 && source.includes(SCAN_EXEMPTIONS[exempt].anchor)) {
+        consumed.add(exempt);
+        continue;
+      }
+      offenders.push({ site, target });
     }
   }
   return offenders;

--- a/src/lib/legacy-integration-retirement.test.ts
+++ b/src/lib/legacy-integration-retirement.test.ts
@@ -14,6 +14,7 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { createHash } from 'node:crypto';
 import {
+  chmodSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -30,6 +31,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { computeDirDigest, computeFileDigest, stampWorkflow } from './agent-sync';
 import {
+  LEGACY_INTEGRATION_SURFACES,
   type LegacyIntegrationEntry,
   type LegacyIntegrationHomes,
   type LegacyIntegrationState,
@@ -38,7 +40,7 @@ import {
   retireLegacyIntegrations,
   runLegacyIntegrationRetirement,
 } from './legacy-integration-retirement';
-import { installCodexAgents } from './runtime-integrations';
+import { inspectRuntimeIntegrationEvidence, installCodexAgents } from './runtime-integrations';
 
 const MANIFEST_NAME = '.genie-sync.json';
 const MANAGED_ROLE_TOML = '# Managed by Genie. Remove with `genie uninstall`.\nname = "genie_reviewer"\n';
@@ -207,6 +209,7 @@ function populateClean(fixture: Fixture): void {
       2,
     )}\n`,
   );
+  write(join(fixture.claudeDir, 'plugins', 'marketplaces', 'automagik', 'plugins', 'genie', 'plugin.json'), '{}\n');
   write(
     join(fixture.claudeDir, 'settings.json'),
     `${JSON.stringify({ model: 'opus', enabledPlugins: { 'genie@automagik': true, 'other@market': true } }, null, 2)}\n`,
@@ -256,9 +259,11 @@ describe('classifyLegacyIntegrations — every surface, every state', () => {
       'codex-plugin-registration',
       'codex-plugin-cache',
       'codex-role-agent',
+      'codex-role-agent-inventory',
       'codex-legacy-curated-skill',
       'claude-plugin-registry',
       'claude-plugin-cache',
+      'claude-marketplace-cache',
       'claude-workflow',
       'claude-agent',
       'claude-skill',
@@ -367,7 +372,7 @@ describe('retireLegacyIntegrations — removes only clean assets, backup-first',
 
     expect(result.failures).toEqual([]);
     expect(result.kept).toEqual([]);
-    expect(result.removed).toHaveLength(15);
+    expect(result.removed).toHaveLength(17);
     expect(result.backupRootUsed).toBe(true);
     for (const removal of result.removed) {
       expect([removal.surface, existsSync(removal.backupPath)]).toEqual([removal.surface, true]);
@@ -405,7 +410,7 @@ describe('retireLegacyIntegrations — removes only clean assets, backup-first',
     expect(existsSync(join(fixture.genieHome, 'plugins', 'hermes-genie'))).toBe(true);
     expect(existsSync(join(fixture.genieHome, 'plugins', 'pi-genie'))).toBe(true);
 
-    expect(lines.filter((line) => line.startsWith('retired '))).toHaveLength(15);
+    expect(lines.filter((line) => line.startsWith('retired '))).toHaveLength(17);
     expect(lines).toContain(`retired claude-workflow: ${join(fixture.claudeDir, 'workflows', 'council.js')}`);
     expect(lines.at(-1)).toBe(`retirement backups: ${result.backupRoot}`);
     expect(lines).not.toContain('nothing to retire');
@@ -461,7 +466,7 @@ describe('retireLegacyIntegrations — removes only clean assets, backup-first',
     });
     expect(result.failures.map((failure) => failure.surface)).toEqual(['claude-agent']);
     expect(result.kept.map((entry) => entry.surface)).toEqual(['claude-agent']);
-    expect(result.removed).toHaveLength(14);
+    expect(result.removed).toHaveLength(16);
   });
 });
 
@@ -798,9 +803,10 @@ describe('backups', () => {
     const configBackup = readFileSync(join(result.backupRoot, '.codex', 'config.toml'), 'utf8');
     expect(configBackup).toContain('[plugins."genie@automagik"]');
 
-    // Re-downloadable plugin payload: a listing, not the bytes.
+    // Re-downloadable plugin payload: a listing, not the bytes. Three now: the
+    // two plugin-cache generations plus the automagik marketplace bundle cache.
     const manifests = readdirSync(join(result.backupRoot, 'cache-manifests'));
-    expect(manifests).toHaveLength(2);
+    expect(manifests).toHaveLength(3);
     expect(readFileSync(join(result.backupRoot, 'cache-manifests', manifests[0]), 'utf8')).toContain('plugin.json');
 
     // A symlink's recovery material is its target.
@@ -835,5 +841,237 @@ describe('backups', () => {
     expect(readFileSync(backup as string, 'utf8')).toContain('genie@automagik');
     expect(lstatSync(join(outside, 'config.toml')).isFile()).toBe(true);
     expect(readFileSync(join(outside, 'config.toml'), 'utf8')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('codex-role-agent-inventory — the sidecar the role-agent surface never saw', () => {
+  const inventoryPathOf = (fixture: Fixture): string => join(fixture.codexHome, 'agents', '.genie-role-agents.json');
+
+  test('a genie-owned inventory is managed-clean and is removed with its transaction debris', () => {
+    const fixture = makeFixture();
+    write(
+      inventoryPathOf(fixture),
+      `${JSON.stringify({ version: 2, managedBy: 'genie-codex-role-agents', files: {} })}\n`,
+    );
+    for (const debris of [
+      '.genie-role-agents.txn-abc',
+      '.genie-role-agents.committed-cleanup-abc',
+      '.genie-role-agents.prepare-abc',
+      '.genie-role-agents.conflict-abc',
+    ]) {
+      write(join(fixture.codexHome, 'agents', debris, 'marker'), 'x\n');
+    }
+    // A user's own file in the same dir must be untouched.
+    write(join(fixture.codexHome, 'agents', 'mine.toml'), 'name = "mine"\n');
+
+    const { entries } = classifyLegacyIntegrations(homesOf(fixture));
+    expect(statesOf(entries, 'codex-role-agent-inventory')).toEqual([
+      'managed-clean',
+      'managed-clean',
+      'managed-clean',
+      'managed-clean',
+      'managed-clean',
+    ]);
+
+    const result = runLegacyIntegrationRetirement({ homes: homesOf(fixture), log: () => undefined, now: FIXED_NOW });
+    expect(result.removed.filter((entry) => entry.surface === 'codex-role-agent-inventory')).toHaveLength(5);
+    expect(existsSync(inventoryPathOf(fixture))).toBe(false);
+    expect(existsSync(join(fixture.codexHome, 'agents', '.genie-role-agents.txn-abc'))).toBe(false);
+    expect(readFileSync(join(fixture.codexHome, 'agents', 'mine.toml'), 'utf8')).toBe('name = "mine"\n');
+  });
+
+  test('an inventory that cannot prove clean genie ownership is managed-modified and kept', () => {
+    const fixture = makeFixture();
+    write(inventoryPathOf(fixture), '{ "version": 2 }\n');
+    expect(statesOf(classifyLegacyIntegrations(homesOf(fixture)).entries, 'codex-role-agent-inventory')).toEqual([
+      'managed-modified',
+    ]);
+    runLegacyIntegrationRetirement({ homes: homesOf(fixture), log: () => undefined, now: FIXED_NOW });
+    expect(existsSync(inventoryPathOf(fixture))).toBe(true);
+  });
+
+  test("someone else's file at the same name is unmanaged and kept", () => {
+    const fixture = makeFixture();
+    write(inventoryPathOf(fixture), `${JSON.stringify({ managedBy: 'someone-else' })}\n`);
+    expect(statesOf(classifyLegacyIntegrations(homesOf(fixture)).entries, 'codex-role-agent-inventory')).toEqual([
+      'unmanaged',
+    ]);
+    runLegacyIntegrationRetirement({ homes: homesOf(fixture), log: () => undefined, now: FIXED_NOW });
+    expect(existsSync(inventoryPathOf(fixture))).toBe(true);
+  });
+
+  test('a host that never had one classifies absent', () => {
+    const fixture = makeFixture();
+    expect(statesOf(classifyLegacyIntegrations(homesOf(fixture)).entries, 'codex-role-agent-inventory')).toEqual([
+      'absent',
+    ]);
+  });
+});
+
+describe('claude-marketplace-cache — the bundle tree the evidence probe kept reading', () => {
+  const cacheOf = (fixture: Fixture): string => join(fixture.claudeDir, 'plugins', 'marketplaces', 'automagik');
+
+  test('a bundle carrying plugins/genie is managed-clean, removed, and prunes its empty parent', () => {
+    const fixture = makeFixture();
+    write(join(cacheOf(fixture), 'plugins', 'genie', 'plugin.json'), '{}\n');
+    expect(statesOf(classifyLegacyIntegrations(homesOf(fixture)).entries, 'claude-marketplace-cache')).toEqual([
+      'managed-clean',
+    ]);
+    const result = runLegacyIntegrationRetirement({ homes: homesOf(fixture), log: () => undefined, now: FIXED_NOW });
+    expect(result.removed.map((entry) => entry.surface)).toContain('claude-marketplace-cache');
+    expect(existsSync(cacheOf(fixture))).toBe(false);
+  });
+
+  test('a marketplace dir without the genie bundle is managed-modified and kept', () => {
+    const fixture = makeFixture();
+    write(join(cacheOf(fixture), 'README.md'), '# not ours\n');
+    expect(statesOf(classifyLegacyIntegrations(homesOf(fixture)).entries, 'claude-marketplace-cache')).toEqual([
+      'managed-modified',
+    ]);
+    runLegacyIntegrationRetirement({ homes: homesOf(fixture), log: () => undefined, now: FIXED_NOW });
+    expect(existsSync(join(cacheOf(fixture), 'README.md'))).toBe(true);
+  });
+
+  test('a symlink at the marketplace path is unmanaged and kept', () => {
+    const fixture = makeFixture();
+    const checkout = join(fixture.home, 'dev-checkout');
+    mkdirSync(checkout, { recursive: true });
+    link(cacheOf(fixture), checkout);
+    expect(statesOf(classifyLegacyIntegrations(homesOf(fixture)).entries, 'claude-marketplace-cache')).toEqual([
+      'unmanaged',
+    ]);
+    runLegacyIntegrationRetirement({ homes: homesOf(fixture), log: () => undefined, now: FIXED_NOW });
+    expect(readlinkSync(cacheOf(fixture))).toBe(checkout);
+  });
+
+  test('a host that never had one classifies absent', () => {
+    const fixture = makeFixture();
+    expect(statesOf(classifyLegacyIntegrations(homesOf(fixture)).entries, 'claude-marketplace-cache')).toEqual([
+      'absent',
+    ]);
+  });
+});
+
+describe('the full plugin-era surface is retired in one run and never re-retired', () => {
+  test('evidence flips to {codex:false, claude:false} and the second run allocates no backup root', () => {
+    const fixture = makeFixture();
+    populateClean(fixture);
+    write(join(fixture.codexHome, 'agents', '.genie-role-agents.txn-stale', 'marker'), 'x\n');
+    const evidenceHomes = { codexHome: fixture.codexHome, claudeHome: fixture.claudeDir };
+    expect(inspectRuntimeIntegrationEvidence(evidenceHomes)).toMatchObject({ codex: true, claude: true });
+
+    runLegacyIntegrationRetirement({ homes: homesOf(fixture), log: () => undefined, now: FIXED_NOW });
+    expect(inspectRuntimeIntegrationEvidence(evidenceHomes)).toMatchObject({ codex: false, claude: false });
+
+    const backupRootsAfterFirst = readdirSync(join(fixture.genieHome, 'state-backups'));
+    const lines: string[] = [];
+    const second = runLegacyIntegrationRetirement({
+      homes: homesOf(fixture),
+      log: (line) => lines.push(line),
+      now: new Date('2026-08-30T13:00:00.000Z'),
+    });
+    expect(second.removed).toEqual([]);
+    expect(second.backupRootUsed).toBe(false);
+    expect(lines).toContain('nothing to retire');
+    expect(readdirSync(join(fixture.genieHome, 'state-backups'))).toEqual(backupRootsAfterFirst);
+  });
+});
+
+describe('sidecar-less skill directories', () => {
+  test('a curated-lane dir with no sidecar is reported by path as kept and never removed', () => {
+    const fixture = makeFixture();
+    const orphan = join(fixture.codexHome, 'skills', '.curated', 'sidecar-less');
+    write(join(orphan, 'SKILL.md'), '# orphan\n');
+
+    const { entries } = classifyLegacyIntegrations(homesOf(fixture));
+    expect(entries.filter((entry) => entry.surface === 'codex-legacy-curated-skill')).toEqual([
+      {
+        surface: 'codex-legacy-curated-skill',
+        path: orphan,
+        state: 'unmanaged',
+        detail: 'no .genie-sync.json sidecar — ownership unprovable, left in place',
+      },
+    ]);
+
+    const lines: string[] = [];
+    runLegacyIntegrationRetirement({ homes: homesOf(fixture), log: (line) => lines.push(line), now: FIXED_NOW });
+    expect(lines).toContain(
+      `kept (unmanaged) codex-legacy-curated-skill: ${orphan} — no .genie-sync.json sidecar — ownership unprovable, left in place`,
+    );
+    expect(readFileSync(join(orphan, 'SKILL.md'), 'utf8')).toBe('# orphan\n');
+  });
+});
+
+describe('writeJsonDocument durability', () => {
+  // A 0o500 parent is the portable way to make the staged write fail; root
+  // ignores the mode bits, so the fault cannot be induced there.
+  test.skipIf(process.getuid?.() === 0)(
+    'a failed rewrite leaves the original bytes byte-identical and no staging residue',
+    () => {
+      const fixture = makeFixture();
+      const settingsPath = join(fixture.claudeDir, 'settings.json');
+      const original = `${JSON.stringify({ model: 'opus', enabledPlugins: { 'genie@automagik': true } }, null, 2)}\n`;
+      write(settingsPath, original);
+      // The write is staged in the target's own directory, so a read-only parent
+      // is the one fault that reaches production identically: ENOSPC, EIO and a
+      // kill all land in the same catch.
+      chmodSync(fixture.claudeDir, 0o500);
+      let result: ReturnType<typeof runLegacyIntegrationRetirement>;
+      try {
+        result = runLegacyIntegrationRetirement({ homes: homesOf(fixture), log: () => undefined, now: FIXED_NOW });
+      } finally {
+        chmodSync(fixture.claudeDir, 0o700);
+      }
+
+      expect(result.failures.map((failure) => failure.surface)).toEqual(['claude-enabled-plugin']);
+      expect(readFileSync(settingsPath, 'utf8')).toBe(original);
+      expect(readdirSync(fixture.claudeDir).filter((name) => name.includes('genie-staging'))).toEqual([]);
+    },
+  );
+
+  test('a successful rewrite commits by rename and leaves no staging sibling', () => {
+    const fixture = makeFixture();
+    const settingsPath = join(fixture.claudeDir, 'settings.json');
+    write(settingsPath, `${JSON.stringify({ model: 'opus', enabledPlugins: { 'genie@automagik': true } }, null, 2)}\n`);
+    chmodSync(settingsPath, 0o640);
+    runLegacyIntegrationRetirement({ homes: homesOf(fixture), log: () => undefined, now: FIXED_NOW });
+    expect(JSON.parse(readFileSync(settingsPath, 'utf8'))).toEqual({ model: 'opus', enabledPlugins: {} });
+    // The user's own mode survives the republish.
+    expect(lstatSync(settingsPath).mode & 0o777).toBe(0o640);
+    expect(readdirSync(fixture.claudeDir).filter((name) => name.includes('genie-staging'))).toEqual([]);
+  });
+});
+
+describe('the surface roster', () => {
+  test('every declared surface is classified, and the roster is the seventeen this module owns', () => {
+    // The list is the contract `classifyLegacyIntegrations` fills in with an
+    // `absent` entry for anything it did not otherwise emit, so a surface added
+    // to the union but not to the array would silently never be reported.
+    expect(LEGACY_INTEGRATION_SURFACES).toEqual([
+      'codex-plugin-registration',
+      'codex-plugin-cache',
+      'codex-role-agent',
+      'codex-role-agent-inventory',
+      'codex-legacy-curated-skill',
+      'claude-plugin-registry',
+      'claude-plugin-cache',
+      'claude-marketplace-registration',
+      'claude-marketplace-cache',
+      'claude-enabled-plugin',
+      'claude-workflow',
+      'claude-agent',
+      'claude-skill',
+      'hermes-plugin-link',
+      'hermes-mcp-server',
+      'hermes-skills-external-dir',
+      'pi-extension-link',
+    ]);
+    expect(LEGACY_INTEGRATION_SURFACES).toHaveLength(17);
+
+    const fixture = makeFixture();
+    const { entries } = classifyLegacyIntegrations(homesOf(fixture));
+    expect([...new Set(entries.map((entry) => entry.surface))].sort()).toEqual([...LEGACY_INTEGRATION_SURFACES].sort());
   });
 });

--- a/src/lib/legacy-integration-retirement.test.ts
+++ b/src/lib/legacy-integration-retirement.test.ts
@@ -528,12 +528,14 @@ describe('content-preserving edits', () => {
     expect(Bun.YAML.parse(text)).toEqual({ models: { default: 'gpt-5' }, skills: null });
   });
 
-  test('the marker literals restated here still exist in the modules that write them', () => {
-    // The two Hermes markers are module-private in their own files, so this is
-    // the drift guard that keeps the classifier and the writer in agreement.
-    expect(readFileSync(join(import.meta.dir, 'hermes-skills-config.ts'), 'utf8')).toContain(
-      "'# genie:managed:skills.external_dirs'",
-    );
+  test('the mcp marker literal restated here still exists in the module that writes it', () => {
+    // `hermes-mcp-config.ts` survives wish `skills-everywhere-b` and still owns
+    // its begin/end pair privately, so this stays the drift guard between that
+    // writer and this classifier. The skills half is gone on purpose: Group 5
+    // deletes `hermes-skills-config.ts`, and pinning a literal to a file that
+    // will not exist is a guard that fails on the deletion rather than on
+    // drift. `HERMES_SKILLS_MARKER` in the retirement module is now the single
+    // source of truth for that marker.
     expect(readFileSync(join(import.meta.dir, 'hermes-mcp-config.ts'), 'utf8')).toContain(
       '# genie:managed:mcp_servers.genie',
     );

--- a/src/lib/legacy-integration-retirement.ts
+++ b/src/lib/legacy-integration-retirement.ts
@@ -49,6 +49,7 @@
  * reporting "installed" and left Claude Code an enabled-but-uninstalled plugin.
  */
 
+import { createHash } from 'node:crypto';
 import {
   type Dirent,
   type Stats,
@@ -67,19 +68,19 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import {
   MANIFEST_NAME,
-  TARGET_NAME,
-  WORKFLOW_MANIFEST_NAME,
-  codexLegacyCuratedDir,
+  PHYSICAL_TREE_IDENTITY_VERSION,
+  type PhysicalTreeEntry,
+  computeDirDigest,
   computeFileDigest,
-  inspectManagedSkillTree,
-  inspectManagedWorkflow,
-  readAgentFilesManifestState,
-  resolveHermesConfigPath,
-} from './agent-sync.js';
-import { fsyncPath, writeAllSync } from './atomic-fs.js';
+  computeLegacyRegularTreeDigest,
+  fsyncPath,
+  physicalEntryKind,
+  readTrimmed,
+  writeAllSync,
+} from './atomic-fs.js';
 import { resolveClaudeDir, resolveCodexDir, resolveHermesHome, resolvePiExtensionsDir } from './genie-home.js';
 import { retireMcpServersGenie } from './hermes-mcp-config.js';
 import { inspectCodexAgentOwnership, removeCodexPluginRegistration } from './runtime-integrations.js';
@@ -223,9 +224,14 @@ const CLAUDE_PLUGIN_ID = 'genie@automagik';
 const CLAUDE_MARKETPLACE_ID = 'automagik';
 
 /**
- * Restated from `hermes-skills-config.ts` (its `MARKER` is module-private).
- * `legacy-integration-retirement.test.ts` asserts the literal still appears in
- * that file, so the two can never drift apart silently.
+ * The single source of truth for the Hermes managed-skills marker.
+ *
+ * It used to be restated from `hermes-skills-config.ts`, with a test asserting
+ * the literal still appeared there. Wish `skills-everywhere-b` Group 5 deletes
+ * that module, and a marker owned by a file that no longer exists is not a
+ * contract. Retirement is the last reader of this marker on disk — every host
+ * that still carries it was written by a release that predates the deletion —
+ * so the definition lives here and the drift guard is retired with the writer.
  */
 const HERMES_SKILLS_MARKER = '# genie:managed:skills.external_dirs';
 
@@ -1198,4 +1204,451 @@ function escapeRegExp(value: string): string {
 
 function errMsg(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+// ============================================================================
+// Absorbed from `agent-sync.ts` — module-private
+// ============================================================================
+//
+// This module is `agent-sync.ts`'s only consumer that survives wish
+// `skills-everywhere-b`, and it is itself deleted two stable releases after
+// that wish ships, so a new shared `src/lib/*.ts` home would outlive its only
+// user (Decision 6). Everything below is a verbatim copy of the classifiers and
+// their transitive leaf helpers with the `export` keyword dropped; the doc
+// comments are preserved as written, including their references to callers that
+// consume the ORIGINAL in `agent-sync.ts`. `MANIFEST_NAME`,
+// `PHYSICAL_TREE_IDENTITY_VERSION` and the digest primitives are NOT copied:
+// they moved to `atomic-fs.ts` with `computeDirDigest`, which outlives this
+// module, and a second definition of the manifest name would be a silent
+// divergence in what counts as a managed directory.
+
+/** Stamped/synced workflow filename. Exported: doctor/uninstall key their checks on it. */
+const TARGET_NAME = 'council.js';
+
+/** Digest-backed ownership record for the stamped council workflow. */
+const WORKFLOW_MANIFEST_NAME = `${TARGET_NAME}.genie-sync.json`;
+
+/** Deterministic physical mode for both stamped council artifacts. */
+const WORKFLOW_FILE_MODE = 0o644;
+
+/** `managedBy` value that certifies a dir as one this engine owns. Exported: single source of truth. */
+const MANAGED_BY = 'genie-agent-sync';
+
+/** Digest stamp for one flat Claude agent file in {@link AgentFilesManifest}. */
+interface AgentFileManifestEntry {
+  digest: string;
+  version: string | null;
+  syncedAt: string;
+}
+
+/** Shared manifest stored at `~/.claude/agents/.genie-sync.json`. */
+interface AgentFilesManifest {
+  managedBy: 'genie-agent-sync';
+  files: Record<string, AgentFileManifestEntry>;
+}
+
+interface ManifestFileSnapshot {
+  path: string;
+  bytes: Buffer;
+  stat: Stats;
+}
+
+type SafeManifestFile = ManifestFileSnapshot &
+  ({ kind: 'managed'; manifest: AgentFilesManifest } | { kind: 'foreign'; manifest: null });
+
+type AgentManifestState =
+  | SafeManifestFile
+  | { kind: 'absent'; path: string }
+  | { kind: 'unsafe'; path: string; reason: string };
+
+interface SyncManifest {
+  managedBy: 'genie-agent-sync';
+  version: string | null;
+  digest: string;
+  syncedAt: string;
+  /** Physical-identity schema for managed directories and stamped workflows. */
+  identityVersion?: typeof PHYSICAL_TREE_IDENTITY_VERSION;
+  /** Stamped workflow target mode; absent from managed-directory manifests. */
+  targetMode?: number;
+}
+
+/**
+ * Retired codex lane (pre-migration): `<codexDir>/skills/.curated`. Codex
+ * provably never loaded it — codex-rs prunes hidden dirs from skill discovery
+ * (`HiddenDirectoryPolicy::Skip`) and marks `$CODEX_HOME/skills` itself
+ * deprecated. Exported so doctor/uninstall can keep checking/cleaning the
+ * legacy location on machines that have not synced since the migration.
+ */
+function codexLegacyCuratedDir(codexDir: string): string {
+  return join(codexDir, 'skills', '.curated');
+}
+
+function readManifest(dir: string): { manifest: SyncManifest; fileDigest: string } | null {
+  try {
+    const content = readFileSync(join(dir, MANIFEST_NAME));
+    const parsed = JSON.parse(content.toString('utf8')) as Partial<SyncManifest>;
+    if (
+      parsed.managedBy === MANAGED_BY &&
+      typeof parsed.digest === 'string' &&
+      /^[a-f0-9]{64}$/.test(parsed.digest) &&
+      (parsed.identityVersion === undefined || parsed.identityVersion === PHYSICAL_TREE_IDENTITY_VERSION)
+    ) {
+      return {
+        manifest: {
+          managedBy: MANAGED_BY,
+          version: parsed.version ?? null,
+          digest: parsed.digest,
+          syncedAt: typeof parsed.syncedAt === 'string' ? parsed.syncedAt : '',
+          ...(parsed.identityVersion === PHYSICAL_TREE_IDENTITY_VERSION
+            ? { identityVersion: PHYSICAL_TREE_IDENTITY_VERSION }
+            : {}),
+        },
+        fileDigest: createHash('sha256').update(content).digest('hex'),
+      };
+    }
+  } catch {
+    // absent, unreadable, or unparsable → treat as unmanaged
+  }
+  return null;
+}
+
+/**
+ * Lightweight, read-only view of the shared agent manifest for external
+ * consumers (doctor). Distinguishes a genie-managed manifest (with its per-file
+ * entries) from foreign / absent / unsafe WITHOUT exposing the raw byte+stat
+ * snapshot. `unsafe` mirrors {@link inspectAgentFilesManifest}'s fail-closed
+ * verdict (symlink, non-regular file, multiple hard links, or unreadable) so a
+ * diagnostic can surface it as a warning instead of silently reporting healthy.
+ */
+type AgentFilesManifestView =
+  | { kind: 'managed'; files: Record<string, AgentFileManifestEntry> }
+  | { kind: 'foreign' }
+  | { kind: 'absent' }
+  | { kind: 'unsafe'; reason: string };
+
+function readAgentFilesManifestState(dir: string): AgentFilesManifestView {
+  const state = inspectAgentFilesManifest(dir);
+  switch (state.kind) {
+    case 'managed':
+      return { kind: 'managed', files: state.manifest.files };
+    case 'foreign':
+      return { kind: 'foreign' };
+    case 'absent':
+      return { kind: 'absent' };
+    default:
+      return { kind: 'unsafe', reason: state.reason };
+  }
+}
+
+function inspectAgentFilesManifest(dir: string): AgentManifestState {
+  const path = join(dir, MANIFEST_NAME);
+  let stat: Stats;
+  try {
+    stat = lstatSync(path);
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ENOENT')) return { kind: 'absent', path };
+    return { kind: 'unsafe', path, reason: `cannot inspect it: ${errMsg(error)}` };
+  }
+  if (stat.isSymbolicLink()) return { kind: 'unsafe', path, reason: 'it is a symlink' };
+  if (!stat.isFile()) return { kind: 'unsafe', path, reason: 'it is not a regular file' };
+  if (stat.nlink !== 1) return { kind: 'unsafe', path, reason: `it has ${stat.nlink} hard links` };
+
+  let bytes: Buffer;
+  try {
+    bytes = readFileSync(path);
+  } catch (error) {
+    return { kind: 'unsafe', path, reason: `cannot read it: ${errMsg(error)}` };
+  }
+  const manifest = parseAgentFilesManifest(bytes);
+  if (manifest === null) {
+    if (isInvalidOrGenieOwnedAgentManifest(bytes)) {
+      return { kind: 'unsafe', path, reason: 'it is invalid JSON or claims Genie ownership with an invalid schema' };
+    }
+    return { kind: 'foreign', path, bytes, stat, manifest: null };
+  }
+  return { kind: 'managed', path, bytes, stat, manifest };
+}
+
+/** Invalid JSON cannot prove foreign ownership; valid JSON is unsafe only when Genie claims it. */
+function isInvalidOrGenieOwnedAgentManifest(bytes: Buffer): boolean {
+  try {
+    const parsed = JSON.parse(bytes.toString('utf8')) as unknown;
+    return (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      !Array.isArray(parsed) &&
+      (parsed as Record<string, unknown>).managedBy === MANAGED_BY
+    );
+  } catch {
+    return true;
+  }
+}
+
+function parseAgentFileManifestEntry(rawEntry: unknown): AgentFileManifestEntry | null {
+  if (typeof rawEntry !== 'object' || rawEntry === null || Array.isArray(rawEntry)) return null;
+  const entry = rawEntry as Record<string, unknown>;
+  if (Object.keys(entry).sort().join('\0') !== ['digest', 'syncedAt', 'version'].join('\0')) return null;
+  if (typeof entry.digest !== 'string' || !/^[a-f0-9]{64}$/.test(entry.digest)) return null;
+  if (
+    entry.version !== null &&
+    (typeof entry.version !== 'string' || !/^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$/.test(entry.version))
+  ) {
+    return null;
+  }
+  if (typeof entry.syncedAt !== 'string') return null;
+  try {
+    if (new Date(entry.syncedAt).toISOString() !== entry.syncedAt) return null;
+  } catch {
+    return null;
+  }
+  return { digest: entry.digest, version: entry.version, syncedAt: entry.syncedAt };
+}
+
+function parseAgentFilesManifest(bytes: Buffer): AgentFilesManifest | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bytes.toString('utf8'));
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return null;
+  const record = parsed as Record<string, unknown>;
+  if (record.managedBy !== MANAGED_BY) return null;
+  if (typeof record.files !== 'object' || record.files === null || Array.isArray(record.files)) return null;
+  if (Object.keys(record).sort().join('\0') !== ['files', 'managedBy'].join('\0')) return null;
+
+  const files: Record<string, AgentFileManifestEntry> = {};
+  for (const [name, rawEntry] of Object.entries(record.files)) {
+    if (!isFlatAgentFilename(name)) return null;
+    const entry = parseAgentFileManifestEntry(rawEntry);
+    if (entry === null) return null;
+    files[name] = entry;
+  }
+  return { managedBy: MANAGED_BY, files };
+}
+
+function isFlatAgentFilename(name: string): boolean {
+  return name === basename(name) && name.endsWith('.md') && name !== '.' && name !== '..';
+}
+
+/**
+ * Return the current v2 physical identity only when the tree still matches its
+ * ownership manifest. An untagged v2 digest is an unambiguous transitional
+ * record. A content-only v1 digest is accepted only when a caller also proves
+ * that the complete current physical tree equals a trusted canonical tree;
+ * destructive orphan/legacy-lane callers intentionally provide no such proof.
+ */
+function acceptedManagedDirPhysicalDigest(
+  dir: string,
+  manifest: SyncManifest,
+  trustedPhysicalDigest?: string,
+): string | null {
+  const physicalDigest = computeDirDigest(dir);
+  if (manifest.identityVersion === PHYSICAL_TREE_IDENTITY_VERSION) {
+    return physicalDigest === manifest.digest ? physicalDigest : null;
+  }
+  // Transitional fixtures/releases could write the v2 digest before adding the
+  // explicit schema tag. Exact v2 equality is unambiguous and safe to accept.
+  if (physicalDigest === manifest.digest) return physicalDigest;
+  const legacyDigest = computeLegacyRegularTreeDigest(dir);
+  return legacyDigest !== null && legacyDigest === manifest.digest && physicalDigest === trustedPhysicalDigest
+    ? physicalDigest
+    : null;
+}
+
+type ManagedSkillTreeState = 'unmanaged' | 'managed-clean' | 'managed-modified' | 'corrupt-metadata';
+
+interface ManagedSkillTreeReport {
+  path: string;
+  state: ManagedSkillTreeState;
+  /** Accepted v2 physical identity captured during classification. */
+  contentDigest?: string;
+  manifestDigest?: string;
+}
+
+/** One ownership classifier shared by sync, doctor-facing callers, and uninstall. */
+function inspectManagedSkillTree(dir: string): ManagedSkillTreeReport {
+  const root = lstatSafe(dir);
+  if (root === null || !root.isDirectory() || root.isSymbolicLink()) return { path: dir, state: 'unmanaged' };
+  const manifestPath = join(dir, MANIFEST_NAME);
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  } catch {
+    return lstatSafe(manifestPath) === null
+      ? { path: dir, state: 'unmanaged' }
+      : { path: dir, state: 'corrupt-metadata' };
+  }
+  if (typeof raw !== 'object' || raw === null || Reflect.get(raw, 'managedBy') !== MANAGED_BY) {
+    return { path: dir, state: 'unmanaged' };
+  }
+  const manifest = readManifest(dir);
+  if (manifest === null) return { path: dir, state: 'corrupt-metadata' };
+  try {
+    const contentDigest = acceptedManagedDirPhysicalDigest(dir, manifest.manifest);
+    return contentDigest === null
+      ? { path: dir, state: 'managed-modified' }
+      : { path: dir, state: 'managed-clean', contentDigest, manifestDigest: manifest.fileDigest };
+  } catch {
+    return { path: dir, state: 'managed-modified' };
+  }
+}
+
+type ManagedWorkflowState = 'unmanaged' | 'managed-clean' | 'managed-modified' | 'corrupt-metadata';
+
+interface ManagedWorkflowReport {
+  targetPath: string;
+  manifestPath: string;
+  state: ManagedWorkflowState;
+  /** Accepted physical identity captured by the ownership read. */
+  targetDigest?: string;
+  manifestDigest?: string;
+  targetMode?: number;
+  manifestMode?: number;
+}
+
+function readWorkflowManifest(path: string): {
+  status: 'missing' | 'valid' | 'corrupt';
+  manifest?: SyncManifest;
+  fileDigest?: string;
+} {
+  const stat = lstatSafe(path);
+  if (stat === null) return { status: 'missing' };
+  if (!stat.isFile() || stat.isSymbolicLink()) return { status: 'corrupt' };
+  try {
+    const content = readFileSync(path);
+    const parsed = JSON.parse(content.toString('utf8')) as Partial<SyncManifest>;
+    if (
+      parsed.managedBy !== MANAGED_BY ||
+      typeof parsed.digest !== 'string' ||
+      !/^[a-f0-9]{64}$/.test(parsed.digest) ||
+      (parsed.version !== null && parsed.version !== undefined && typeof parsed.version !== 'string') ||
+      typeof parsed.syncedAt !== 'string' ||
+      (parsed.identityVersion !== undefined && parsed.identityVersion !== PHYSICAL_TREE_IDENTITY_VERSION) ||
+      (parsed.identityVersion === PHYSICAL_TREE_IDENTITY_VERSION && !isPhysicalMode(parsed.targetMode))
+    ) {
+      return { status: 'corrupt' };
+    }
+    return {
+      status: 'valid',
+      manifest: {
+        managedBy: MANAGED_BY,
+        version: parsed.version ?? null,
+        digest: parsed.digest,
+        syncedAt: parsed.syncedAt,
+        ...(parsed.identityVersion === PHYSICAL_TREE_IDENTITY_VERSION
+          ? { identityVersion: PHYSICAL_TREE_IDENTITY_VERSION, targetMode: parsed.targetMode }
+          : {}),
+      },
+      fileDigest: createHash('sha256').update(content).digest('hex'),
+    };
+  } catch {
+    return { status: 'corrupt' };
+  }
+}
+
+interface PhysicalRegularFileIdentity {
+  kind: 'regular';
+  mode: number;
+  digest: string;
+}
+
+type PhysicalFileIdentity =
+  | { kind: 'absent' }
+  | PhysicalRegularFileIdentity
+  | { kind: 'directory'; mode: number }
+  | { kind: 'symlink'; mode: number; target: string }
+  | { kind: 'other'; mode: number; entry: PhysicalTreeEntry['kind'] }
+  | { kind: 'unreadable'; code: string };
+
+function physicalFileIdentity(path: string): PhysicalFileIdentity {
+  let stat: Stats;
+  try {
+    stat = lstatSync(path);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code ?? 'UNKNOWN';
+    return code === 'ENOENT' ? { kind: 'absent' } : { kind: 'unreadable', code };
+  }
+  const mode = stat.mode & 0o7777;
+  if (stat.isSymbolicLink()) {
+    try {
+      return { kind: 'symlink', mode, target: readlinkSync(path) };
+    } catch (error) {
+      return { kind: 'unreadable', code: (error as NodeJS.ErrnoException).code ?? 'UNKNOWN' };
+    }
+  }
+  if (stat.isDirectory()) return { kind: 'directory', mode };
+  if (!stat.isFile()) return { kind: 'other', mode, entry: physicalEntryKind(stat) };
+  try {
+    return { kind: 'regular', mode, digest: computeFileDigest(path) };
+  } catch (error) {
+    return { kind: 'unreadable', code: (error as NodeJS.ErrnoException).code ?? 'UNKNOWN' };
+  }
+}
+
+function isPhysicalMode(value: unknown): value is number {
+  return Number.isInteger(value) && Number(value) >= 0 && Number(value) <= 0o7777;
+}
+
+/**
+ * Resolve the Hermes `config.yaml` for the live profile the plugin-link lane
+ * targets: the active sticky profile's home when a safe `active_profile` is set,
+ * else the default Hermes home. Mirrors {@link ensureStickyProfileLink}'s
+ * validation so a config write lands in the same home whose plugins/genie link is
+ * converged. An unsafe/invalid profile falls back to the default home (never an
+ * escaped path); the link lane already surfaces the invalid-profile failure.
+ */
+function resolveHermesConfigPath(hermesHome: string): string {
+  return join(resolveHermesProfileHome(hermesHome), 'config.yaml');
+}
+
+function resolveHermesProfileHome(hermesHome: string): string {
+  const active = readTrimmed(join(hermesHome, 'active_profile'));
+  if (active === null || active === '') return hermesHome;
+  // Same guard the sticky-link lane enforces — an invalid/unsafe profile name
+  // must never redirect a write outside the profiles root.
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(active) || active === '.' || active === '..') return hermesHome;
+  const profilesRoot = resolve(hermesHome, 'profiles');
+  const profileRoot = resolve(profilesRoot, active);
+  if (!profileRoot.startsWith(`${profilesRoot}${sep}`)) return hermesHome;
+  return profileRoot;
+}
+
+/** Classify council.js using only its sidecar ownership grant and recorded digest. */
+function inspectManagedWorkflow(targetDir: string): ManagedWorkflowReport {
+  const targetPath = join(targetDir, TARGET_NAME);
+  const manifestPath = join(targetDir, WORKFLOW_MANIFEST_NAME);
+  const ownership = readWorkflowManifest(manifestPath);
+  if (ownership.status === 'missing') return { targetPath, manifestPath, state: 'unmanaged' };
+  if (ownership.status === 'corrupt') return { targetPath, manifestPath, state: 'corrupt-metadata' };
+  const targetIdentity = physicalFileIdentity(targetPath);
+  const manifestIdentity = physicalFileIdentity(manifestPath);
+  const expectedTargetMode =
+    ownership.manifest?.identityVersion === PHYSICAL_TREE_IDENTITY_VERSION
+      ? ownership.manifest.targetMode
+      : WORKFLOW_FILE_MODE;
+  const clean =
+    targetIdentity.kind === 'regular' &&
+    targetIdentity.digest === ownership.manifest?.digest &&
+    targetIdentity.mode === expectedTargetMode &&
+    manifestIdentity.kind === 'regular' &&
+    manifestIdentity.digest === ownership.fileDigest &&
+    manifestIdentity.mode === WORKFLOW_FILE_MODE;
+  return {
+    targetPath,
+    manifestPath,
+    state: clean ? 'managed-clean' : 'managed-modified',
+    ...(clean && targetIdentity.kind === 'regular' && manifestIdentity.kind === 'regular'
+      ? {
+          targetDigest: targetIdentity.digest,
+          manifestDigest: manifestIdentity.digest,
+          targetMode: targetIdentity.mode,
+          manifestMode: manifestIdentity.mode,
+        }
+      : {}),
+  };
+}
+
+function isNodeErrorCode(error: unknown, code: string): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === code;
 }

--- a/src/lib/legacy-integration-retirement.ts
+++ b/src/lib/legacy-integration-retirement.ts
@@ -49,10 +49,11 @@
  * reporting "installed" and left Claude Code an enabled-but-uninstalled plugin.
  */
 
-import { createHash } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import {
   type Dirent,
   type Stats,
+  chmodSync,
   closeSync,
   cpSync,
   existsSync,
@@ -63,6 +64,7 @@ import {
   readFileSync,
   readdirSync,
   readlinkSync,
+  renameSync,
   rmSync,
   rmdirSync,
   unlinkSync,
@@ -83,7 +85,11 @@ import {
 } from './atomic-fs.js';
 import { resolveClaudeDir, resolveCodexDir, resolveHermesHome, resolvePiExtensionsDir } from './genie-home.js';
 import { retireMcpServersGenie } from './hermes-mcp-config.js';
-import { inspectCodexAgentOwnership, removeCodexPluginRegistration } from './runtime-integrations.js';
+import {
+  CODEX_AGENT_INVENTORY_NAME,
+  inspectCodexAgentOwnership,
+  removeCodexPluginRegistration,
+} from './runtime-integrations.js';
 
 // ============================================================================
 // Contract
@@ -94,10 +100,12 @@ export type LegacyIntegrationSurface =
   | 'codex-plugin-registration'
   | 'codex-plugin-cache'
   | 'codex-role-agent'
+  | 'codex-role-agent-inventory'
   | 'codex-legacy-curated-skill'
   | 'claude-plugin-registry'
   | 'claude-plugin-cache'
   | 'claude-marketplace-registration'
+  | 'claude-marketplace-cache'
   | 'claude-enabled-plugin'
   | 'claude-workflow'
   | 'claude-agent'
@@ -111,10 +119,12 @@ export const LEGACY_INTEGRATION_SURFACES: readonly LegacyIntegrationSurface[] = 
   'codex-plugin-registration',
   'codex-plugin-cache',
   'codex-role-agent',
+  'codex-role-agent-inventory',
   'codex-legacy-curated-skill',
   'claude-plugin-registry',
   'claude-plugin-cache',
   'claude-marketplace-registration',
+  'claude-marketplace-cache',
   'claude-enabled-plugin',
   'claude-workflow',
   'claude-agent',
@@ -224,6 +234,25 @@ const CLAUDE_PLUGIN_ID = 'genie@automagik';
 const CLAUDE_MARKETPLACE_ID = 'automagik';
 
 /**
+ * `managedBy` owner of `.genie-role-agents.json`. Restated from
+ * `runtime-integrations.ts`, whose constant is module-private and whose
+ * transaction engine wish `skills-everywhere-b` Group 3 deletes; retirement
+ * outlives the writer, so the literal it classifies on lives here.
+ */
+const CODEX_AGENT_INVENTORY_OWNER = 'genie-codex-role-agents';
+
+/**
+ * Directory prefixes a crashed role-agent transaction leaves in
+ * `<codexHome>/agents/`. Same provenance and same reason as the owner above.
+ */
+const CODEX_AGENT_TRANSACTION_PREFIXES = [
+  '.genie-role-agents.txn-',
+  '.genie-role-agents.committed-cleanup-',
+  '.genie-role-agents.prepare-',
+  '.genie-role-agents.conflict-',
+] as const;
+
+/**
  * The single source of truth for the Hermes managed-skills marker.
  *
  * It used to be restated from `hermes-skills-config.ts`, with a test asserting
@@ -276,6 +305,8 @@ function surfaceRoot(surface: LegacyIntegrationSurface, homes: ResolvedHomes): s
       return pluginCacheFamilyDir(homes.codexHome);
     case 'codex-role-agent':
       return join(homes.codexHome, 'agents');
+    case 'codex-role-agent-inventory':
+      return join(homes.codexHome, 'agents', CODEX_AGENT_INVENTORY_NAME);
     case 'codex-legacy-curated-skill':
       return codexLegacyCuratedDir(homes.codexHome);
     case 'claude-plugin-registry':
@@ -284,6 +315,8 @@ function surfaceRoot(surface: LegacyIntegrationSurface, homes: ResolvedHomes): s
       return pluginCacheFamilyDir(homes.claudeDir);
     case 'claude-marketplace-registration':
       return claudeMarketplaceRegistryPath(homes.claudeDir);
+    case 'claude-marketplace-cache':
+      return claudeMarketplaceCacheDir(homes.claudeDir);
     case 'claude-enabled-plugin':
       return claudeSettingsPath(homes.claudeDir);
     case 'claude-workflow':
@@ -316,6 +349,7 @@ function classifyCodex(homes: ResolvedHomes, entries: LegacyIntegrationEntry[]):
             : 'absent';
     entries.push({ surface: 'codex-role-agent', path: entry.path, state, detail: `role ${entry.state}` });
   }
+  classifyCodexRoleAgentInventory(join(homes.codexHome, 'agents'), entries);
   collectManagedSkillMirrors('codex-legacy-curated-skill', codexLegacyCuratedDir(homes.codexHome), entries);
 }
 
@@ -359,6 +393,7 @@ function classifyClaude(homes: ResolvedHomes, entries: LegacyIntegrationEntry[])
   }
   collectPluginCacheGenerations('claude-plugin-cache', homes.claudeDir, entries);
   entries.push(classifyClaudeMarketplaceRegistration(claudeMarketplaceRegistryPath(homes.claudeDir), homes.genieHome));
+  classifyClaudeMarketplaceCache(homes.claudeDir, entries);
   entries.push(classifyClaudeEnabledPlugin(claudeSettingsPath(homes.claudeDir)));
   entries.push(classifyClaudeWorkflow(join(homes.claudeDir, 'workflows')));
   collectManagedClaudeAgents(join(homes.claudeDir, 'agents'), entries);
@@ -373,6 +408,79 @@ function classifyClaudePluginRegistry(path: string): LegacyIntegrationEntry {
   return pruned.removed === 0
     ? { surface, path, state: 'absent' }
     : { surface, path, state: 'managed-clean', detail: `${pruned.removed} registration entr(y|ies)` };
+}
+
+/**
+ * The Codex role-agent inventory sidecar and its transaction debris.
+ *
+ * `codex-role-agent` classifies only `genie-*.toml`, so the sidecar that names
+ * them — and every `.genie-role-agents.{txn,conflict,prepare,committed-cleanup}-*`
+ * directory a crashed transaction left behind — survived every retirement run.
+ * A host with zero role agents left still carried genie's own inventory file.
+ *
+ * The name is genie's alone (`runtime-integrations.ts` writes it and nothing
+ * else does), so presence at that exact path is the ownership marker; the
+ * `managedBy` owner is what separates clean from unprovable.
+ */
+function classifyCodexRoleAgentInventory(agentsDir: string, entries: LegacyIntegrationEntry[]): void {
+  const surface = 'codex-role-agent-inventory' as const;
+  const path = join(agentsDir, CODEX_AGENT_INVENTORY_NAME);
+  const read = readJsonDocument(path);
+  if (read.kind === 'value') {
+    if (!isPlainObject(read.value)) {
+      entries.push({ surface, path, state: 'managed-modified', detail: 'inventory root is not a JSON object' });
+    } else if (read.value.managedBy === CODEX_AGENT_INVENTORY_OWNER) {
+      entries.push({ surface, path, state: 'managed-clean', detail: 'codex role-agent inventory' });
+    } else if (typeof read.value.managedBy === 'string' && read.value.managedBy !== '') {
+      entries.push({ surface, path, state: 'unmanaged', detail: `managedBy is ${read.value.managedBy}` });
+    } else {
+      entries.push({ surface, path, state: 'managed-modified', detail: 'inventory declares no managedBy owner' });
+    }
+  } else if (read.kind !== 'absent') {
+    entries.push(unreadableEntry(surface, path, read));
+  }
+  for (const child of readdirSafe(agentsDir)) {
+    if (!CODEX_AGENT_TRANSACTION_PREFIXES.some((prefix) => child.name.startsWith(prefix))) continue;
+    const debris = join(agentsDir, child.name);
+    const stat = lstatSafe(debris);
+    if (stat === null) continue;
+    entries.push(
+      stat.isDirectory() && !stat.isSymbolicLink()
+        ? { surface, path: debris, state: 'managed-clean', detail: 'role-agent transaction debris' }
+        : { surface, path: debris, state: 'unmanaged', detail: 'not a physical directory' },
+    );
+  }
+}
+
+/**
+ * `~/.claude/plugins/marketplaces/automagik/` — the marketplace bundle tree
+ * `plugin marketplace add` materialized.
+ *
+ * `claude-plugin-cache` covers `plugins/cache/automagik/genie` and nothing else,
+ * so this tree survived retirement while `inspectRuntimeIntegrationEvidence`
+ * kept reading its `plugins/genie` child as proof the integration is installed —
+ * a host reported "installed" forever. Ownership is that child: a directory
+ * under genie's own marketplace name that carries the genie bundle is provably
+ * ours; one that does not is reported and left alone.
+ */
+function classifyClaudeMarketplaceCache(claudeDir: string, entries: LegacyIntegrationEntry[]): void {
+  const surface = 'claude-marketplace-cache' as const;
+  const path = claudeMarketplaceCacheDir(claudeDir);
+  const stat = lstatSafe(path);
+  if (stat === null) return;
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    entries.push({ surface, path, state: 'unmanaged', detail: 'not a physical directory' });
+    return;
+  }
+  if (lstatSafe(join(path, 'plugins', 'genie')) === null) {
+    entries.push({ surface, path, state: 'managed-modified', detail: 'no plugins/genie bundle under it' });
+    return;
+  }
+  entries.push({ surface, path, state: 'managed-clean', detail: 'automagik marketplace bundle cache' });
+}
+
+function claudeMarketplaceCacheDir(claudeDir: string): string {
+  return join(claudeDir, 'plugins', 'marketplaces', CLAUDE_MARKETPLACE_ID);
 }
 
 function claudeMarketplaceRegistryPath(claudeDir: string): string {
@@ -518,10 +626,22 @@ function collectManagedClaudeAgents(agentsDir: string, entries: LegacyIntegratio
 /**
  * Managed bare-name skill mirrors under a skills parent.
  *
- * A child WITHOUT a `.genie-sync.json` is not a candidate at all and produces no
- * entry: that is the skills.sh channel's own plain copy (or a user's skill), not
- * a plugin-era mirror, and listing every one of them would bury the report.
- * A child WITH one is classified by the shared `inspectManagedSkillTree`.
+ * A child WITH a `.genie-sync.json` is classified by the shared
+ * `inspectManagedSkillTree`.
+ *
+ * A child WITHOUT one is ownership-unprovable, so it is NEVER removed — but
+ * whether it is even worth reporting depends on the parent:
+ *
+ *   - `~/.claude/skills` is where the skills.sh channel writes its own plain
+ *     `--copy` of every shipped skill. A sidecar-less child there is the normal,
+ *     expected shape; emitting an advisory for each would print ~25 `kept` lines
+ *     on every `genie update` and bury the surfaces that matter.
+ *   - `<codexHome>/skills/.curated` is a hidden lane only the plugin-era sync
+ *     ever wrote (Codex itself prunes hidden dirs from discovery, and skills.sh
+ *     does not know the path). A sidecar-less child there is a managed-looking
+ *     directory whose ownership record is gone — exactly the case an operator
+ *     must be told about by path, because retirement will otherwise leave it
+ *     silently forever.
  */
 function collectManagedSkillMirrors(
   surface: 'claude-skill' | 'codex-legacy-curated-skill',
@@ -530,7 +650,17 @@ function collectManagedSkillMirrors(
 ): void {
   for (const child of childDirectories(parent)) {
     const path = join(parent, child.name);
-    if (lstatSafe(join(path, MANIFEST_NAME)) === null) continue;
+    if (lstatSafe(join(path, MANIFEST_NAME)) === null) {
+      if (surface === 'codex-legacy-curated-skill') {
+        entries.push({
+          surface,
+          path,
+          state: 'unmanaged',
+          detail: 'no .genie-sync.json sidecar — ownership unprovable, left in place',
+        });
+      }
+      continue;
+    }
     const inspected = inspectManagedSkillTree(path);
     if (inspected.state === 'managed-clean') {
       entries.push({ surface, path, state: 'managed-clean' });
@@ -763,6 +893,7 @@ function retireEntry(
           detail: `codex config carries no removable registration (${removal.status})`,
         };
       });
+    case 'claude-marketplace-cache':
     case 'codex-plugin-cache':
     case 'claude-plugin-cache':
       // Re-downloadable payload: a file listing is the backup (legacy-v4 rule).
@@ -777,6 +908,14 @@ function retireEntry(
     case 'claude-agent':
       return withBackup(backup, entry, backupObject(backup, entry.path), () => {
         unlinkSync(entry.path);
+        return { changed: true };
+      });
+    case 'codex-role-agent-inventory':
+      // The sidecar is a file; the transaction debris is a directory tree. One
+      // recursive remove covers both, and the `agents` dir itself is never
+      // pruned -- a user's own agent files may still live there.
+      return withBackup(backup, entry, backupObject(backup, entry.path), () => {
+        rmSync(entry.path, { recursive: true, force: true });
         return { changed: true };
       });
     case 'codex-legacy-curated-skill':
@@ -1068,8 +1207,42 @@ function removeClaudeEnabledPlugin(path: string): boolean {
   return true;
 }
 
+/**
+ * Crash-safe in-place rewrite of a user-owned JSON document.
+ *
+ * `known_marketplaces.json` and `settings.json` belong to the user and this
+ * module's whole story is backup-first: a truncating `writeFileSync` that dies
+ * mid-flight -- ENOSPC, EIO, a kill between truncate and write -- would leave a
+ * half-written or empty file and destroy exactly what the backups promise never
+ * to lose. Stage beside the target, write and fsync the staging file, rename
+ * over the target (the commit point), then fsync the directory entry. Every
+ * failure path unlinks the staging file, so a refused write leaves the original
+ * bytes byte-identical and no `.genie-staging-*` residue.
+ *
+ * The staging sibling is required (not a tmpdir file) so the rename is
+ * same-filesystem and therefore atomic.
+ */
 function writeJsonDocument(path: string, value: unknown): void {
-  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+  const staging = join(dirname(path), `.${basename(path)}.genie-staging-${process.pid}-${stagingNonce()}`);
+  try {
+    writeDurableFile(staging, `${JSON.stringify(value, null, 2)}\n`);
+    const mode = lstatSafe(path)?.mode;
+    if (mode !== undefined) chmodSync(staging, mode & 0o7777);
+    renameSync(staging, path);
+  } catch (error) {
+    try {
+      unlinkSync(staging);
+    } catch {
+      // Never mask the write failure with a cleanup failure; a staging file the
+      // caller can see is strictly better than a corrupted target.
+    }
+    throw error;
+  }
+  fsyncPath(dirname(path));
+}
+
+function stagingNonce(): string {
+  return randomBytes(6).toString('hex');
 }
 
 /**

--- a/src/lib/runtime-integrations.test.ts
+++ b/src/lib/runtime-integrations.test.ts
@@ -3613,6 +3613,86 @@ describe('removeCodexPluginRegistration — plugin-era retirement preserves ever
     expect(lstatSync(path).mode & 0o777).toBe(0o600);
   });
 
+  test('a multi-line string body that looks like the genie table never starts a drop', () => {
+    // Shape 1: the fake header lives inside an unrelated operator's multi-line
+    // value. A line-level scanner that ignores multi-line strings reads it as a
+    // real table header, starts dropping, and eats the rest of that value plus
+    // every line up to the next header — destroying a user-owned config.
+    const body = [
+      '[notes]',
+      'text = """',
+      '[plugins."genie@automagik"]',
+      'enabled = true',
+      '"""',
+      '',
+      '# a trailing comment',
+      '[profiles.work]',
+      'model = "gpt-5"',
+      '',
+    ].join('\n');
+    const path = configWith(body);
+    expect(removeCodexPluginRegistration(path)).toMatchObject({ ok: true, status: 'unchanged', removed: [] });
+    expect(readFileSync(path, 'utf8')).toBe(body);
+  });
+
+  test('a multi-line string inside the genie table cannot end its drop early', () => {
+    // Shape 2: the genie table's own value carries a line that looks like a
+    // header. Ending the drop there would leave `enabled = true` and the closing
+    // delimiter behind as orphaned top-level keys, and would mis-scope the
+    // following real table.
+    const path = configWith(
+      [
+        '[plugins."genie@automagik"]',
+        "description = '''",
+        '[profiles.decoy]',
+        'model = "decoy"',
+        "'''",
+        'enabled = true',
+        '',
+        '[profiles.work]  # keep me',
+        'model = "gpt-5"',
+        '',
+      ].join('\n'),
+    );
+    const result = removeCodexPluginRegistration(path);
+    expect(result).toMatchObject({ ok: true, status: 'removed' });
+    expect(result.removed).toEqual(['[plugins."genie@automagik"]']);
+    expect(readFileSync(path, 'utf8')).toBe(['[profiles.work]  # keep me', 'model = "gpt-5"', ''].join('\n'));
+  });
+
+  test('a hooks.state row that only appears inside a multi-line string is not dropped', () => {
+    const body = ['[hooks.state]', 'note = """', '"genie@automagik:session_start" = "approved"', '"""', ''].join('\n');
+    const path = configWith(body);
+    expect(removeCodexPluginRegistration(path)).toMatchObject({ ok: true, status: 'unchanged', removed: [] });
+    expect(readFileSync(path, 'utf8')).toBe(body);
+  });
+
+  test('a triple quote inside a single-line string or a comment opens nothing', () => {
+    const body = [
+      '[notes]',
+      'inline = "a \\"\\"\\" b"  # """ not an opener either',
+      '',
+      '[plugins."genie@automagik"]',
+      'enabled = true',
+      '',
+      '[profiles.work]',
+      'model = "gpt-5"',
+      '',
+    ].join('\n');
+    const path = configWith(body);
+    expect(removeCodexPluginRegistration(path)).toMatchObject({ ok: true, status: 'removed' });
+    expect(readFileSync(path, 'utf8')).toBe(
+      [
+        '[notes]',
+        'inline = "a \\"\\"\\" b"  # """ not an opener either',
+        '',
+        '[profiles.work]',
+        'model = "gpt-5"',
+        '',
+      ].join('\n'),
+    );
+  });
+
   test('an absent config succeeds (nothing to retire); a symlinked one is refused untouched', () => {
     const root = mkdtempSync(join(tmpdir(), 'genie-codex-retire-edge-'));
     expect(removeCodexPluginRegistration(join(root, 'config.toml'))).toMatchObject({ ok: true, status: 'absent' });

--- a/src/lib/runtime-integrations.ts
+++ b/src/lib/runtime-integrations.ts
@@ -2125,6 +2125,68 @@ function isRetiredCodexGenieTable(header: string): boolean {
   );
 }
 
+/** The two TOML multi-line string delimiters, which suspend line-level parsing. */
+type TomlMultilineDelimiter = '"""' | "'''";
+
+/**
+ * Consume one line and report whether it ENDS inside a multi-line string.
+ *
+ * A `"""…"""` (or `'''…'''`) value body is arbitrary text: it can contain a
+ * line that reads exactly like `[plugins."genie@automagik"]` or like any other
+ * table header. Treating such a line as a header would either start dropping in
+ * the middle of an unrelated operator's value or end the genie table's drop
+ * early and leave half its body behind — both silent corruptions of a
+ * user-owned config. Single-line basic/literal strings and `#` comments are
+ * skipped for the same reason: a `"""` inside them opens nothing.
+ */
+function scanTomlLine(line: string, open: TomlMultilineDelimiter | null): TomlMultilineDelimiter | null {
+  let current = open;
+  let index = 0;
+  while (index < line.length) {
+    if (current !== null) {
+      // Only a basic multi-line string honours backslash escapes.
+      if (current === '"""' && line[index] === '\\') {
+        index += 2;
+        continue;
+      }
+      if (line.startsWith(current, index)) {
+        current = null;
+        index += 3;
+        continue;
+      }
+      index += 1;
+      continue;
+    }
+    if (line[index] === '#') return null; // a comment runs to end of line
+    if (line.startsWith('"""', index) || line.startsWith("'''", index)) {
+      current = line.startsWith('"""', index) ? '"""' : "'''";
+      index += 3;
+      continue;
+    }
+    if (line[index] === '"' || line[index] === "'") {
+      index = skipSingleLineTomlString(line, index);
+      continue;
+    }
+    index += 1;
+  }
+  return current;
+}
+
+/** Advance past a single-line basic/literal string; an unterminated one eats the line. */
+function skipSingleLineTomlString(line: string, start: number): number {
+  const quote = line[start];
+  let index = start + 1;
+  while (index < line.length) {
+    if (quote === '"' && line[index] === '\\') {
+      index += 2;
+      continue;
+    }
+    if (line[index] === quote) return index + 1;
+    index += 1;
+  }
+  return line.length;
+}
+
 /**
  * Pure line-level plan: drop every retired genie table (header + body) and every
  * `genie@automagik:` row inside `[hooks.state]`, and keep every other byte.
@@ -2133,14 +2195,21 @@ function isRetiredCodexGenieTable(header: string): boolean {
  * so exactly one separator survives between the neighbours it sat between, and a
  * table dropped at EOF leaves no trailing blank paragraph. The file's original
  * trailing-newline convention is restored by the `endsWith` repair below.
+ *
+ * Lines that begin inside a multi-line string are never read as headers or as
+ * `hooks.state` keys; they are body bytes of whichever table is currently in
+ * scope, and they are kept or dropped with it.
  */
 function planCodexPluginRegistrationRemoval(content: string): { next: string; removed: string[] } {
   const kept: string[] = [];
   const removed: string[] = [];
   let dropping = false;
   let inHooksState = false;
+  let multiline: TomlMultilineDelimiter | null = null;
   for (const line of content.split('\n')) {
-    const header = TOML_TABLE_HEADER.exec(line)?.[1];
+    const insideString = multiline !== null;
+    multiline = scanTomlLine(line, multiline);
+    const header = insideString ? undefined : TOML_TABLE_HEADER.exec(line)?.[1];
     if (header !== undefined) {
       dropping = isRetiredCodexGenieTable(header);
       inHooksState = header === 'hooks.state';
@@ -2152,7 +2221,7 @@ function planCodexPluginRegistrationRemoval(content: string): { next: string; re
       continue;
     }
     if (dropping) continue;
-    if (inHooksState && CODEX_GENIE_HOOK_STATE_KEY.test(line)) {
+    if (!insideString && inHooksState && CODEX_GENIE_HOOK_STATE_KEY.test(line)) {
       removed.push(line.trim());
       continue;
     }


### PR DESCRIPTION
Group 2 of the APPROVED wish `skills-everywhere-b` — **rehomes and retirement hardening, zero deletions**. Every primitive `legacy-integration-retirement.ts` still needs is moved out of the two modules Groups 3 and 5 delete, and the durability/coverage follow-ups Wish A's G2/G3 reviews carried into this wish are closed. `agent-sync.ts` and `codex-activation-persistence.ts` can now be deleted mechanically.

Base: `wish/skills-everywhere-b` @ `6b00a9807`.

## Commits

| sha | subject |
|-----|---------|
| `637f9d296` | `refactor(scripts): rehome validate-wish beside its surviving consumer` (D10) |
| `aa70a7166` | `refactor(lib): rehome the digest and durable-write primitives into atomic-fs` (D2, D4, D9) |
| `27762ebad` | `refactor(retirement): absorb the surviving agent-sync symbols module-private` (D1, D3, D11) |
| `1bfc2c0e4` | `fix(retirement): durable json writes, two new surfaces, toml multi-line safety` (D5, D6, D7, D8) |
| `c3b267cef` | `test(update): expect the new codex-role-agent-inventory surface in convergence` (CI fix) |

---

## D1 — surviving-consumer re-derivation (done first, re-derived at this base)

Every real `agent-sync` import statement in the tree, classified. Command:

```
git grep -n "from '\(\.\.\?/\)*\(lib/\)\?agent-sync\(\.js\|\.ts\)\?'" -- src scripts tests
```

| importer | symbols | disposition |
|---|---|---|
| `src/lib/legacy-integration-retirement.ts:71-81` | `MANIFEST_NAME`, `TARGET_NAME`, `WORKFLOW_MANIFEST_NAME`, `codexLegacyCuratedDir`, `computeFileDigest`, `inspectManagedSkillTree`, `inspectManagedWorkflow`, `readAgentFilesManifestState`, `resolveHermesConfigPath` | **survives Wish B** — the only surviving non-test importer, exactly the nine the plan names. Handled by D2/D3. |
| `src/genie-commands/doctor.ts:21-35` | 13 symbols | doctor.ts survives, but **every one of its 20 use sites sits between `:1255` and `:2171`** — inside the `Codex Genie plugin` / role-agent / hook / Kimi / `agent sync` checks G3 D6 deletes. Verified site-by-site; nothing outside that region touches them. Both digests are available from `atomic-fs.js` after this PR if G3 finds a survivor. |
| `src/genie-commands/uninstall.ts:35-60` | 24 symbols | deleted by G3 D7 (the whole import block leaves with the flat-agent transaction machinery). |
| `src/genie-commands/update.ts:23` | `AgentSyncReport`, `AgentSyncSelection`, `runAgentSync` | deleted by G5. |
| `src/lib/runtime-integrations.ts:25-39` | 14 Codex-fallback / managed-skill-tree symbols | deleted by G5 (the plugin half of that module). `computeDirDigest` and `inspectManagedSkillTree` are in the set and are now available from `atomic-fs.js` / the retirement module. |
| `src/lib/atomic-fs.test.ts:27` | `computeDirDigest` | **re-pointed here** at `./atomic-fs`. |
| test-only importers: `agent-sync.test.ts`, `doctor.test.ts`, `install.test.ts`, `install-promote.test.ts`, `setup.test.ts`, `uninstall.test.ts`, `__tests__/update.test.ts`, `runtime-integrations.test.ts`, `legacy-integration-retirement.test.ts` | — | owned by the group that deletes their subject (G3 D12 / G5). None changed here except `legacy-integration-retirement.test.ts` (subject edited by this PR) and `__tests__/update.test.ts` (the CI fix below). |

**No symbol with an unnamed surviving consumer was found**, so nothing extra was pushed into `atomic-fs.ts` beyond what D2/D4 mandate — with one exception recorded under *Deviations* (`MANIFEST_NAME`).

---

## D2 — verbatim-move proof, `agent-sync.ts` → `atomic-fs.ts`

Both directions, block by block (old file from `git show 6b00a9807:src/lib/agent-sync.ts`, new from `src/lib/atomic-fs.ts`), 15 blocks: the two constants, `computeDirDigest`, `computeExactDirDigest`, `computePhysicalTreeDigest`, `PhysicalTreeEntry`, `byRel`, `normalizePhysicalRelPath`, `physicalEntryKind`, `physicalTreeEntry`, `collectPhysicalTreeEntries`, `updateLengthPrefixed`, `computeLegacyRegularTreeDigest`, `hashFile`, `computeFileDigest`.

```diff
21c21
< function computeExactDirDigest(dir: string): string {
---
> export function computeExactDirDigest(dir: string): string {
44c44
< interface PhysicalTreeEntry {
---
> export interface PhysicalTreeEntry {
61c61
< function physicalEntryKind(stat: Stats): PhysicalTreeEntry['kind'] {
---
> export function physicalEntryKind(stat: Stats): PhysicalTreeEntry['kind'] {
108c108
< function computeLegacyRegularTreeDigest(dir: string): string | null {
---
> export function computeLegacyRegularTreeDigest(dir: string): string | null {
```

**Four changed lines, all `export` keyword additions** so `agent-sync.ts` can import back what it still uses internally. Every other byte — including doc comments — is identical.

## D4 — verbatim-move proof, `codex-activation-persistence.ts` → `atomic-fs.ts`

Same method over 12 blocks (`O_NOFOLLOW`, `BoundedFileRead`, `readBoundedRegularFile`, `fsyncParentDir`, `AtomicWriteOptions`, `atomicWriteFileSync`, `unlinkWithParentFsync`, `backupExistingRegularFile`, `basenameOf`, `timestamp`, `uniqueSuffix`, `errorText`):

```
$ diff d4.old.txt d4.new.txt
$ echo $?
0
```

**Byte-identical, zero changed lines.** The only accommodation is one added line in `atomic-fs.ts` — `const fsConstants = constants;` — so the moved blocks read unchanged against that file's existing `constants` import.

## D3 — verbatim-move proof, `agent-sync.ts` → `legacy-integration-retirement.ts` (module-private)

34 blocks: the 8 absorbed symbols plus their transitive leaf helpers (manifest parsers, physical-identity reader, workflow ownership read, Hermes profile resolver, `isNodeErrorCode`, `isPhysicalMode`). The wish budgeted "~18 leaf helpers"; the real closure is 34 symbols / ~430 lines.

```diff
2c2
< export const TARGET_NAME = 'council.js';
---
> const TARGET_NAME = 'council.js';
5c5
< export const WORKFLOW_MANIFEST_NAME = `${TARGET_NAME}.genie-sync.json`;
---
> const WORKFLOW_MANIFEST_NAME = `${TARGET_NAME}.genie-sync.json`;
11c11
< export const MANAGED_BY = 'genie-agent-sync';
---
> const MANAGED_BY = 'genie-agent-sync';
14c14
< export interface AgentFileManifestEntry {
---
> interface AgentFileManifestEntry {
21c21
< export interface AgentFilesManifest {
---
> interface AgentFilesManifest {
58c58
< export function codexLegacyCuratedDir(codexDir: string): string {
---
> function codexLegacyCuratedDir(codexDir: string): string {
99c99
< export type AgentFilesManifestView =
---
> type AgentFilesManifestView =
105c105
< export function readAgentFilesManifestState(dir: string): AgentFilesManifestView {
---
> function readAgentFilesManifestState(dir: string): AgentFilesManifestView {
235c235
< export type ManagedSkillTreeState = 'unmanaged' | 'managed-clean' | 'managed-modified' | 'corrupt-metadata';
---
> type ManagedSkillTreeState = 'unmanaged' | 'managed-clean' | 'managed-modified' | 'corrupt-metadata';
237c237
< export interface ManagedSkillTreeReport {
---
> interface ManagedSkillTreeReport {
246c246
< export function inspectManagedSkillTree(dir: string): ManagedSkillTreeReport {
---
> function inspectManagedSkillTree(dir: string): ManagedSkillTreeReport {
273c273
< export type ManagedWorkflowState = 'unmanaged' | 'managed-clean' | 'managed-modified' | 'corrupt-metadata';
---
> type ManagedWorkflowState = 'unmanaged' | 'managed-clean' | 'managed-modified' | 'corrupt-metadata';
275c275
< export interface ManagedWorkflowReport {
---
> interface ManagedWorkflowReport {
359c359
<     return { kind: 'regular', mode, digest: hashFile(path) };
---
>     return { kind: 'regular', mode, digest: computeFileDigest(path) };
377c377
< export function resolveHermesConfigPath(hermesHome: string): string {
---
> function resolveHermesConfigPath(hermesHome: string): string {
394c394
< export function inspectManagedWorkflow(targetDir: string): ManagedWorkflowReport {
---
> function inspectManagedWorkflow(targetDir: string): ManagedWorkflowReport {
```

**16 changed lines: 15 `export` keyword drops (module-private is the deliverable) and one call rename** — `hashFile(path)` → `computeFileDigest(path)`, because `hashFile` is now private to `atomic-fs.ts` and `computeFileDigest` is its public name with an identical body. Everything else, doc comments included, is identical.

**No cycle.** `atomic-fs.ts` imports no local module at all (it is the bottom of the graph); `lifecycle-lease.ts` imports only `atomic-fs` + `genie-home`; `legacy-integration-retirement.ts` imports `atomic-fs`, `genie-home`, `hermes-mcp-config`, `runtime-integrations` — never `agent-sync` and never `lifecycle-lease`.

## Public surface: nothing lost

Exported-name diff, base vs head:

```
=== src/lib/agent-sync.ts (< lost, > gained) ===
(empty — zero exports lost, zero gained)

=== src/lib/codex-activation-persistence.ts ===
< AtomicWriteOptions
< BoundedFileRead

=== src/lib/atomic-fs.ts ===
> AtomicWriteOptions              > MANIFEST_NAME                   > atomicWriteFileSync
> BoundedFileRead                 > PHYSICAL_TREE_IDENTITY_VERSION  > computeDirDigest
> PhysicalTreeEntry               > computeExactDirDigest           > computeFileDigest
> computeLegacyRegularTreeDigest  > fsyncParentDir                  > physicalEntryKind
> readBoundedRegularFile          > unlinkWithParentFsync

=== src/lib/legacy-integration-retirement.ts ===
(empty)
```

`agent-sync.ts` re-exports all four public digest symbols, so doctor, uninstall and runtime-integrations are untouched. The two **types** dropped from `codex-activation-persistence.ts` had **zero cross-module importers** at this base (`git grep -n "BoundedFileRead\|AtomicWriteOptions" -- src scripts tests` finds only their definitions and the local uses); a pure re-export with no importer is a knip failure. Both remain exported from `atomic-fs.ts`. This is the one deliberate subtraction from that module's surface and it is called out under *Deviations*.

## D4 acceptance — the four consumers are byte-unchanged

```
$ git diff --stat 6b00a9807..HEAD -- src/lib/install-version-marker.ts src/lib/update-capabilities.ts \
    src/lib/codex-activation.ts src/lib/codex-lifecycle-lease.ts src/genie-commands/codex-rollback.ts \
    src/lib/codex-delivery-evidence.ts
(no output)

$ bun test src/lib/install-version-marker.test.ts src/lib/update-capabilities.test.ts \
    src/lib/codex-activation.test.ts src/lib/codex-lifecycle-lease.test.ts src/lib/codex-delivery-evidence.test.ts
 200 pass  0 fail  525 expect() calls
```

## D6 — `LEGACY_INTEGRATION_SURFACES` is 17, every new surface has four states

`codex-role-agent-inventory` and `claude-marketplace-cache` join the roster. A new `the surface roster` test pins the full seventeen-element array **in order**, asserts `toHaveLength(17)`, and asserts that classification emits an entry for every declared surface (a surface added to the union but not the array would otherwise never be reported).

| surface | `managed-clean` | `managed-modified` | `unmanaged` | `absent` |
|---|---|---|---|---|
| `codex-role-agent-inventory` | genie-owned inventory + 4 transaction-debris dirs, all removed; a user's `mine.toml` in the same dir untouched | `{ "version": 2 }` — no `managedBy` owner; kept on disk | `managedBy: "someone-else"`; kept on disk | fresh fixture |
| `claude-marketplace-cache` | bundle carrying `plugins/genie`, removed | marketplace dir with no genie bundle; `README.md` still there after the run | symlink at the marketplace path; `readlink` unchanged | fresh fixture |

Acceptance, end to end (`the full plugin-era surface is retired in one run and never re-retired`): on the fully populated fixture `inspectRuntimeIntegrationEvidence` is `{codex: true, claude: true}`, **one** retirement run flips it to `{codex: false, claude: false}`, and a second run returns `removed: []`, `backupRootUsed: false`, logs `nothing to retire`, and leaves `state-backups` with exactly the roots the first run created.

The full-host fixture now retires **17** surfaces (was 15): the sidecar `installCodexAgents` already wrote, plus the marketplace bundle cache added to `populateClean`.

## D5 — `writeJsonDocument` durability

Stage beside the target → `writeAllSync` + `fsync` → `chmod` to the target's own mode → `rename` (the commit point) → `fsync` the directory. Every failure path unlinks the staging file and rethrows.

- `a failed rewrite leaves the original bytes byte-identical and no staging residue` — a `0o500` parent makes the staged write fail; `result.failures` names `claude-enabled-plugin`, `settings.json` is byte-identical to the original, and no `*genie-staging*` sibling remains. Skipped under uid 0, where mode bits cannot induce the fault.
- `a successful rewrite commits by rename and leaves no staging sibling` — the key is dropped, the user's `0o640` mode survives the republish, no residue.

## D7 — TOML multi-line strings

`scanTomlLine` tracks `"""` / `'''` state across lines, skipping single-line basic/literal strings and `#` comments; a line that *begins* inside a multi-line string is never read as a table header or as a `hooks.state` key. Four new tests; **three of them fail on the prior implementation** (proved by restoring `git show HEAD:src/lib/runtime-integrations.ts` and re-running):

```
(fail) ... > a multi-line string body that looks like the genie table never starts a drop
(fail) ... > a multi-line string inside the genie table cannot end its drop early
(fail) ... > a hooks.state row that only appears inside a multi-line string is not dropped
 5 pass  3 fail
```

With the fix: `8 pass 0 fail`. Both shapes assert the unrelated tables and comments round-trip **byte-identically**, and the fourth test pins that a triple quote inside a single-line string or a comment opens nothing.

## D8 — sidecar-less skill-dir advisory

A child with no `.genie-sync.json` is now reported by path as `kept (unmanaged) … — no .genie-sync.json sidecar — ownership unprovable, left in place`, and never removed — **in the `.curated` lane only**. That hidden lane is plugin-era-exclusive (Codex prunes hidden dirs from discovery; skills.sh does not know the path), so a sidecar-less child there is genuinely managed-looking. The same rule is deliberately *not* applied under `~/.claude/skills`, where the skills.sh channel writes exactly that shape for all 25 shipped skills — an advisory per skill would print ~25 `kept` lines on every `genie update` and bury the surfaces that matter. The existing `a skills.sh copy is not a mirror candidate at all` test still passes unchanged.

## D9 — `SCAN_EXEMPTIONS` is content-anchored

The key was `src/lib/agent-sync.ts:4962`; this PR's move alone shifted it to `:4827`. A drifted line key **fails open** — the exemption silently stops matching and the offender reappears with no link to the move. The entry is now `{ file, call, anchor, reason }`: the whitespace-normalized `mkdirSync(before, { recursive: true })` call plus the anchor `const before = join(transactionDir, 'before');` that pins which call it is. A new test, `every SCAN_EXEMPTIONS entry still matches exactly one real call site`, makes a stale entry **fail closed**. Mutation-proved: corrupting the anchor produces `error: stale SCAN_EXEMPTIONS entries — re-point or delete them` and `6 pass / 2 fail`. The `atomicWriteFileSync` pin in the hand-maintained list follows the call from `codex-activation-persistence.ts` to `atomic-fs.ts`.

## D10 — `scripts/validate-wish.ts`, the exact two-line import delta

```
$ diff plugins/genie/scripts/src/validate-wish.ts scripts/validate-wish.ts
42,43c42,43
< import { readBoundedWishFile, extractLegacyStatusValue, extractStatusCell } from '../../../../src/lib/wish-status.js';
< import wishTemplate from '../../../../skills/wish/templates/wish-template.md' with { type: 'text' };
---
> import { readBoundedWishFile, extractLegacyStatusValue, extractStatusCell } from '../src/lib/wish-status.js';
> import wishTemplate from '../skills/wish/templates/wish-template.md' with { type: 'text' };

$ diff plugins/genie/scripts/src/wish-template-text.d.ts scripts/wish-template-text.d.ts
$ echo $?
0
```

Exactly the two specifiers the depth change forces, no other hunk; the `.d.ts` is byte-identical. `scripts/wishes-lint.ts:19` now imports `./validate-wish.js`. The plugin-side original and its built artifacts are untouched. `bun run wishes:lint` → `OK (84 files scanned, 0 broken brainstorm links, template validator green)`.

## D11 — Hermes marker source-lock

`HERMES_SKILLS_MARKER` is now the retirement module's own definition. Its drift guard pinned the literal inside `hermes-skills-config.ts`, which G5 deletes — a guard that fails on the deletion rather than on drift is not a contract. The `hermes-mcp-config.ts` half of that test stays, since that module survives.

---

## Validation

| gate / test | result |
|---|---|
| `bun run check:fast` (typecheck, lint, dead-code, skills:lint, wishes:lint, complexity-budget, council-workflow, hook-bundles, orca-bundle, hook-budgets, hook-content, plugin-executables, plugin-skills) | **green** |
| `bun run dead-code` (knip) | **clean, no output** |
| `bun run lint:complexity-budget` | `OK: budget intact` — 3/7 warnings, max 37/42, all pre-existing (`doctor.ts:2606`, `orca-orchestration-adapter.ts:789`, `doctor.ts:941`) |
| `bun test src/lib/legacy-integration-retirement.test.ts` | 38 pass / 0 fail (was 25) |
| `bun test src/lib/atomic-fs.test.ts` | 30 pass / 0 fail (was 23) |
| `bun test src/lib/agent-sync.test.ts` | 240 pass / 0 fail |
| `bun test src/lib/genie-home-permissions.test.ts` | 8 pass / 0 fail (was 7) |
| `bun test scripts/wishes-lint.test.ts` | green (in the 89-pass batch) |
| `bun test src/lib/install-version-marker.test.ts src/lib/update-capabilities.test.ts src/lib/codex-activation.test.ts src/lib/codex-lifecycle-lease.test.ts src/lib/codex-delivery-evidence.test.ts` | 200 pass / 0 fail |
| `bun test src/genie-commands/__tests__/update.test.ts` | 212 pass / 0 fail |
| `bun test src/lib/runtime-integrations.test.ts -t "removeCodexPluginRegistration"` | 8 pass / 0 fail |
| `bun test src/lib/runtime-integrations.test.ts -t "installCodexAgents"` | 41 pass / 0 fail |
| `bun test src/lib/runtime-integrations.test.ts -t "evidence"` | 8 pass / 0 fail |

**Not run locally, by host policy (recorded in the wish's own gotchas and this session's brief):** the full `bun test` / `bun run check` — the suite OOMs this host (exit 137, pre-existing `Worker` tests), and `src/lib/runtime-integrations.test.ts` unfiltered is one of the offenders, so it was run under `-t` filters covering every describe this PR touches.

### Full CI gate

`ci.yml` only triggers on PRs into `main`/`dev`, so it does not fire on a PR into a wish branch. It was therefore dispatched explicitly against this ref (`workflow_dispatch` is read-only).

- **Run [33427610497](https://github.com/automagik-dev/genie/actions/runs/33427610497) — FAILED**, one test: `runManualUpdateConvergence … > a fresh record: pass one retires every surface, pass two is a byte-for-byte no-op`. `src/genie-commands/__tests__/update.test.ts:4389` pins the exact sorted surface list one convergence pass retires, and its fixture's `~/.codex/agents` carries the `.genie-role-agents.json` sidecar the new `codex-role-agent-inventory` surface now removes. That file is outside the group's Validation set and the full suite cannot be run on this host, so CI is what caught it. Fixed in `c3b267cef` (one list entry). Committed with the documented `SKIP_CI_CHECK=1` CI-fix override, since the pre-commit hook blocks while branch CI is red.
- **Run [33428101629](https://github.com/automagik-dev/genie/actions/runs/33428101629) — SUCCESS**, all seven jobs green: `Unit (build + typecheck + lint + dead-code + test)`, `Quality Gate (typecheck + lint + test)`, `E2E (v5 lifecycle)`, `Codex Plugin Smoke (black-box)`, `Skills Inventory Parity (skills.sh --list)`, `Secrets Scan (GitGuardian)`, `Action Pin Resolvability`.
- `Build Tarballs` (all four platforms) passed on the PR event itself.

---

## Deviations from the plan

1. **`MANIFEST_NAME` is imported from `atomic-fs.ts`, not copied into the retirement module.** Decision 6 lists it among the eight absorbed symbols. It could not stay only in `agent-sync.ts`: `computeDirDigest` is *defined* in terms of it (it is the always-excluded entry), so the constant had to travel to `atomic-fs.ts` with the digest — and `atomic-fs.ts` outlives the retirement module. A module-private second definition of `'.genie-sync.json'` would be two sources of truth for what counts as a managed directory, drifting silently into a wrong digest. `PHYSICAL_TREE_IDENTITY_VERSION` travelled for the same reason. The other seven symbols are module-private exactly as written.
2. **`BoundedFileRead` / `AtomicWriteOptions` are not re-exported from `codex-activation-persistence.ts`.** The AC asks for no public symbol lost from that module this wave; keeping them would break `bun run dead-code`, which the same AC requires clean. Zero modules outside that file imported either type at this base, so no consumer loses anything, and both are exported from `atomic-fs.ts`.
3. **`scripts/validate-wish.ts` and `scripts/wish-template-text.d.ts` are added to `biome.json`'s ignore list.** A verbatim copy of a file living under the already-ignored `plugins/genie/scripts` fails root biome with four real lint errors plus formatter and import-order diffs. Formatting the copy would destroy the exact-two-line-delta contract; formatting the original is forbidden this wave. Ignoring the mirror exactly as its source is ignored keeps both invariants, and the `diff` above is the parity guard.
4. **D8's advisory is scoped to the `.curated` lane** rather than every skills parent — rationale above; applying it under `~/.claude/skills` would print an advisory for every skills.sh-installed skill on every update.
5. **D5 changes a failure mode:** an unwritable *parent directory* now fails the JSON rewrite where a truncating `writeFileSync` could previously still complete it. Atomic rename requires a writable directory, and every other durable writer in this repo already stages in the target's directory. The failure is reported per-surface with the original bytes intact, which is the module's contract.
6. **D3's closure is larger than budgeted:** 34 symbols / ~430 lines rather than "~18 leaf helpers". Every one is in the transitive closure of the eight absorbed symbols; none is unused (verified by biome and by `bun run dead-code`).
7. **One file outside the plan's G2 worklist changed:** `src/genie-commands/__tests__/update.test.ts`, by one list entry, because D6's new surface is retired by a convergence path that test pins exactly. No production code outside the group's ownership was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKqeXSyZMD8YmQtk4vtXFZ
