### PR TITLE
docs(wish): group 7 proof — wish-level evidence for skills-everywhere-b

### DIFF
--- a/.genie/wishes/skills-everywhere-b/qa/20260901.md
+++ b/.genie/wishes/skills-everywhere-b/qa/20260901.md
@@ -25,7 +25,7 @@ Nothing is inferred from a group PR. Criteria that cannot be proven pre-merge ar
 | **C9** — `ruleset-main.json` committed, Decision 9 records the gap | ✅ **MET** | [C9](#c9--branch-protection-evidence) |
 | **C11** — toolchain | ✅ **MET** locally for every runnable leg | [C11](#c11--buildrelease-toolchain) |
 | **C11 (4-platform matrix leg)** | ⏳ **post-merge acceptance** — `build-tarballs.yml` on the merge commit | [Post-merge](#post-merge-acceptance) |
-| **C-G** — `plugins/genie` only Orca-owned; gate green | ✅ **MET** — 105 hits, all in three named classes; `check:fast` green | [C-G](#c-g--pluginsgenie-references--the-gate) |
+| **C-G** — `plugins/genie` only Orca-owned; gate green | ✅ **MET** — 105 hits, all in three named classes; `check:fast` green locally and the **full gate green in CI on the measured head** (run 33455733167) | [C-G](#c-g--pluginsgenie-references--the-gate) |
 | **C-R4** — fresh-host install/uninstall | ✅ **MET** — 57 homes recorded and 57 measured; 1,425 dirs removed; **zero** genie skill dirs left; record gone; foreign skills byte-identical | [C-R4](#c-r4--fresh-host-installuninstall-cycle) |
 | **C-A** — Wish A `SHIPPED` | ✅ **MET** | [C-A](#c-a--wish-a-closure) |
 
@@ -525,8 +525,12 @@ check:fast: typecheck && lint && dead-code && skills:lint && wishes:lint && lint
 which OOMs this host at exit 137 on pre-existing `Worker` tests): `check:fast` covers all seven static
 gates locally, and the full test gate is the named CI run below.
 
-> **Full-gate CI leg:** `Quality Gate (typecheck + lint + test)` — see
-> [post-merge / CI acceptance](#post-merge-acceptance) for the run id on this branch.
+> **Full-gate CI leg: green.** `Quality Gate (typecheck + lint + test)` **and**
+> `Unit (build + typecheck + lint + dead-code + test)` both succeeded in run
+> **[33455733167](https://github.com/automagik-dev/genie/actions/runs/33455733167)** on the exact
+> measured head `3d56eed7e`, and again in run
+> **[33456983012](https://github.com/automagik-dev/genie/actions/runs/33456983012)** on this branch.
+> Full job lists are pasted [below](#named-ci-runs-for-the-full-gate--both-green-).
 
 ---
 
@@ -944,26 +948,63 @@ Recorded, **not ticked** — each names the run that will prove it.
 
 | Criterion leg | Proven by |
 |---|---|
-| **Full `bun run check`** (its last step is the full `bun test`, which OOMs this host at exit 137 on pre-existing `Worker` tests) | `Quality Gate (typecheck + lint + test)` on `wish/skills-everywhere-b-g7` — run id recorded below |
+| ~~**Full `bun run check`**~~ — **already proven, not post-merge** | Runs **33455733167** (measured head `3d56eed7e`) and **33456983012** (this branch), both success — see below |
 | **C11, four-platform matrix** — `bun run build:binary` green on linux-x64-glibc, linux-arm64-glibc, linux-x64-musl, darwin-arm64 | `build-tarballs.yml` on the merge commit of this wish into `dev`. Only linux-x64-glibc was built locally (pasted under C11). |
 | **C11, `bash scripts/release-guard.sh`** — green *in its CI job* | `release.yml:116` (`guard-trusted-release`) on the first release cut from a head carrying this wish. It fails closed outside Actions by design (exit 3, output pasted above); `release-guard.test.ts` 39 pass is the local substitute. |
 | **C7 live leg** — a candidate `Release publish` run green with `skills-install-smoke` + `release-update-path-smoke` and no Codex dogfood matrix | The dev-channel candidate run fired by the merge of `wish/skills-everywhere-b` into `dev`. G3's release freeze is closed by G6 (both dogfood jobs and their `publish.needs` edge are gone — proven statically under C7). |
 | **QA criterion — plugin-era host retirement** ("a host carrying the full plugin-era surface is fully retired by one `genie update`, second run prints `nothing to retire`") | A real dogfood host on the first dev release carrying this wish. The fresh-host fixture had no plugin-era assets to retire, and correctly printed `nothing to retire` (pasted under C-R4 step 6). |
 | **`version.yml` edits** | `workflow_run` executes the default-branch copy, so G6's edit is inert on `dev` until promoted; evidence is `version-format.test.ts` / `version-ci-staging.test.ts` (50 pass, pasted under C11) plus the first post-promotion bump on `main` (design Risk 15). |
 
-### Named CI run for the full gate
+### Named CI runs for the full gate — both green ✅
 
-<!-- CI-RUN-ANCHOR -->
-_Recorded in the follow-up commit on this branch once the push-triggered run completes._
+The full `bun run check` (its last step is the full `bun test`) is proven in CI, on **two** heads:
+
+| Run | Event | Head | Result |
+|---|---|---|---|
+| **[33455733167](https://github.com/automagik-dev/genie/actions/runs/33455733167)** | `pull_request` (PR #2878, `wish/skills-everywhere-b` → `dev`) | **`3d56eed7e`** — the exact assembled head this document measures | **success** |
+| **[33456983012](https://github.com/automagik-dev/genie/actions/runs/33456983012)** | `workflow_dispatch` on `wish/skills-everywhere-b-g7` | `6a011f62b` — this branch, evidence commit | **success** |
+
+```bash
+gh run view 33455733167 --json displayTitle,conclusion,jobs
+```
+```
+title: feat(wish): skills-everywhere-b — honest pinned install, delete every non-Orca integration
+conclusion: success   at: 2026-09-01T00:40:52Z
+  success  Secrets Scan (GitGuardian)
+  success  Unit (build + typecheck + lint + dead-code + test)      <- the full `bun test`
+  success  E2E (v5 lifecycle)
+  success  Skills Inventory Parity (skills.sh --list)
+  success  Action Pin Resolvability
+  success  Quality Gate (typecheck + lint + test)                  <- the required check
+```
+```bash
+gh run view 33456983012 --json event,headSha,conclusion,jobs
+```
+```
+run 33456983012  event=workflow_dispatch  sha=6a011f62b  conclusion=success  at=2026-09-01T00:59:47Z
+  success  Unit (build + typecheck + lint + dead-code + test)
+  success  Skills Inventory Parity (skills.sh --list)
+  success  Secrets Scan (GitGuardian)
+  success  E2E (v5 lifecycle)
+  success  Action Pin Resolvability
+  success  Quality Gate (typecheck + lint + test)
+```
+
+`ci.yml` triggers on `pull_request: branches: [main, dev]`, so a group PR based on
+`wish/skills-everywhere-b` gets no automatic run; run 33456983012 was raised explicitly with
+`gh workflow run ci.yml --ref wish/skills-everywhere-b-g7`. Run 33455733167 is the more important of
+the two — it is the full gate on the head every measurement in this document was taken from.
 
 ---
 
 ## Deviations and host substitutions
 
-1. **`bun run check` → `bun run check:fast` + a named CI run.** Mandated by the host rule (the full
-   `bun test` OOMs this host at exit 137 on pre-existing `Worker` tests). All seven static gates ran
-   locally and are green; the full test gate is the CI Quality Gate named above. Same substitution
-   G1, G3 and G5 recorded.
+1. **`bun run check` → `bun run check:fast` + two named CI runs.** Mandated by the host rule (the
+   full `bun test` OOMs this host at exit 137 on pre-existing `Worker` tests). All seven static gates
+   ran locally and are green; the full test gate is proven by CI runs **33455733167** (on the exact
+   measured head `3d56eed7e`) and **33456983012** (on this branch), both success. Same substitution
+   G1, G3 and G5 recorded — but unlike theirs, this one names a run on the head the numbers came
+   from, so the substitution costs nothing.
 2. **`bun test` run in targeted batches**, never unfiltered:
    `plugins/genie/orca-runtime.test.ts scripts/orca-manifest-parity.test.ts scripts/orca-bundle-parity.test.ts src/lib/orca-plugin-lifecycle.test.ts`
    (29 pass), `scripts/version-format.test.ts scripts/version-ci-staging.test.ts scripts/release-docs.test.ts`

--- a/.genie/wishes/skills-everywhere-b/qa/20260901.md
+++ b/.genie/wishes/skills-everywhere-b/qa/20260901.md
@@ -1,0 +1,988 @@
+# Group 7 — proof: wish-level evidence for `skills-everywhere-b`
+
+| Field | Value |
+|-------|-------|
+| **Measured on** | 2026-09-01 |
+| **Measured head** | `wish/skills-everywhere-b-g7`, base commit `3d56eed7e` — the assembled wish head (`wish/skills-everywhere-b` with G1–G6 merged) |
+| **Baseline** | `18b85341b` (Wish A merge, PR #2868) |
+| **`origin/dev`** | `6b00a9807` — the merge-base of this branch with `dev` **is** `origin/dev`, so every `git diff origin/dev` below is a pure wish diff with no dev drift |
+| **Agent** | QA (wave 6), session 17ecb3d2 |
+| **Host** | linux-x64-glibc, `bun 1.3.14`, `node v26.7.0`, real `claude` CLI present on PATH |
+
+Every criterion below carries the **exact command** and its **pasted output**, measured on this head.
+Nothing is inferred from a group PR. Criteria that cannot be proven pre-merge are recorded as
+**post-merge acceptance** with the named run that will prove them, and are **not ticked**.
+
+## Verdict summary
+
+| Criterion | Result | Proof |
+|-----------|--------|-------|
+| **C4** — ≥ 20,000 non-test `src/` lines out | ✅ **MET** — 60,189 → **38,308** (**−21,881**, −26 files); target ≤ 40,189 | [C4](#c4--non-test-src-line-delta) |
+| **C5-lite** — no dangling plugin-root token in `skills/**` | ✅ **MET** (grep empty); Decision-7 worklist handed to Wish C by `file:line` | [C5-lite](#c5-lite--skills-token-guard--wish-c-worklist) |
+| **C7** — dogfood matrix gone, six `publish.needs` edges, musl byte-unchanged | ✅ **MET** statically | [C7](#c7--release-publishyml-surgery) |
+| **C7 (live leg)** | ⏳ **post-merge acceptance** — the dev-channel candidate `Release publish` run fired by the merge of this wish into `dev` | [Post-merge](#post-merge-acceptance) |
+| **C8** — Orca untouched, four Orca suites green | ⚠️ **MET with one classified residual** — 29 pass / 0 fail; the diff is **one comment-only hunk** (zero executable bytes) | [C8](#c8--orca-no-diff--orca-suites) |
+| **C9** — `ruleset-main.json` committed, Decision 9 records the gap | ✅ **MET** | [C9](#c9--branch-protection-evidence) |
+| **C11** — toolchain | ✅ **MET** locally for every runnable leg | [C11](#c11--buildrelease-toolchain) |
+| **C11 (4-platform matrix leg)** | ⏳ **post-merge acceptance** — `build-tarballs.yml` on the merge commit | [Post-merge](#post-merge-acceptance) |
+| **C-G** — `plugins/genie` only Orca-owned; gate green | ✅ **MET** — 105 hits, all in three named classes; `check:fast` green | [C-G](#c-g--pluginsgenie-references--the-gate) |
+| **C-R4** — fresh-host install/uninstall | ✅ **MET** — 57 homes recorded and 57 measured; 1,425 dirs removed; **zero** genie skill dirs left; record gone; foreign skills byte-identical | [C-R4](#c-r4--fresh-host-installuninstall-cycle) |
+| **C-A** — Wish A `SHIPPED` | ✅ **MET** | [C-A](#c-a--wish-a-closure) |
+
+> **One HIGH finding, not a criterion failure, found by the C-R4 fresh-host pass:**
+> `genie install --integrations claude|all` now **aborts with an unhandled stack trace** on any host
+> that has the `claude` CLI, because G4 deleted the marketplace manifest the surviving Claude
+> runtime-integration still registers. See **[Finding H1](#finding-h1-high--the-claude-marketplace-registration-outlived-its-payload)**.
+> No src change was made by this group; the disposition is an orchestrator/`final-gate` decision.
+
+---
+
+## C4 — non-test `src/` line delta
+
+**Command (identical on both heads), run at `18b85341b` in a detached worktree and on the wish head:**
+
+```bash
+git ls-files src | grep '\.ts$' | grep -v '\.test\.ts$' | xargs wc -l | tail -1
+```
+
+```
+# baseline — git worktree add --detach <tmp> 18b85341b
+Preparing worktree (detached HEAD 18b85341b)
+HEAD is now at 18b85341b Merge pull request #2868 from automagik-dev/wish/skills-everywhere
+  60189 total          <- matches the wish's recorded baseline exactly
+97                     <- git ls-files src | grep '\.ts$' | grep -v '\.test\.ts$' | wc -l
+
+# wish head 3d56eed7e
+  38308 total
+71
+```
+
+| | Baseline `18b85341b` | Wish head `3d56eed7e` | Delta |
+|---|---|---|---|
+| Non-test `src/**/*.ts` lines | **60,189** | **38,308** | **−21,881** |
+| Non-test `src/**/*.ts` files | 97 | 71 | −26 |
+| C4 target | ≤ 40,189 | **38,308** | **1,881 lines under target** |
+
+**Where the 21,881 lines went:** 17,685 in 29 wholly deleted files, 6,961 shrunk out of 12 surviving
+files, minus 765 added in 3 new surviving leaf modules (`17,685 + 6,961 − 765 = 23,881`; the residual
+2,000 is spread over small growth in the remaining files, e.g. the G1 discovery scan and collision
+snapshot in `skills-installer.ts`).
+
+### Top-10 largest departed files
+
+Derived from the baseline-vs-head file sets (`comm -23`), ranked by their line count **at the baseline**:
+
+| # | File | Lines at `18b85341b` | Deleted by |
+|---|------|---------------------:|-----------|
+| 1 | `src/lib/agent-sync.ts` | 6,733 | G5 |
+| 2 | `src/lib/codex-activation.ts` | 2,158 | G3 |
+| 3 | `src/lib/codex-lifecycle-lease.ts` | 1,068 | G3 |
+| 4 | `src/lib/codex-delivery-evidence.ts` | 957 | G3 |
+| 5 | `src/lib/codex-activation-executor.ts` | 834 | G3 |
+| 6 | `src/lib/hermes-skills-config.ts` | 728 | G5 |
+| 7 | `src/hooks/index.ts` | 610 | G4 |
+| 8 | `src/hooks/handlers/git-freeze-guard.ts` | 498 | G4 |
+| 9 | `src/genie-commands/codex-delivery-repair.ts` | 405 | G3 |
+| 10 | `src/lib/codex-host-observation.ts` | 378 | G3 |
+
+<details>
+<summary>All 29 departed files (17,685 lines)</summary>
+
+```
+6733 src/lib/agent-sync.ts
+2158 src/lib/codex-activation.ts
+1068 src/lib/codex-lifecycle-lease.ts
+ 957 src/lib/codex-delivery-evidence.ts
+ 834 src/lib/codex-activation-executor.ts
+ 728 src/lib/hermes-skills-config.ts
+ 610 src/hooks/index.ts
+ 498 src/hooks/handlers/git-freeze-guard.ts
+ 405 src/genie-commands/codex-delivery-repair.ts
+ 378 src/lib/codex-host-observation.ts
+ 372 src/hooks/handlers/omni-approval.ts
+ 317 src/hooks/handlers/branch-guard.ts
+ 279 src/lib/codex-lifecycle-truth.ts
+ 276 src/genie-commands/codex-delivery.ts
+ 259 src/genie-commands/codex-rollback.ts
+ 237 src/hooks/dispatch-command.ts
+ 214 src/lib/codex-activation-persistence.ts
+ 209 src/term-commands/hook/trust.ts
+ 186 src/hooks/handlers/freshness.ts
+ 156 src/hooks/trust.ts
+ 147 src/lib/codex-doctor-observation.ts
+ 134 src/lib/codex-delivery-evidence.test-support.ts
+ 120 src/hooks/types.ts
+ 104 src/hooks/codex-adapter.ts
+  95 src/hooks/handlers/audit-context.ts
+  86 src/hooks/shell-quoting.ts
+  48 src/lib/codex-release-version.ts
+  45 src/hooks/handlers/identity-inject.ts
+  32 src/hooks/env-identity.ts
+```
+
+</details>
+
+### Largest shrinks among surviving files (`delta baseline head file`)
+
+```
+-2260 4348 2088 src/lib/runtime-integrations.ts
+-1392 3731 2339 src/genie-commands/uninstall.ts
+-1327 2711 1384 src/genie-commands/doctor.ts
+ -713 1183  470 src/genie-commands/setup.ts
+ -601 3840 3239 src/genie-commands/update.ts
+ -244  522  278 src/genie-commands/install.ts
+ -154  237   83 src/genie-commands/update-integrations.ts
+  -61  115   54 src/lib/ordered-lifecycle-leases.ts
+  -18  368  350 src/genie-commands/install-promote.ts
+  -11  174  163 src/lib/interactivity.ts
+  -11 2080 2069 src/lib/install-promotion.ts
+   -4  277  273 src/types/genie-config.ts
+```
+
+### The three files that arrived (765 lines, all planned by G3 deliverable 10)
+
+```
+477 src/lib/delivery-evidence-verify.ts
+134 src/lib/delivery-evidence-verify.test-support.ts
+154 src/lib/release-payload-proof.ts
+```
+
+---
+
+## C5-lite — `skills/` token guard + Wish C worklist
+
+**Guard (must be empty):**
+
+```bash
+git grep -nE 'CLAUDE_PLUGIN_ROOT|LENS_ROOT' -- skills
+```
+```
+(no output; exit 1)
+```
+✅ Wish B leaves nothing under `skills/**` pointing at the deleted plugin root.
+
+**Decision-7 worklist for Wish C** — the enumerated tokens, still exactly the 5 files the plan named:
+
+```bash
+git grep -nE '\$genie:|genie_(engineer|reviewer|fixer|final_gate|scout)|engineer-(trivial|standard|complex)' -- skills
+```
+```
+skills/README.md:8:- Codex plugin: `$genie:brainstorm`, `$genie:wish`, `$genie:review`, `$genie:work`
+skills/README.md:12:The `agents/openai.yaml` starter prompt inside each skill is deliberately selector-free. …
+skills/genie-hacks/references/catalog.md:141:  #    engineer-trivial named role (model/effort set in its agent profile)
+skills/trace/SKILL.md:40:Trace runs through a fresh read-only scout/explorer role … (runtime profile `genie_scout` when installed).
+skills/wish/templates/wish-template.md:66:`engineer-trivial` / low; **2–3** → `engineer-standard` / medium or high;
+skills/wish/templates/wish-template.md:67:**4–6** → `engineer-complex` / high; **7+** → `engineer-complex` plus an
+skills/work/SKILL.md:56:| Deterministic implementation, complexity 0-1 | `engineer-trivial` (`genie_engineer_trivial`) |
+skills/work/SKILL.md:57:| Moderately coupled implementation, complexity 2-3 | `engineer-standard` (`genie_engineer_standard`) |
+skills/work/SKILL.md:58:| High-coupling or stateful implementation, complexity 4+ | `engineer-complex` (`genie_engineer_complex`) |
+skills/work/SKILL.md:59:| Review | `reviewer` (`genie_reviewer`; never the group's engineer) |
+skills/work/SKILL.md:60:| Fix | `fixer` (`genie_fixer`; separate from the reviewer) |
+skills/work/SKILL.md:61:| Final plan or execution gate | `final-gate` (`genie_final_gate`) |
+skills/work/SKILL.md:62:| Bounded read-only discovery | `scout` (`genie_scout`) |
+```
+
+### Worklist handed to Wish C, by `file:line`
+
+| # | Site | What is now false / stale | Owner |
+|---|------|---------------------------|-------|
+| 1 | `skills/README.md:8` | `$genie:<name>` selectors named as "Codex plugin" invocations — the Codex plugin is deleted | Wish C (BANNED-13 + vocabulary mapping) |
+| 2 | `skills/README.md:12` | Same `$genie:<name>` / `$<name>` selector vocabulary | Wish C |
+| 3 | **`skills/README.md:37-38`** | **"`plugins/genie/skills/` is a committed physical mirror of this directory … Never edit the mirror directly" — the mirror was deleted by G4 (`e250b9463`); the sentence is now false.** Named in C5-lite as a required worklist addition. | Wish C |
+| 4 | **`skills/README.md:40-41`** (found by this group, **not** in the plan's worklist) | The "Distribution contract" code block still tells the reader to run `bun scripts/sync-plugin-skills.ts --write` / `--check` — **G4 deleted that script**, so both commands now fail. Same paragraph as #3. `bun run skills:lint` and `bun scripts/fresh-install-smoke.ts` on the following lines still exist. | Wish C |
+| 5 | `skills/genie-hacks/references/catalog.md:141` | `engineer-trivial` named role | Wish C |
+| 6 | `skills/trace/SKILL.md:40` | `genie_scout` runtime profile | Wish C |
+| 7 | `skills/wish/templates/wish-template.md:66-67` | `engineer-trivial` / `engineer-standard` / `engineer-complex` routing table | Wish C |
+| 8 | `skills/work/SKILL.md:56-62` | The whole `genie_*` role-profile mapping table | Wish C |
+
+Sites 3 and 4 are stale-docs only: nothing in `.github/workflows`, `.husky` or `package.json` invokes
+them, and Wish B's scope is explicitly "minimum CLAUDE.md / AGENTS.md edits only" (Decision 12), with
+the `skills/**` rewrite assigned to Wish C. They are recorded here rather than fixed.
+
+---
+
+## C7 — `release-publish.yml` surgery
+
+**(a) Neither dogfood job survives, anywhere in `.github`:**
+
+```bash
+git grep -n "codex-native-dogfood\|codex-dogfood-completeness" -- .github
+```
+```
+(no output; exit 1)
+```
+
+**(b) `publish.needs` is exactly six edges, each with its `if:` guard intact** (`release-publish.yml:1359-1377`):
+
+```yaml
+  publish:
+    name: Publish to GitHub Releases
+    needs:
+      - admit
+      - attest-delivery-evidence
+      - delivery-evidence-compatibility
+      - skills-install-smoke
+      - release-update-path-smoke
+      - stable-release-security-gate
+    if: >-
+      ${{
+        always() &&
+        needs.admit.result == 'success' &&
+        needs.attest-delivery-evidence.result == 'success' &&
+        needs.delivery-evidence-compatibility.result == 'success' &&
+        needs.skills-install-smoke.result == 'success' &&
+        needs.release-update-path-smoke.result == 'success' &&
+        needs.stable-release-security-gate.result == 'success'
+      }}
+```
+
+Seven edges → six; only `codex-dogfood-completeness` left; the six survivors each keep their
+`needs.<job>.result == 'success'` guard. ✅
+
+**(c) musl surfaces byte-unchanged:**
+
+```bash
+git diff --exit-code origin/dev -- .github/workflows/musl-adapter-smoke.yml scripts/run-musl-dogfood.sh
+```
+```
+(no output; exit 0)
+```
+
+**The live leg** — that a real candidate `Release publish` run is green with `skills-install-smoke`
+and `release-update-path-smoke` and no Codex dogfood matrix — cannot be proven pre-merge. Recorded as
+[post-merge acceptance](#post-merge-acceptance).
+
+---
+
+## C8 — Orca no-diff + Orca suites
+
+```bash
+git diff --stat origin/dev -- plugins/genie/orca-* plugins/genie/plugin.json \
+  plugins/genie/references/orca-orchestration.md orca-marketplace.json \
+  scripts/orca-*.ts src/lib/orca-*.ts .github/workflows/orca-plugin-ref.yml
+```
+```
+ scripts/orca-bundle-parity.ts | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+```
+
+**Not empty — classified, and it is comment-only.** Every changed line in the diff, with the file
+markers stripped:
+
+```
+- * tarball, yet it sits outside tsc, biome, knip and the hook-bundle gate, so a
+- * commit that edits only the blob would pass `bun run check`, get attested,
+- * and reach every operator. Provenance proves origin, not correspondence to
+- * reviewed source. This script binds the committed bundle byte-for-byte to
+- * `plugins/genie/orca-entrypoint.ts`, exactly like `hook-bundle-parity.ts`
+- * does for the generated hook executables.
++ * tarball, yet it sits outside tsc, biome and knip, so a commit that edits only
++ * the blob would pass `bun run check`, get attested, and reach every operator.
++ * Provenance proves origin, not correspondence to reviewed source. This script
++ * binds the committed bundle byte-for-byte to
++ * `plugins/genie/orca-entrypoint.ts`.
+```
+
+Every `+`/`-` line begins with ` * ` — the change is entirely inside the module's header comment, and
+**zero executable bytes moved**. It was made by G4 (`e250b9463`) because the old text named
+`hook-bundle-parity.ts`, a script that commit deleted; reverting it would restore a dangling
+reference to a nonexistent gate. Recorded as an accepted, classified C8 residual rather than a
+silent pass.
+
+**The four Orca suites:**
+
+```bash
+bun test plugins/genie/orca-runtime.test.ts scripts/orca-manifest-parity.test.ts \
+  scripts/orca-bundle-parity.test.ts src/lib/orca-plugin-lifecycle.test.ts
+```
+```
+bun test v1.3.14 (0d9b296a)
+
+ 29 pass
+ 0 fail
+ 115 expect() calls
+Ran 29 tests across 4 files. [451.00ms]
+```
+
+---
+
+## C9 — branch-protection evidence
+
+```bash
+git ls-files .genie/wishes/skills-everywhere-b/
+```
+```
+.genie/wishes/skills-everywhere-b/HANDOFF.md
+.genie/wishes/skills-everywhere-b/WISH.md
+.genie/wishes/skills-everywhere-b/ruleset-main.json
+```
+
+The committed ruleset, re-read on this head:
+
+```json
+{"id": 9203218, "name": "main", "target": "branch", "enforcement": "active",
+ "rules": ["deletion", "non_fast_forward", "pull_request", "required_status_checks"]}
+```
+
+`pull_request` carries `required_approving_review_count: 1`, `dismiss_stale_reviews_on_push: true`,
+`require_last_push_approval: true`, `required_review_thread_resolution: true`,
+**`require_extra_approval_for_unattributed_changes: true`** and `allowed_merge_methods: ["merge"]`;
+`required_status_checks` carries `Quality Gate (typecheck + lint + test)` (integration 15368);
+`bypass_actors` are `RepositoryRole 5` (admin) and one Integration.
+
+Decision 9 (`WISH.md:67`) records both what this proves and the accepted actor gap
+(a ruleset cannot distinguish an agent from the human whose `gh` credentials it uses). ✅
+
+---
+
+## C11 — build/release toolchain
+
+```bash
+bun scripts/version.ts --check
+```
+```
+version --check: 3 version file(s), no writes performed
+  • package.json
+  • plugins/genie/orca-plugin.json
+  • plugins/genie/package.json
+
+✅ Every version file is present and bump-ready
+exit=0
+```
+Exactly the three targets C11 names — the deviation the criterion itself records
+(`plugins/genie/package.json` as a third stamp target) and nothing else. ✅
+
+```bash
+bun scripts/release-payload-version.ts --verify-source .
+```
+```
+release-payload-version: OK (verify-source 5.260831.7)
+exit=0
+```
+
+```bash
+bun scripts/fresh-install-smoke.ts
+```
+```
+fresh-install-smoke: OK (25 valid skills, 22 bundled references, Claude variables unset)
+exit=0
+```
+
+```bash
+bun test scripts/version-format.test.ts scripts/version-ci-staging.test.ts scripts/release-docs.test.ts
+```
+```
+ 50 pass
+ 0 fail
+ 781 expect() calls
+Ran 50 tests across 3 files. [373.00ms]
+```
+
+**`bash scripts/release-guard.sh` — fails closed outside GitHub Actions, by design.** Both invocation
+forms, pasted honestly:
+
+```bash
+bash scripts/release-guard.sh
+# release-guard: unknown subcommand '<none>'        exit=64
+
+bash scripts/release-guard.sh guard-trusted-release   # the only CI invocation, release.yml:116
+# release-guard: privileged release workflow must run from trusted refs/heads/main (got '<empty>')
+# exit=3
+```
+
+Its runnable proof — the same substitution G6 recorded — is its own suite, plus a direct read of the
+version-file list it now enumerates (`release-guard.sh:160-168`: `package.json`,
+`plugins/genie/package.json`, and `plugins/genie/orca-plugin.json` only when it changed):
+
+```bash
+bun test scripts/release-guard.test.ts
+```
+```
+ 39 pass
+ 0 fail
+ 81 expect() calls
+Ran 39 tests across 1 file. [2.23s]
+```
+
+**`bash scripts/build-binary.sh` — run in full for one platform** (it is also the C-R4 candidate):
+
+```bash
+bash scripts/build-binary.sh --platform linux-x64-glibc
+```
+```
+fresh-install-smoke: OK (25 valid skills, 22 bundled references, Claude variables unset)
+orca-bundle-parity: OK
+release-payload-version: OK (verify-source 5.260831.7)
+==> [linux-x64-glibc] bun build --compile --target=bun-linux-x64  (v5.260831.7)
+  [81ms]  bundle  283 modules
+ [387ms] compile  …/dist/linux-x64-glibc/genie
+release-payload-version: OK (stamp 5.260831.7)
+fresh-install-smoke: OK (25 valid skills, 22 bundled references, Claude variables unset)
+release-payload-version: OK (verify 5.260831.7)
+fresh-install-smoke: OK (25 valid skills, 22 bundled references, Claude variables unset)
+release-payload-version: OK (verify 5.260831.7)
+==> …/dist/genie-5.260831.7-linux-x64-glibc.tar.gz  (34 MB)
+exit=0
+```
+
+**Payload-member allowlist re-proof** (the release-breaking class G3 and G4 each found in their fix
+loops — re-measured here on the assembled head, over a freshly built tarball):
+
+```bash
+tar -tzf dist/genie-5.260831.7-linux-x64-glibc.tar.gz | sed 's|^\./||' | awk -F/ 'NF>0{print $1}' | sort -u
+```
+```
+LICENSE
+VERSION
+genie
+plugins
+skills
+templates
+```
+```ts
+// src/lib/install-promotion.ts:32
+export const INSTALL_PAYLOAD_MEMBERS = ['LICENSE', 'VERSION', 'genie', 'plugins', 'skills', 'templates'] as const;
+```
+Byte-equal, six members on both sides. ✅
+
+**The four-platform matrix leg** (`bun run build:binary` green on all four platforms) needs the CI
+matrix; recorded as [post-merge acceptance](#post-merge-acceptance).
+
+---
+
+## C-G — `plugins/genie` references + the gate
+
+```bash
+git grep -n "plugins/genie" -- src scripts .github package.json
+```
+
+105 hits. The literal criterion wording is "only Orca-owned lines"; as in G3/G4/G5's amended headline
+greps, that literal form is unattainable without deleting the proofs, so every hit is classified into
+exactly **three** named classes and any fourth class is a regression. There is no fourth class.
+
+### Class (i) — Orca payload, its version stamping and its parity gates (79 hits)
+
+`\.github/workflows/orca-plugin-ref.yml` (8) · `version.yml:15,199,200` (3) ·
+`package.json:10` (the published `files` array) · `scripts/build-binary.sh:120,121` (the two required
+Orca payload files) · `scripts/orca-bundle-parity.ts` (4) · `scripts/orca-manifest-parity.test.ts` (7) ·
+`scripts/release-docs.test.ts:41,45,682,744,745,765,773,862` (8) ·
+`scripts/release-guard.sh:163,166,167` (3) · `scripts/release-guard.test.ts` (5) ·
+`scripts/release-payload-version.{ts,test.ts}` (17) · `scripts/version.ts:15,16,118` (3) ·
+`scripts/version-format.test.ts` (11) · `scripts/version-ci-staging.test.ts` (5) ·
+`src/genie-commands/doctor.ts:1295` and `src/lib/orca-plugin-lifecycle.ts:162,252` (the three dynamic
+`plugins/genie/orca-runtime.js` imports).
+
+### Class (ii) — the shipped payload **directory** (which is now the Orca tree) as a delivery member (13 hits)
+
+`.github/workflows/release-publish.yml:977,981,985` (the update-path smoke stages the payload tree
+into `$GENIE_HOME`) · `scripts/build-delivery-evidence.ts:119` (the tree must be a physical
+directory; `:227` digests it wholesale) · `src/lib/runtime-integrations.ts:374,391,1222`
+(`isBundleRoot` probes `existsSync(join(root,'plugins','genie'))` — bundle-root discovery, re-pointed
+by G3) · `src/genie-commands/__tests__/update-command-publication.test.ts:48` ·
+`src/genie-commands/__tests__/update.test.ts:1502`.
+
+### Class (iii) — negative guards and historical prose about the **deleted** mirror (13 hits)
+
+`scripts/fresh-install-smoke.ts:118` — the smoke **forbids** `plugins/genie/references/` and
+`$GENIE_HOME/plugins/genie` inside any `SKILL.md`; `src/lib/skills-installer.ts:81,490` and
+`skills-installer.test.ts:532` — the comments explaining why the install source is pinned to
+`$GENIE_HOME/skills` and why that path is pruned from the discovery scan, both of which say in so many
+words that the mirror "left with the Claude plugin";
+`src/lib/legacy-integration-retirement.ts:461,476,747,1770` + `legacy-integration-retirement.test.ts:953`
+— retirement surfaces for `plugins/genie` bundles a **previous** Genie wrote onto a real host, which
+must keep naming the path to be able to remove it; `scripts/wishes-lint.ts:14` — the rehome note.
+
+### The gate on this head
+
+```bash
+bun run check:fast
+```
+```
+…
+skills-lint: OK (43 files scanned, 0 missing, 0 resource violations)
+wishes-lint: OK (84 files scanned, 0 broken brainstorm links, template validator green)
+Cognitive-complexity budget report
+Warnings (score > threshold): 2 / 7
+Max observed score:           29 / 42
+Explicit suppressions:        0 / 8
+Retained hotspots (score, location, function):
+  -  29  src/lib/orca-orchestration-adapter.ts:789 parseJsonRejectingDuplicateKeys
+  -  26  src/genie-commands/doctor.ts:765 codexPluginSurfaceChecks
+OK: budget intact.
+orca-bundle-parity: OK
+exit=0
+```
+
+`check` composition on this head, read from `package.json` — the **eight** / **seven** steps the wish
+specifies:
+
+```
+check     : typecheck && lint && dead-code && skills:lint && wishes:lint && lint:complexity-budget && lint:orca-bundle && bun test
+check:fast: typecheck && lint && dead-code && skills:lint && wishes:lint && lint:complexity-budget && lint:orca-bundle
+```
+
+**The full `bun run check` is substituted per the host rule** (its last step is the full `bun test`,
+which OOMs this host at exit 137 on pre-existing `Worker` tests): `check:fast` covers all seven static
+gates locally, and the full test gate is the named CI run below.
+
+> **Full-gate CI leg:** `Quality Gate (typecheck + lint + test)` — see
+> [post-merge / CI acceptance](#post-merge-acceptance) for the run id on this branch.
+
+---
+
+## C-R4 — fresh-host install/uninstall cycle
+
+Run inside a **throwaway fixture**: `HOME` and `GENIE_HOME` were exported **for the child processes
+only** (`env HOME=<fixture> GENIE_HOME=<fixture>/.genie …`), never into the session environment. The
+real `$HOME` was verified untouched afterwards (`find /home/genie/.claude/skills -maxdepth 1 -newermt
+'2026-09-01 00:40'` → empty). `$HOME` below is the fixture root
+`…/scratchpad/fresh-host-home`.
+
+### 1. Candidate tarball, laid out exactly as `install.sh` does
+
+`install.sh` extracts the verified tarball into `$GENIE_HOME/bin/` and `genie install`'s
+`normalizeAuxLayout` then promotes `bin/{plugins,skills,templates}` to the `$GENIE_HOME` root. The
+fixture reproduces that:
+
+```bash
+bash scripts/build-binary.sh --platform linux-x64-glibc     # 34 MB, output pasted under C11
+mkdir -p "$FH/.genie/bin"
+tar -xzpf dist/genie-5.260831.7-linux-x64-glibc.tar.gz -C "$FH/.genie/bin"
+ls -la "$FH/.genie/bin"
+```
+```
+-rw-r--r--  1 genie genie     1066 LICENSE
+-rw-r--r--  1 genie genie       11 VERSION
+-rwxr-xr-x  1 genie genie 96909440 genie
+drwxr-xr-x  3 genie genie     4096 plugins
+drwxr-xr-x 27 genie genie     4096 skills
+drwxr-xr-x  2 genie genie     4096 templates
+```
+
+### 2. Foreign skills planted **before** the install
+
+Three, in two homes, covering both cases the wish separates — a foreign name that must survive, and a
+**colliding** name that must be snapshotted and backed up (C-R3):
+
+```bash
+mkdir -p "$FH/.claude/skills/foreign-tool" "$FH/.claude/skills/quick" "$FH/.config/goose/skills/goose-native"
+# … each gets its own SKILL.md …
+sha256sum "$FH/.claude/skills/foreign-tool/SKILL.md" "$FH/.claude/skills/quick/SKILL.md" \
+          "$FH/.config/goose/skills/goose-native/SKILL.md"
+```
+```
+23e638dab39f60f8ecb7001fe4b4ab48e3986fe56e0fb4d1bd95939ba5638c30  $HOME/.claude/skills/foreign-tool/SKILL.md
+837ddad7a07b10944d2bf28dedb878fb208d40d6868ff0fb1b58307956879b11  $HOME/.claude/skills/quick/SKILL.md      <- collides with our `quick`
+4d98cf9fd3ba494557adfdc60f03ef6d16c266c35ae1869b82e3853b5d095751  $HOME/.config/goose/skills/goose-native/SKILL.md
+```
+
+### 3. Install
+
+```bash
+env HOME="$FH" GENIE_HOME="$FH/.genie" "$FH/.genie/bin/genie" install
+```
+```
+  + plugins: refreshed
+  + skills: refreshed
+  + templates: refreshed
+  ! claude: claude plugin marketplace add $HOME/.genie failed: ✘ Failed to add marketplace:
+    Marketplace file not found at $HOME/.genie/.claude-plugin/marketplace.json      <-- FINDING H1
+skills: installed 25 skill(s) from local:$HOME/.genie/skills into 57 agent dir(s)
+skills: collision: $HOME/.claude/skills/quick (quick) — backed up to
+        $HOME/.genie/state-backups/skills-collision-2026-09-01T00-46-44-705Z
+exit=0
+```
+
+**This one line is the whole point of Wish B's G1**, measured on a real host end-to-end:
+`local:$HOME/.genie/skills` (not `automagik-dev/genie@…`), and **57** agent dirs — not 4.
+
+### 4. Measure the written homes with the dogfood evidence command
+
+```bash
+find "$HOME" -maxdepth 6 -type d -name skills | sort | wc -l
+```
+```
+60
+```
+
+```
+$HOME/.adal/skills            $HOME/.agents/skills          $HOME/.aider-desk/skills
+$HOME/.astrbot/data/skills    $HOME/.augment/skills         $HOME/.autohand/skills
+$HOME/.bob/skills             $HOME/.claude/skills          $HOME/.codeartsdoer/skills
+$HOME/.codebuddy/skills       $HOME/.codeium/windsurf/skills $HOME/.codemaker/skills
+$HOME/.codestudio/skills      $HOME/.commandcode/skills     $HOME/.config/crush/skills
+$HOME/.config/devin/skills    $HOME/.config/goose/skills    $HOME/.config/kimchi/harness/skills
+$HOME/.continue/skills        $HOME/.factory/skills         $HOME/.forge/skills
+$HOME/.genie/skills                                                       <- SOURCE (pruned)
+$HOME/.genie/state-backups/skills-collision-…/.claude/skills              <- COLLISION BACKUP (pruned)
+$HOME/.grok/skills            $HOME/.hermes/skills          $HOME/.iflow/skills
+$HOME/.inferencesh/skills     $HOME/.jazz/skills            $HOME/.junie/skills
+$HOME/.kilocode/skills        $HOME/.kiro/skills            $HOME/.kode/skills
+$HOME/.lingma/skills          $HOME/.mcpjam/skills          $HOME/.minimax/skills
+$HOME/.moxby/skills           $HOME/.mux/skills             $HOME/.neovate/skills
+$HOME/.npm/_npx/ee7d2e9969555a41/node_modules/skills                      <- npx CLI cache (pruned)
+$HOME/.ona/skills             $HOME/.openclaw/skills        $HOME/.openhands/skills
+$HOME/.pi/agent/skills        $HOME/.pochi/skills           $HOME/.posit/assistant/skills
+$HOME/.qoder-cn/skills        $HOME/.qoder/skills           $HOME/.qwen/skills
+$HOME/.reasonix/skills        $HOME/.roo/skills             $HOME/.rovodev/skills
+$HOME/.snowflake/cortex/skills $HOME/.tabnine/agent/skills  $HOME/.terramind/skills
+$HOME/.tinycloud/skills       $HOME/.trae-cn/skills         $HOME/.trae/skills
+$HOME/.vibe/skills            $HOME/.zcode/skills           $HOME/.zencoder/skills
+```
+
+```bash
+# measured homes, minus the source, the collision backup and the npx package cache
+grep -vE "\.genie/skills$|state-backups|node_modules" homes-after-install.txt | wc -l
+```
+```
+57
+```
+
+**C-R1 proven end-to-end: measured 57 === recorded 57**, on a host where
+`KNOWN_AGENT_SKILL_HOMES` matches 4. On the pre-Wish-B channel this record would have said `4`, and a
+record-driven uninstall would have orphaned 25 × 53 = 1,325 directories.
+
+### 5. The record
+
+```bash
+ls -l "$FH/.genie/skills-install.json"
+```
+```
+-rw------- 1 genie genie 341129 Sep  1 00:46 $HOME/.genie/skills-install.json
+```
+```json
+{ "ref": "v5.260831.7",
+  "source": "local:$HOME/.genie/skills",
+  "inventoryCount": 25,
+  "agentDirsCount": 57,
+  "collisions": [ { "dir": "$HOME/.claude/skills/quick", "skill": "quick" } ],
+  "installedAt": "2026-09-01T00:46:51.600Z" }
+```
+Record keys: `ref, source, cliVersion, inventory, agentDirs, dirDigests, collisions, installedAt`.
+First agent dirs, in table-then-scan order: `.claude/skills`, `.agents/skills`,
+`.config/goose/skills`, `.codeium/windsurf/skills` (the known-home floor), then `.adal`,
+`.aider-desk`, `.astrbot/data`, `.augment`, … (the scan). Inventory (25):
+`architecture brainstorm code-quality council docs dream dx-docs fix genie genie-hacks
+genie-orca-review genie-orca-wish genie-orca-work omni perf qa quick refine repo-hygiene report
+review supply-chain trace wish work`.
+
+**C-R3 proven on a real host:** the backup holds the *original foreign* bytes and the live directory
+now holds *our* bytes.
+
+```bash
+sha256sum "$FH/.genie/state-backups/skills-collision-…/.claude/skills/quick/SKILL.md"
+# 837ddad7a07b10944d2bf28dedb878fb208d40d6868ff0fb1b58307956879b11   <- == the pre-install foreign sha
+sha256sum "$FH/.claude/skills/quick/SKILL.md" "$FH/.genie/skills/quick/SKILL.md"
+# 5693413bbb37a78755546985071371cdb250ac6354a21cfb434c2bd457d8bff1  $HOME/.claude/skills/quick/SKILL.md
+# 5693413bbb37a78755546985071371cdb250ac6354a21cfb434c2bd457d8bff1  $HOME/.genie/skills/quick/SKILL.md
+```
+
+### 6. Uninstall
+
+Run under a PTY (the confirmation prompt is `@inquirer/prompts`), answering `y`:
+
+```bash
+printf 'y\n' | script -qec "env HOME=$FH GENIE_HOME=$FH/.genie $FH/.genie/bin/genie uninstall" /dev/null
+```
+```
+⚠ Warning: removing Genie can break current or resumable tasks. …
+✔ Are you sure you want to uninstall Genie CLI? Yes
+
+  + skills.sh channel: removed 1425 recorded skill dir(s) (v5.260831.7)
+  nothing to retire
+Removing genie directory...
+  + Install state removed (state backups preserved)
+
++ Genie CLI uninstalled.
+exit=0
+```
+
+**1,425 = 25 × 57.** The old 4-home record would have removed 100 and orphaned 1,325.
+
+### 7. Post-uninstall proof
+
+**(a) Zero genie skill directories remain anywhere under `$HOME`** — cross-checked against the whole
+25-name inventory, at depth 7 so a deeper home could not hide:
+
+```bash
+for n in architecture brainstorm … wish work; do
+  find "$HOME" -maxdepth 7 -type d -name "$n" -path "*/skills/*"
+done | grep -v state-backups | sort | wc -l
+```
+```
+0
+```
+
+**(b) The 59 remaining `skills` directories are empty shells, foreign content, or the deliberately
+preserved backup** — every non-empty one, listed exhaustively:
+
+```bash
+find "$HOME" -maxdepth 6 -type d -name skills | sort   # 59
+# … then, for each, the entry count and contents; only these four are non-empty:
+1   $HOME/.claude/skills                                          | foreign-tool
+1   $HOME/.config/goose/skills                                    | goose-native
+1   $HOME/.genie/state-backups/skills-collision-…/.claude/skills  | quick
+6   $HOME/.npm/_npx/ee7d2e9969555a41/node_modules/skills          | LICENSE README.md … package.json
+```
+The other 55 are empty directories `skills.sh` created and genie never claimed — uninstall removes
+only the skill directories it recorded, never a home it did not create.
+
+**(c) The record is gone and `$GENIE_HOME` is reduced to the preserved backups:**
+
+```bash
+ls -la "$FH/.genie"; test -e "$FH/.genie/skills-install.json" && echo YES || echo NO
+```
+```
+drwxr-xr-x  3 genie genie 4096 .
+drwx------  3 genie genie 4096 state-backups
+record exists? NO
+```
+
+**(d) Foreign skills survive byte-identical:**
+
+```bash
+sha256sum "$FH/.claude/skills/foreign-tool/SKILL.md" "$FH/.config/goose/skills/goose-native/SKILL.md"
+```
+```
+23e638dab39f60f8ecb7001fe4b4ab48e3986fe56e0fb4d1bd95939ba5638c30  $HOME/.claude/skills/foreign-tool/SKILL.md
+4d98cf9fd3ba494557adfdc60f03ef6d16c266c35ae1869b82e3853b5d095751  $HOME/.config/goose/skills/goose-native/SKILL.md
+```
+Both hashes equal their pre-install values. `$HOME/.claude/skills/quick` — the foreign directory
+`--copy` overwrote — is gone from the live home and its original bytes sit in the collision backup;
+that is the wish's explicit OUT ("Restoring a foreign skill dir that `--copy` overwrote" is not
+implemented, only detected, backed up, recorded and reported).
+
+**C-R4 ✅ MET.**
+
+---
+
+## Group-level residual greps, re-run on the assembled head
+
+Each deletion group's amended headline grep names a fixed set of non-importer classes; G3's
+acceptance explicitly obliges **G7** to re-run its grep "against the same two-class list, not against
+'returns nothing'". All three are re-measured here and none has grown a new class.
+
+**G3 (two classes, 4 hits — unchanged from the G3 review):**
+```bash
+git grep -n "codex-activation\|codex-lifecycle-lease\|codex-delivery\|codex-rollback\|codex-host-observation\|codex-doctor-observation\|codex-lifecycle-truth\|codex-release-version" -- src scripts
+```
+```
+scripts/build-delivery-evidence.ts:123:  digest.update('genie-codex-activation-tree-v1\0');   <- wire contract
+src/genie-commands/setup.test.ts:131:      'codex-activation',                                <- negative guard
+src/genie-commands/setup.test.ts:132:      'codex-lifecycle-lease',                           <- negative guard
+src/lib/release-payload-proof.ts:93:  digest.update('genie-codex-activation-tree-v1\0');      <- wire contract (other side)
+```
+Zero importers; the digest domain separator is byte-identical on both sides, as required.
+
+**G4 (two classes, 2 hits):**
+```bash
+git grep -n "src/hooks\|hook dispatch" -- src scripts package.json
+```
+```
+src/genie-commands/legacy-v4.test.ts:164:  '{\n  "hooks": [{ "command": "genie hook dispatch" }]\n}\n'
+src/lib/claude-settings.test.ts:52:  hooks: { PreToolUse: [{ …, command: 'genie hook dispatch' }] }
+```
+Both are settings fixtures a host installed **before** this wish would carry — exactly what v4-residue
+detection and settings-hook removal must still recognize. No importer of `src/hooks/**` survives.
+
+**G5 (three ratified classes, 26 hits, counts matching the amendment exactly):**
+```bash
+git grep -c "agent-sync" -- src scripts plugins package.json   # total 26
+```
+| Class | Token | Hits |
+|---|---|---|
+| (i) wire contract — the `managedBy` value on real hosts | `genie-agent-sync` | **10** |
+| (ii) wire contract — the published-release-body idempotency marker | `genie-agent-sync-migration-v1` | **14** |
+| (iii) negative guards — `.last-agent-sync` must be absent from `update.ts` | `.last-agent-sync` | **2** |
+
+```bash
+git grep -n "agent-sync" -- src scripts plugins package.json | grep -v "genie-agent-sync" | grep -v "last-agent-sync"
+```
+```
+(no output; exit 1)     <- no fourth class, no stale prose
+```
+
+**And the G1 pin guard:**
+```bash
+git grep -n "automagik-dev/genie@" -- src
+```
+```
+(no output; exit 1)
+```
+
+---
+
+## C-A — Wish A closure
+
+```bash
+grep -n "Status" .genie/wishes/skills-everywhere/WISH.md | head -1
+```
+```
+5:| **Status** | SHIPPED |
+```
+
+The dated correction block is present and names Wish B G1 as the owner of the fix:
+
+```
+381:- **Dated correction (2026-08-31):** C1/C2's premise that `add automagik-dev/genie@v<ver>` pins the
+     release tag is FICTION — skills@1.5.23 ignores the `@ref` suffix and serves the repository
+     default branch … Corrected by Wish B G1 (local-source install from `$GENIE_HOME/skills`).
+383:### Closure correction, part 2 — 2026-08-31 — owned by Wish B Group 1
+385:- **Upstream follow-up (recorded, not filed).** `vercel-labs/skills`: `skills add <repo>@<ref>`
+     silently ignores the `@<ref>` suffix …
+```
+
+Both halves of the correction are now **independently confirmed on a real host** by C-R4 above: the
+production argv names `local:$HOME/.genie/skills` (no `automagik-dev/genie@`), and the reported N is
+the measured 57, not 4. ✅
+
+---
+
+## Finding H1 (HIGH) — the Claude marketplace registration outlived its payload
+
+**Found by the C-R4 fresh-host pass. Not a criterion failure — no wish criterion covers it — but it
+is a release-breaking regression on the assembled head, and it is exactly the class of defect
+(a break invisible to `bun run check`) that Decision 7 and the mandatory importer sweeps exist to
+catch.**
+
+### What breaks
+
+G4 (`e250b9463`) deleted the root `.claude-plugin/marketplace.json` and delisted `.claude-plugin`
+from `INSTALL_PAYLOAD_MEMBERS`, so **no delivered `$GENIE_HOME` can ever contain a marketplace
+manifest again**. But the Claude *runtime integration* that registers one survived G5:
+`installRuntimeIntegrations` (`src/lib/runtime-integrations.ts:1203`) still calls
+`installClaudeIntegration` → `claude plugin marketplace add <bundleRoot>`.
+
+On any host with the `claude` CLI:
+
+- **`genie install` (default `--integrations auto`)** — a yellow `!` failure line on every fresh
+  install; exit code unaffected. Cosmetic but alarming, and it names a file the product deliberately
+  deleted.
+- **`genie install --integrations claude` (and `all`)** — a **documented installer flag**
+  (`README.md:30`, forwarded by `install.sh:821` as `curl … | bash -s -- --integrations claude`) —
+  **aborts with an unhandled error and a raw stack trace**, exit 1. Under `install.sh` that is fatal:
+  `die "genie install finishing failed; installation remains incomplete and retryable" 1`
+  (`install.sh:854`).
+
+Reproduced verbatim in a second throwaway fixture on this head:
+
+```bash
+env HOME="$F2" GENIE_HOME="$F2/.genie" "$F2/.genie/bin/genie" install --integrations claude
+```
+```
+  + plugins: refreshed
+  + skills: refreshed
+  + templates: refreshed
+  ! claude: claude plugin marketplace add $HOME/.genie failed: ✘ Failed to add marketplace:
+    Marketplace file not found at $HOME/.genie/.claude-plugin/marketplace.json
+…
+error: Requested integration failed: claude
+      at runPermittedPostDeliveryIntegrations (/$bunfs/root/genie:45890:13)
+      at installCommand (/$bunfs/root/genie:45919:56)
+Bun v1.3.14 (Linux x64)
+exit=1
+```
+
+The throw is `src/genie-commands/install.ts:185-189` — an explicit selection that reports a failed
+runtime is fatal by design; the design just never anticipated a runtime that can no longer succeed.
+A raw stack trace also violates the wish's own QA criterion *"gone from the CLI surface with a clear
+error, not a stack trace"*.
+
+### That it is wish-introduced, not pre-existing
+
+```bash
+git ls-tree -r --name-only 18b85341b -- .claude-plugin   # .claude-plugin/marketplace.json
+git ls-tree -r --name-only HEAD       -- .claude-plugin   # (empty)
+git log --oneline --diff-filter=D -1 -- .claude-plugin/marketplace.json
+# e250b9463 refactor(hooks): delete the hook runtime and the Claude/Kimi plugin payload
+```
+
+### Why it slipped through
+
+G5 deliverable 3's keep-list for `runtime-integrations.ts` enumerates `IntegrationSelection` + consent
+I/O, `CommandRunner`/`runBoundedIntegrationCommand`, the three retirement-consumed Codex symbols,
+`inspectRuntimeIntegrationEvidence` and the `migrateDeadGenieOtel` seam. **`installRuntimeIntegrations`
+/ `convergeClaudePlugin` / `verifyClaudePhysicalPayload` are not on it.** The group's acceptance
+criterion is "every remaining export is named in the PR with its consumer", which they satisfy
+literally (`install.ts:207` consumes it) — so a live-but-doomed subsystem passed a consumer-existence
+check that was never a reachability check. G2 pulling in the opposite direction is the tell: it added
+a **retirement surface** for `~/.claude/plugins/marketplaces/automagik/` while install still tries to
+create it.
+
+### Why this group did **not** fix it
+
+1. **The fix is not minimal.** The correct fix is deleting the Claude convergence half of
+   `runtime-integrations.ts` (`installRuntimeIntegrations`, `convergeClaudePlugin`,
+   `verifyClaudePhysicalPayload`, `parseClaudePluginState`, `ClaudePayloadVerifier`),
+   `src/genie-commands/update-integrations.ts`'s `refreshUpdatePlugins`, `install.ts`'s whole
+   integration-results block, and their tests — while **keeping** `inspectRuntimeIntegrationEvidence`
+   and `removeRuntimeIntegrations`, which read and remove the very same registration for doctor and
+   retirement. That is a G5-sized deliverable, not a QA patch.
+2. **It changes a contract the orchestrator ratified on 2026-09-01.** The G5 fix-loop ratification
+   defines `genie update --sync-only` as "skills channel → **Claude plugin refresh** → plugin-era
+   retirement". Deleting the refresh step re-opens a ratified decision; that is the orchestrator's
+   call, not the proof group's.
+3. **Reviewer ≠ engineer.** The proof group must not author the change whose evidence it publishes.
+
+### Candidate dispositions (for the orchestrator / `final-gate`)
+
+| # | Disposition | Cost | Note |
+|---|-------------|------|------|
+| A | **Delete the Claude install-convergence half** (matches G5 D3's keep-list) | ~1,200–1,500 lines across ≥6 files incl. tests; must preserve `inspectRuntimeIntegrationEvidence` / `removeRuntimeIntegrations` | The wish's evident intent; needs a ratification note for the `--sync-only` contract |
+| B | **Guard it**: `installRuntimeIntegrations` returns `[]` when the delivered root carries no `.claude-plugin/marketplace.json` | ~5 lines + one test; keeps every export referenced, so `dead-code` stays green | Mirrors `refreshUpdatePlugins`'s existing `installIfAbsent: false` "an absent plugin remains absent" doctrine, but leaves the subsystem as dead weight for Wish C |
+| C | Ship as-is | 0 | **Not recommended** — a documented installer flag hard-fails on every host with the `claude` CLI |
+
+`refreshUpdatePlugins` (the `genie update` path) is **not** affected: it passes
+`installIfAbsent: false`, so an absent plugin stays absent and no marketplace add is attempted.
+The blast radius is `genie install` only.
+
+---
+
+## Post-merge acceptance
+
+Recorded, **not ticked** — each names the run that will prove it.
+
+| Criterion leg | Proven by |
+|---|---|
+| **Full `bun run check`** (its last step is the full `bun test`, which OOMs this host at exit 137 on pre-existing `Worker` tests) | `Quality Gate (typecheck + lint + test)` on `wish/skills-everywhere-b-g7` — run id recorded below |
+| **C11, four-platform matrix** — `bun run build:binary` green on linux-x64-glibc, linux-arm64-glibc, linux-x64-musl, darwin-arm64 | `build-tarballs.yml` on the merge commit of this wish into `dev`. Only linux-x64-glibc was built locally (pasted under C11). |
+| **C11, `bash scripts/release-guard.sh`** — green *in its CI job* | `release.yml:116` (`guard-trusted-release`) on the first release cut from a head carrying this wish. It fails closed outside Actions by design (exit 3, output pasted above); `release-guard.test.ts` 39 pass is the local substitute. |
+| **C7 live leg** — a candidate `Release publish` run green with `skills-install-smoke` + `release-update-path-smoke` and no Codex dogfood matrix | The dev-channel candidate run fired by the merge of `wish/skills-everywhere-b` into `dev`. G3's release freeze is closed by G6 (both dogfood jobs and their `publish.needs` edge are gone — proven statically under C7). |
+| **QA criterion — plugin-era host retirement** ("a host carrying the full plugin-era surface is fully retired by one `genie update`, second run prints `nothing to retire`") | A real dogfood host on the first dev release carrying this wish. The fresh-host fixture had no plugin-era assets to retire, and correctly printed `nothing to retire` (pasted under C-R4 step 6). |
+| **`version.yml` edits** | `workflow_run` executes the default-branch copy, so G6's edit is inert on `dev` until promoted; evidence is `version-format.test.ts` / `version-ci-staging.test.ts` (50 pass, pasted under C11) plus the first post-promotion bump on `main` (design Risk 15). |
+
+### Named CI run for the full gate
+
+<!-- CI-RUN-ANCHOR -->
+_Recorded in the follow-up commit on this branch once the push-triggered run completes._
+
+---
+
+## Deviations and host substitutions
+
+1. **`bun run check` → `bun run check:fast` + a named CI run.** Mandated by the host rule (the full
+   `bun test` OOMs this host at exit 137 on pre-existing `Worker` tests). All seven static gates ran
+   locally and are green; the full test gate is the CI Quality Gate named above. Same substitution
+   G1, G3 and G5 recorded.
+2. **`bun test` run in targeted batches**, never unfiltered:
+   `plugins/genie/orca-runtime.test.ts scripts/orca-manifest-parity.test.ts scripts/orca-bundle-parity.test.ts src/lib/orca-plugin-lifecycle.test.ts`
+   (29 pass), `scripts/version-format.test.ts scripts/version-ci-staging.test.ts scripts/release-docs.test.ts`
+   (50 pass), `scripts/release-guard.test.ts` (39 pass). `src/lib/runtime-integrations.test.ts` was
+   not run unfiltered and `scripts/reconcile-release-assets.test.ts` was skipped (pre-existing local
+   timeout), both per the host rule.
+3. **C8's diff is not empty.** One comment-only hunk, fully quoted and classified above; zero
+   executable bytes.
+4. **C-G's literal "only Orca-owned lines" is unattainable** and is discharged the way G3/G4/G5's
+   amended headline greps are: three named classes, no fourth class.
+5. **`bash scripts/release-guard.sh` cannot be run to green locally** — it fails closed outside
+   GitHub Actions. Both invocations are pasted with their exit codes rather than omitted.
+6. **The C4 baseline was measured two ways** — a detached `git worktree` at `18b85341b` running the
+   criterion's exact command (60,189 / 97), and a `git show`-per-file sum (60,189). Identical.
+7. **The C-R4 fixture uses the `release-publish.yml` update-path layout** (extract into
+   `$GENIE_HOME/bin`, let `genie install`'s `normalizeAuxLayout` promote `plugins`/`skills`/
+   `templates`), not `install.sh` itself, because `install.sh` downloads and cosign-verifies a
+   *published* GitHub release and this is an unpublished local candidate. That is the same layout
+   `install.sh` produces, and `genie install` — the real post-install finisher `install.sh` hands off
+   to — ran unmodified.
+8. **No `src/` change was made by this group.** Finding H1 is recorded and escalated instead; the
+   reasoning is in its own section.

--- a/.genie/wishes/skills-everywhere-b/qa/20260901.md
+++ b/.genie/wishes/skills-everywhere-b/qa/20260901.md
@@ -29,11 +29,14 @@ Nothing is inferred from a group PR. Criteria that cannot be proven pre-merge ar
 | **C-R4** — fresh-host install/uninstall | ✅ **MET** — 57 homes recorded and 57 measured; 1,425 dirs removed; **zero** genie skill dirs left; record gone; foreign skills byte-identical | [C-R4](#c-r4--fresh-host-installuninstall-cycle) |
 | **C-A** — Wish A `SHIPPED` | ✅ **MET** | [C-A](#c-a--wish-a-closure) |
 
-> **One HIGH finding, not a criterion failure, found by the C-R4 fresh-host pass:**
+> **One HIGH finding, not a criterion failure, found by the C-R4 fresh-host pass and since
+> independently reproduced by the Group 7 review:**
 > `genie install --integrations claude|all` now **aborts with an unhandled stack trace** on any host
 > that has the `claude` CLI, because G4 deleted the marketplace manifest the surviving Claude
 > runtime-integration still registers. See **[Finding H1](#finding-h1-high--the-claude-marketplace-registration-outlived-its-payload)**.
 > No src change was made by this group; the disposition is an orchestrator/`final-gate` decision.
+> It does **not** block this docs-only evidence PR; it **does** block merging the wish into `dev` and
+> any release cut from this head.
 
 ---
 
@@ -63,10 +66,23 @@ HEAD is now at 18b85341b Merge pull request #2868 from automagik-dev/wish/skills
 | Non-test `src/**/*.ts` files | 97 | 71 | −26 |
 | C4 target | ≤ 40,189 | **38,308** | **1,881 lines under target** |
 
-**Where the 21,881 lines went:** 17,685 in 29 wholly deleted files, 6,961 shrunk out of 12 surviving
-files, minus 765 added in 3 new surviving leaf modules (`17,685 + 6,961 − 765 = 23,881`; the residual
-2,000 is spread over small growth in the remaining files, e.g. the G1 discovery scan and collision
-snapshot in `skills-installer.ts`).
+**Where the 21,881 lines went** — every term measured per file (baseline `git show 18b85341b:<f> | wc -l`
+vs head `wc -l`) over the 68 files common to both sets, and the five terms reconcile exactly:
+
+| Term | Lines | Files |
+|---|---:|---:|
+| departed (present at baseline, absent at head) | **−17,685** | 29 |
+| shrunk (surviving, fewer lines) | **−6,797** | 13 |
+| grown (surviving, more lines) | **+1,836** | 7 |
+| arrived (absent at baseline, present at head) | **+765** | 3 |
+| unchanged | 0 | 48 |
+
+`60,189 − 17,685 − 6,797 + 1,836 + 765 = **38,308**` — the head total, exactly.
+
+The +1,836 of growth is the wish's additive half: `skills-installer.ts` +657 (the G1 discovery scan
+and collision snapshot), `legacy-integration-retirement.ts` +626 (G2's retirement surfaces),
+`atomic-fs.ts` +298, `codex-project-mcp.ts` +193, `install-link.ts` +43,
+`local-delivery-repair.ts` +18, `genie.ts` +1.
 
 ### Top-10 largest departed files
 
@@ -122,7 +138,7 @@ Derived from the baseline-vs-head file sets (`comm -23`), ranked by their line c
 
 </details>
 
-### Largest shrinks among surviving files (`delta baseline head file`)
+### All 13 shrinking surviving files — 6,797 lines (`delta baseline head file`)
 
 ```
 -2260 4348 2088 src/lib/runtime-integrations.ts
@@ -137,7 +153,9 @@ Derived from the baseline-vs-head file sets (`comm -23`), ranked by their line c
   -11  174  163 src/lib/interactivity.ts
   -11 2080 2069 src/lib/install-promotion.ts
    -4  277  273 src/types/genie-config.ts
+   -1  164  163 src/lib/omni-config.ts
 ```
+Sums to exactly −6,797.
 
 ### The three files that arrived (765 lines, all planned by G3 deliverable 10)
 
@@ -314,8 +332,13 @@ git ls-files .genie/wishes/skills-everywhere-b/
 ```
 .genie/wishes/skills-everywhere-b/HANDOFF.md
 .genie/wishes/skills-everywhere-b/WISH.md
+.genie/wishes/skills-everywhere-b/qa/20260901.md
 .genie/wishes/skills-everywhere-b/ruleset-main.json
 ```
+
+> Re-run on the current branch head, **after** this evidence file was itself committed — hence four
+> tracked files, not the three that existed at the moment the criterion was first measured. The
+> criterion is `ruleset-main.json` being committed, which is unaffected.
 
 The committed ruleset, re-read on this head:
 
@@ -456,41 +479,209 @@ matrix; recorded as [post-merge acceptance](#post-merge-acceptance).
 git grep -n "plugins/genie" -- src scripts .github package.json
 ```
 
-105 hits. The literal criterion wording is "only Orca-owned lines"; as in G3/G4/G5's amended headline
-greps, that literal form is unattainable without deleting the proofs, so every hit is classified into
-exactly **three** named classes and any fourth class is a regression. There is no fourth class.
+105 hits across 27 files. The literal criterion wording is "only Orca-owned lines"; as in G3/G4/G5's
+amended headline greps, that literal form is unattainable without deleting the proofs, so every hit is
+classified into exactly **three** named classes and any fourth class is a regression. There is no
+fourth class: the per-file counts below partition the 27 hit-bearing files with no file in two classes
+and no file in none, and the three subtotals sum to the headline 105.
 
-### Class (i) — Orca payload, its version stamping and its parity gates (79 hits)
+**The full output, pasted (Deliverable 2 — 105 lines, one per hit):**
 
-`\.github/workflows/orca-plugin-ref.yml` (8) · `version.yml:15,199,200` (3) ·
-`package.json:10` (the published `files` array) · `scripts/build-binary.sh:120,121` (the two required
-Orca payload files) · `scripts/orca-bundle-parity.ts` (4) · `scripts/orca-manifest-parity.test.ts` (7) ·
+<details>
+<summary><code>git grep -n "plugins/genie" -- src scripts .github package.json</code> — all 105 hits</summary>
+
+```
+.github/workflows/orca-plugin-ref.yml:3:# Republish `plugins/genie` as a standalone git ref that Orca can install.
+.github/workflows/orca-plugin-ref.yml:11:#   * the manifest is nested at `plugins/genie/orca-plugin.json`, invisible to a
+.github/workflows/orca-plugin-ref.yml:14:# `plugins/genie` on its own is symlink-free, ~132 files / ~1.3 MB, and holds the
+.github/workflows/orca-plugin-ref.yml:35:      - 'plugins/genie/**'
+.github/workflows/orca-plugin-ref.yml:51:    name: Publish plugins/genie subtree
+.github/workflows/orca-plugin-ref.yml:88:          SUBTREE="$(git rev-parse "HEAD:plugins/genie")"
+.github/workflows/orca-plugin-ref.yml:108:          # Parentless root commit whose ROOT IS `plugins/genie`. `commit-tree`
+.github/workflows/orca-plugin-ref.yml:111:            -m "chore(orca-plugin): plugins/genie subtree of ${BRANCH} ${SOURCE_SHA}")"
+.github/workflows/release-publish.yml:977:            [[ -d "${stage}/plugins/genie" && ! -L "${stage}/plugins/genie" ]] || {
+.github/workflows/release-publish.yml:981:            rm -rf -- "${GENIE_HOME}/plugins/genie"
+.github/workflows/release-publish.yml:985:            cp -R -- "${stage}/plugins/genie" "${GENIE_HOME}/plugins/genie"
+.github/workflows/version.yml:15:# `plugins/genie/package.json`, `plugins/genie/orca-plugin.json`), of which the
+.github/workflows/version.yml:199:            plugins/genie/orca-plugin.json
+.github/workflows/version.yml:200:            plugins/genie/package.json
+package.json:10:  "files": ["dist/", "skills/", "plugins/genie/", "templates/", "README.md", "LICENSE"],
+scripts/build-binary.sh:120:  "plugins/genie/orca-plugin.json" \
+scripts/build-binary.sh:121:  "plugins/genie/orca-entrypoint.min.js"; do
+scripts/build-delivery-evidence.ts:119:  if (!stat.isDirectory() || stat.isSymbolicLink()) fail('plugins/genie must be a physical directory');
+scripts/fresh-install-smoke.ts:118:    for (const forbidden of ['plugins/genie/references/', '$GENIE_HOME/plugins/genie']) {
+scripts/orca-bundle-parity.ts:6: * `plugins/genie/orca-entrypoint.min.js` is the file the Orca host executes
+scripts/orca-bundle-parity.ts:7: * (`plugins/genie/orca-plugin.json` → `main`). It ships inside every signed
+scripts/orca-bundle-parity.ts:12: * `plugins/genie/orca-entrypoint.ts`.
+scripts/orca-bundle-parity.ts:62:      `Orca bundle drift: plugins/genie/${target.name}.min.js does not match its TypeScript source; run \`bun scripts/orca-bundle-parity.ts --write\``,
+scripts/orca-manifest-parity.test.ts:12: * Genie's only manifest lives at `plugins/genie/orca-plugin.json`. The genie
+scripts/orca-manifest-parity.test.ts:17: * `orca-plugin-dev` from dev) whose root IS `plugins/genie`, republished by
+scripts/orca-manifest-parity.test.ts:23: * `plugins/genie` inside the limits that make the published subtree installable.
+scripts/orca-manifest-parity.test.ts:27:const PAYLOAD_DIR = join(REPO_ROOT, 'plugins/genie');
+scripts/orca-manifest-parity.test.ts:45: * Enumerate the committed `plugins/genie` tree — the exact bytes the workflow
+scripts/orca-manifest-parity.test.ts:50:  const listed = Bun.spawnSync(['git', '-C', REPO_ROOT, 'ls-files', '-s', '--', 'plugins/genie']);
+scripts/orca-manifest-parity.test.ts:95:  test('the plugin ref is republished from plugins/genie by a workflow, not by hand', () => {
+scripts/orca-manifest-parity.test.ts:97:    expect(workflow).toContain('HEAD:plugins/genie');
+scripts/orca-manifest-parity.test.ts:106:  test('plugins/genie is installable as an Orca plugin root: a manifest, no symlinks, inside the file cap', () => {
+scripts/orca-manifest-parity.test.ts:111:    expect(paths).toContain('plugins/genie/orca-plugin.json');
+scripts/release-docs.test.ts:41:    for (const path of ['package.json', 'plugins/genie/orca-plugin.json', 'plugins/genie/package.json']) {
+scripts/release-docs.test.ts:45:    // tree-only `plugins/genie` subtree ref, not from the repo root.
+scripts/release-docs.test.ts:682:    const pluginPackage = JSON.parse(read('plugins/genie/package.json')) as { license?: unknown };
+scripts/release-docs.test.ts:744:    const contributor = read('plugins/genie/references/orca-orchestration.md');
+scripts/release-docs.test.ts:745:    const pluginReadme = read('plugins/genie/README.md');
+scripts/release-docs.test.ts:765:    expect(operator).toContain('plugins/genie/references/orca-orchestration.md');
+scripts/release-docs.test.ts:773:      '~/.genie/plugins/genie',
+scripts/release-docs.test.ts:862:    expect(read('plugins/genie/README.md')).toContain('No launcher or registration ships');
+scripts/release-guard.sh:163:    plugins/genie/package.json
+scripts/release-guard.sh:166:  if grep -qx 'plugins/genie/orca-plugin.json' <<<"$changed"; then
+scripts/release-guard.sh:167:    json_paths+=(plugins/genie/orca-plugin.json)
+scripts/release-guard.test.ts:308:    ['plugins/genie/orca-plugin.json', { id: 'genie', version }],
+scripts/release-guard.test.ts:309:    ['plugins/genie/package.json', { name: 'genie-plugin', version }],
+scripts/release-guard.test.ts:346:    git(fixture.root, 'checkout', '-q', fixture.parent, '--', 'plugins/genie/orca-plugin.json');
+scripts/release-guard.test.ts:351:      'plugins/genie/orca-plugin.json',
+scripts/release-guard.test.ts:363:      join(fixture.root, 'plugins/genie/orca-plugin.json'),
+scripts/release-payload-version.test.ts:29:    for (const path of ['plugins/genie/package.json', 'plugins/genie/orca-plugin.json']) {
+scripts/release-payload-version.test.ts:42:    expect(JSON.parse(readFileSync(join(repoRoot, 'plugins/genie/orca-plugin.json'), 'utf8')).version).toMatch(
+scripts/release-payload-version.test.ts:50:    writeJson(root, 'plugins/genie/package.json', {
+scripts/release-payload-version.test.ts:60:    for (const path of ['plugins/genie/package.json', 'plugins/genie/orca-plugin.json']) {
+scripts/release-payload-version.test.ts:63:    expect(JSON.parse(readFileSync(join(root, 'plugins/genie/package.json'), 'utf8')).metadata.version).toBe(
+scripts/release-payload-version.test.ts:72:    writeJson(root, 'plugins/genie/package.json', { name: 'genie-plugin', version: '5.260711.9' });
+scripts/release-payload-version.test.ts:74:    expect(() => verifyReleasePayloadVersion(root, version)).toThrow('plugins/genie/package.json');
+scripts/release-payload-version.test.ts:81:    writeJson(root, 'plugins/genie/orca-plugin.json', { id: 'genie', version: '5.260711.9' });
+scripts/release-payload-version.test.ts:84:    rmSync(join(root, 'plugins/genie/orca-plugin.json'));
+scripts/release-payload-version.test.ts:92:    writeJson(root, 'plugins/genie/package.json', { name: 'genie-plugin', version: '5.999999.1' });
+scripts/release-payload-version.test.ts:94:    expect(() => verifyCommittedReleaseVersions(root)).toThrow('plugins/genie/package.json');
+scripts/release-payload-version.test.ts:103:    writeJson(root, 'plugins/genie/orca-plugin.json', { id: 'genie', version: '5.000000.0-lagging' });
+scripts/release-payload-version.test.ts:107:    expect(JSON.parse(readFileSync(join(root, 'plugins/genie/orca-plugin.json'), 'utf8')).version).toBe('5.260711.10');
+scripts/release-payload-version.test.ts:112:    rmSync(join(root, 'plugins/genie/package.json'));
+scripts/release-payload-version.test.ts:127:    expect(buildScript).toContain('"plugins/genie/orca-plugin.json"');
+scripts/release-payload-version.test.ts:128:    expect(buildScript).toContain('"plugins/genie/orca-entrypoint.min.js"');
+scripts/release-payload-version.ts:16:const TOP_LEVEL_VERSION_FILES = ['plugins/genie/package.json', 'plugins/genie/orca-plugin.json'] as const;
+scripts/release-payload-version.ts:29:const COMMITTED_VERSION_FILES = ['package.json', 'plugins/genie/package.json'] as const;
+scripts/version-ci-staging.test.ts:32:    for (const path of ['package.json', 'plugins/genie/orca-plugin.json', 'plugins/genie/package.json']) {
+scripts/version-ci-staging.test.ts:61:    expect(staged).toContain('plugins/genie/package.json');
+scripts/version-ci-staging.test.ts:62:    expect(staged).toContain('plugins/genie/orca-plugin.json');
+scripts/version-ci-staging.test.ts:65:    expect(JSON.parse(readFileSync(join(root, 'plugins/genie/package.json'), 'utf8')).version).toBe('5.260713.3');
+scripts/version-ci-staging.test.ts:77:    expect(JSON.parse(readFileSync(join(root, 'plugins/genie/package.json'), 'utf8')).version).toBe('5.260713.4');
+scripts/version-ci-staging.test.ts:91:    expect(JSON.parse(readFileSync(join(root, 'plugins/genie/package.json'), 'utf8')).version).toBe('5.260713.5');
+scripts/version-format.test.ts:41:    for (const path of ['package.json', 'plugins/genie/orca-plugin.json', 'plugins/genie/package.json']) {
+scripts/version-format.test.ts:66:   * `plugins/genie/package.json` used to be regenerated by the deleted
+scripts/version-format.test.ts:89:    const before = ['package.json', 'plugins/genie/orca-plugin.json', 'plugins/genie/package.json'].map((path) =>
+scripts/version-format.test.ts:95:      join(root, 'plugins/genie/orca-plugin.json'),
+scripts/version-format.test.ts:96:      join(root, 'plugins/genie/package.json'),
+scripts/version-format.test.ts:99:    const after = ['package.json', 'plugins/genie/orca-plugin.json', 'plugins/genie/package.json'].map((path) =>
+scripts/version-format.test.ts:107:    writeFileSync(join(root, 'plugins/genie/orca-plugin.json'), '{"name":"genie"}\n');
+scripts/version-format.test.ts:108:    rmSync(join(root, 'plugins/genie/package.json'));
+scripts/version-format.test.ts:128:      expect(JSON.parse(readFileSync(join(root, 'plugins/genie/package.json'), 'utf8')).version).toBe('5.260711.3');
+scripts/version-format.test.ts:129:      expect(JSON.parse(readFileSync(join(root, 'plugins/genie/orca-plugin.json'), 'utf8')).version).toBe('5.260711.3');
+scripts/version-format.test.ts:131:      rmSync(join(root, 'plugins/genie/package.json'));
+scripts/version-format.test.ts:144:    writeFileSync(join(root, 'plugins/genie/orca-plugin.json'), '{"name":"genie"}\n');
+scripts/version.ts:15: * - plugins/genie/orca-plugin.json (Orca)
+scripts/version.ts:16: * - plugins/genie/package.json (runtime payload metadata)
+scripts/version.ts:118:export const VERSION_FILES = ['package.json', 'plugins/genie/orca-plugin.json', 'plugins/genie/package.json'] as const;
+scripts/wishes-lint.ts:14:// The wish validator, rehomed here from the retired `plugins/genie/scripts/src/`
+src/genie-commands/__tests__/update-command-publication.test.ts:48:  for (const directory of ['plugins/genie', 'skills/review', 'templates']) {
+src/genie-commands/__tests__/update.test.ts:1502:  test('repo source tree does NOT contain plugins/genie/.orphaned_at', () => {
+src/genie-commands/doctor.ts:1295:        const { createOrcaPluginRuntime } = await import('../../plugins/genie/orca-runtime.js');
+src/lib/legacy-integration-retirement.test.ts:953:  test('a bundle carrying plugins/genie is managed-clean, removed, and prunes its empty parent', () => {
+src/lib/legacy-integration-retirement.ts:461: * kept reading its `plugins/genie` child as proof the integration is installed —
+src/lib/legacy-integration-retirement.ts:476:    entries.push({ surface, path, state: 'managed-modified', detail: 'no plugins/genie bundle under it' });
+src/lib/legacy-integration-retirement.ts:747:/** `<hermesHome>/plugins/genie` plus the same link under every well-named profile. */
+src/lib/legacy-integration-retirement.ts:1770: * validation so a config write lands in the same home whose plugins/genie link is
+src/lib/orca-plugin-lifecycle.ts:162:        const { createOrcaPluginRuntime } = await import('../../plugins/genie/orca-runtime.js');
+src/lib/orca-plugin-lifecycle.ts:252:      const { createOrcaPluginRuntime } = await import('../../plugins/genie/orca-runtime.js');
+src/lib/runtime-integrations.ts:374: * genie plugin payload the integrations reference (`plugins/genie` ships in
+src/lib/runtime-integrations.ts:391: * Locate the directory that contains the `plugins/genie` payload.
+src/lib/runtime-integrations.ts:1222:          'genie bundle root not found — expected plugins/genie under $GENIE_HOME (~/.genie) or beside the genie binary; set GENIE_BUNDLE_ROOT to override',
+src/lib/skills-installer.test.ts:532:   * `$GENIE_HOME` (`plugins/genie/skills`, byte-identical to `skills/`),
+src/lib/skills-installer.ts:81: * tree at `plugins/genie/skills/`; the explicit pin is what made that safe and
+src/lib/skills-installer.ts:490:   * uninstall manifest. The `plugins/genie/skills/` mirror that motivated this
+```
+
+</details>
+
+**The per-file counts the classification is built on** (this is what the class subtotals are summed
+from, so they are counted, never back-fitted from the headline total):
+
+```bash
+git grep -c "plugins/genie" -- src scripts .github package.json | sort
+```
+```
+.github/workflows/orca-plugin-ref.yml:8
+.github/workflows/release-publish.yml:3
+.github/workflows/version.yml:3
+package.json:1
+scripts/build-binary.sh:2
+scripts/build-delivery-evidence.ts:1
+scripts/fresh-install-smoke.ts:1
+scripts/orca-bundle-parity.ts:4
+scripts/orca-manifest-parity.test.ts:10
+scripts/release-docs.test.ts:8
+scripts/release-guard.sh:3
+scripts/release-guard.test.ts:5
+scripts/release-payload-version.test.ts:16
+scripts/release-payload-version.ts:2
+scripts/version-ci-staging.test.ts:6
+scripts/version-format.test.ts:12
+scripts/version.ts:3
+scripts/wishes-lint.ts:1
+src/genie-commands/__tests__/update-command-publication.test.ts:1
+src/genie-commands/__tests__/update.test.ts:1
+src/genie-commands/doctor.ts:1
+src/lib/legacy-integration-retirement.test.ts:1
+src/lib/legacy-integration-retirement.ts:4
+src/lib/orca-plugin-lifecycle.ts:2
+src/lib/runtime-integrations.ts:3
+src/lib/skills-installer.test.ts:1
+src/lib/skills-installer.ts:2
+```
+
+27 files; the counts sum to 105, matching the `git grep -n | wc -l` headline.
+
+### Class (i) — Orca payload, its version stamping and its parity gates (86 hits, 15 files)
+
+`.github/workflows/orca-plugin-ref.yml` (8) · `version.yml:15,199,200` (3) ·
+`package.json:10` (1 — the published `files` array) · `scripts/build-binary.sh:120,121` (2 — the two
+required Orca payload files) · `scripts/orca-bundle-parity.ts` (4) ·
+`scripts/orca-manifest-parity.test.ts` (10) ·
 `scripts/release-docs.test.ts:41,45,682,744,745,765,773,862` (8) ·
 `scripts/release-guard.sh:163,166,167` (3) · `scripts/release-guard.test.ts` (5) ·
-`scripts/release-payload-version.{ts,test.ts}` (17) · `scripts/version.ts:15,16,118` (3) ·
-`scripts/version-format.test.ts` (11) · `scripts/version-ci-staging.test.ts` (5) ·
-`src/genie-commands/doctor.ts:1295` and `src/lib/orca-plugin-lifecycle.ts:162,252` (the three dynamic
-`plugins/genie/orca-runtime.js` imports).
+`scripts/release-payload-version.ts` (2) + `scripts/release-payload-version.test.ts` (16) ·
+`scripts/version.ts:15,16,118` (3) · `scripts/version-format.test.ts` (12) ·
+`scripts/version-ci-staging.test.ts` (6) · `src/genie-commands/doctor.ts:1295` (1) and
+`src/lib/orca-plugin-lifecycle.ts:162,252` (2) — the three dynamic
+`plugins/genie/orca-runtime.js` imports.
 
-### Class (ii) — the shipped payload **directory** (which is now the Orca tree) as a delivery member (13 hits)
+`8+3+1+2+4+10+8+3+5+2+16+3+12+6+1+2 = **86**`.
 
-`.github/workflows/release-publish.yml:977,981,985` (the update-path smoke stages the payload tree
-into `$GENIE_HOME`) · `scripts/build-delivery-evidence.ts:119` (the tree must be a physical
-directory; `:227` digests it wholesale) · `src/lib/runtime-integrations.ts:374,391,1222`
-(`isBundleRoot` probes `existsSync(join(root,'plugins','genie'))` — bundle-root discovery, re-pointed
-by G3) · `src/genie-commands/__tests__/update-command-publication.test.ts:48` ·
-`src/genie-commands/__tests__/update.test.ts:1502`.
+### Class (ii) — the shipped payload **directory** (which is now the Orca tree) as a delivery member (9 hits, 5 files)
 
-### Class (iii) — negative guards and historical prose about the **deleted** mirror (13 hits)
+`.github/workflows/release-publish.yml:977,981,985` (3 — the update-path smoke stages the payload tree
+into `$GENIE_HOME`) · `scripts/build-delivery-evidence.ts:119` (1 — the tree must be a physical,
+non-symlinked directory) · `src/lib/runtime-integrations.ts:374,391,1222` (3 — the two doc comments
+over the bundle-root resolver and its not-found error string; the probe itself is
+`existsSync(join(root, 'plugins', 'genie'))`, re-pointed by G3, so it carries no literal) ·
+`src/genie-commands/__tests__/update-command-publication.test.ts:48` (1) ·
+`src/genie-commands/__tests__/update.test.ts:1502` (1).
 
-`scripts/fresh-install-smoke.ts:118` — the smoke **forbids** `plugins/genie/references/` and
-`$GENIE_HOME/plugins/genie` inside any `SKILL.md`; `src/lib/skills-installer.ts:81,490` and
-`skills-installer.test.ts:532` — the comments explaining why the install source is pinned to
+`3+1+3+1+1 = **9**`.
+
+### Class (iii) — negative guards and historical prose about the **deleted** mirror (10 hits, 6 files)
+
+`scripts/fresh-install-smoke.ts:118` (1) — the smoke **forbids** `plugins/genie/references/` and
+`$GENIE_HOME/plugins/genie` inside any `SKILL.md`; `src/lib/skills-installer.ts:81,490` (2) and
+`skills-installer.test.ts:532` (1) — the comments explaining why the install source is pinned to
 `$GENIE_HOME/skills` and why that path is pruned from the discovery scan, both of which say in so many
 words that the mirror "left with the Claude plugin";
-`src/lib/legacy-integration-retirement.ts:461,476,747,1770` + `legacy-integration-retirement.test.ts:953`
+`src/lib/legacy-integration-retirement.ts:461,476,747,1770` (4) +
+`legacy-integration-retirement.test.ts:953` (1)
 — retirement surfaces for `plugins/genie` bundles a **previous** Genie wrote onto a real host, which
-must keep naming the path to be able to remove it; `scripts/wishes-lint.ts:14` — the rehome note.
+must keep naming the path to be able to remove it; `scripts/wishes-lint.ts:14` (1) — the rehome note.
+
+`1+2+1+4+1+1 = **10**`.
+
+**Reconciliation:** `86 + 9 + 10 = 105` ✅ — equal to the headline, and every one of the 27
+hit-bearing files appears in exactly one class.
 
 ### The gate on this head
 
@@ -500,7 +691,7 @@ bun run check:fast
 ```
 …
 skills-lint: OK (43 files scanned, 0 missing, 0 resource violations)
-wishes-lint: OK (84 files scanned, 0 broken brainstorm links, template validator green)
+wishes-lint: OK (85 files scanned, 0 broken brainstorm links, template validator green)
 Cognitive-complexity budget report
 Warnings (score > threshold): 2 / 7
 Max observed score:           29 / 42
@@ -512,6 +703,10 @@ OK: budget intact.
 orca-bundle-parity: OK
 exit=0
 ```
+
+> Re-run on the current branch head after this evidence file was committed: `wishes-lint` now scans
+> **85** files, not the 84 it scanned before the file existed. Every gate is still green and no
+> criterion moves.
 
 `check` composition on this head, read from `package.json` — the **eight** / **seven** steps the wish
 specifies:
@@ -940,6 +1135,30 @@ create it.
 `installIfAbsent: false`, so an absent plugin stays absent and no marketplace add is attempted.
 The blast radius is `genie install` only.
 
+### Independently confirmed by the Group 7 review (fix loop 1)
+
+The reviewing agent reproduced this end-to-end on its own fixture — a real tarball from
+`bash scripts/build-binary.sh --platform linux-x64-glibc`, its own `$HOME`/`$GENIE_HOME` — and got the
+same two outcomes (`auto` → yellow `!` line, exit 0; `--integrations claude` → raw Bun stack trace,
+`error: Requested integration failed: claude`, exit 1). It also walked the chain line by line and
+confirmed every link on this head; re-verified again here after the fix-loop edits:
+
+| Link | Location | State at this head |
+|---|---|---|
+| Manifest existed at the C4 baseline | `git ls-tree -r --name-only 18b85341b -- .claude-plugin` | one file |
+| Manifest gone at head | `git ls-tree -r --name-only HEAD -- .claude-plugin` | empty |
+| `.claude-plugin` delisted from the payload | `src/lib/install-promotion.ts:32` | six members, no `.claude-plugin` |
+| Install path forces the add | `src/lib/runtime-integrations.ts:1749` `installIfAbsent: true` | defeats the `:1650` early return, so `:1660` always runs |
+| The add throws on this output | `src/lib/runtime-integrations.ts:1576-1587` | "Marketplace file not found" matches none of `/already\|exists\|configured\|different source/i` |
+| Explicit selection rethrows | `src/genie-commands/install.ts:188` | `Requested integration failed: claude` |
+| `genie update` unaffected | `src/genie-commands/update-integrations.ts:74` `installIfAbsent: false` | short-circuits at `:1650`; blast radius is `genie install` only |
+
+**Status:** the review classified it as **not a Group 7 defect** — the proof group found it correctly
+and correctly declined to author the fix — and as **not blocking this docs-only evidence PR**. It
+**does** block merging the wish into `dev` and any release cut from this head. Disposition A or B
+above is an orchestrator / `final-gate` decision, and disposition A additionally needs a ratification
+note re-opening the 2026-09-01 `--sync-only` contract.
+
 ---
 
 ## Post-merge acceptance
@@ -1026,4 +1245,19 @@ the two — it is the full gate on the head every measurement in this document w
    `install.sh` produces, and `genie install` — the real post-install finisher `install.sh` hands off
    to — ran unmodified.
 8. **No `src/` change was made by this group.** Finding H1 is recorded and escalated instead; the
-   reasoning is in its own section.
+   reasoning is in its own section, and the Group 7 review agreed with that split (reviewer ≠
+   engineer; the disposition belongs to the orchestrator / `final-gate`).
+
+---
+
+## Fix loop 1 — corrections applied after the Group 7 review (2026-09-01)
+
+The review returned FIX-FIRST with four findings. Three were evidence-integrity defects in **this
+document** and are corrected above; the fourth is Finding H1, which is not a Group 7 defect.
+
+| # | Finding | Correction |
+|---|---|---|
+| HIGH | Finding H1 reproduced independently by the review | No code change (out of Group 7's approved scope — its Deliverables and ACs are measurement-only). H1 now carries the reviewer's line-by-line confirmation table and an explicit block/no-block status. |
+| MEDIUM | C-G was **not** "pasted in full" (Deliverable 2), and all three class subtotals were back-fitted to the correct total instead of counted (79/13/13 published; 86/9/10 actual). One enumerated reference, `scripts/build-delivery-evidence.ts:227`, was not a hit at all. | The raw 105-line `git grep -n` output is now pasted in full, plus the `git grep -c` per-file table the classes are summed from. Subtotals corrected to **86 / 9 / 10** with per-class arithmetic shown; the phantom `:227` is dropped; four wrong per-file counts fixed (`orca-manifest-parity.test.ts` 7→10, `release-payload-version.{ts,test.ts}` 17→18, `version-format.test.ts` 11→12, `version-ci-staging.test.ts` 5→6). The substantive conclusion is unchanged: three classes, no fourth. |
+| LOW | C4's line-accounting narrative was wrong by 164 lines in two places (shrink "6,961"/12 files, growth "the residual 2,000"). The **headline delta was always exact.** | Replaced the prose with a five-term table measured per file — departed 17,685 / shrunk **6,797** (13 files) / grown **1,836** (7 files) / arrived 765 / unchanged 0 — reconciling to 38,308 exactly. The shrink listing gained its missing 13th row (`omni-config.ts`, −1) so it sums to −6,797. |
+| LOW | Two pasted outputs were stale against the branch head (`git ls-files` returned 3, now 4; `wishes-lint` said 84, now 85) — both caused by this evidence file itself becoming tracked. | Both re-run on the current head and updated, each with a one-line note naming the cause. `bun run check:fast` was re-run in full and is green. |


### PR DESCRIPTION
## Group 7 — proof

Measures every wish-level criterion of `skills-everywhere-b` on the **assembled head** (`3d56eed7e`, G1–G6 merged) rather than inferring it from the group PRs. One file added: the complete evidence document
`.genie/wishes/skills-everywhere-b/qa/20260901.md`, reproduced below. **No `src/` change.**

**Full gate:** green in CI on the measured head — run [33455733167](https://github.com/automagik-dev/genie/actions/runs/33455733167) (`3d56eed7e`) and run [33456983012](https://github.com/automagik-dev/genie/actions/runs/33456983012) (evidence commit `6a011f62b`), both success. `bun run check:fast` re-run green on the fix-loop head.

> **Read the HIGH finding at the bottom before merging.** The C-R4 fresh-host pass found that
> `genie install --integrations claude|all` now aborts with a stack trace on any host with the `claude` CLI,
> because G4 deleted the marketplace manifest that the surviving Claude runtime integration still registers.
> The Group 7 review **independently reproduced it**. It is not a criterion failure and not a Group 7 defect,
> it does not block this docs-only PR, it **does** block merging the wish into `dev`, and it needs an
> orchestrator / `final-gate` decision between the three dispositions laid out.

### Fix loop 1 (review returned FIX-FIRST) — `ed32706a4`

All four findings were independently re-verified on this head before acting.

| Sev | Finding | Correction |
|---|---|---|
| HIGH | Finding H1 reproduced end-to-end by the review | **No code change** — out of Group 7's approved scope (its Deliverables and ACs are measurement-only), and the review agreed the disposition belongs to the orchestrator. H1 now carries the reviewer's line-by-line confirmation table and an explicit block/no-block status. |
| MEDIUM | C-G was not "pasted in full" as Deliverable 2 requires, and all three class subtotals were back-fitted to the correct 105 total rather than counted (79/13/13 published; **86/9/10** actual). One enumerated reference, `scripts/build-delivery-evidence.ts:227`, was not a hit at all. | Raw 105-line `git grep -n` output now pasted in full, plus the `git grep -c` per-file table the classes are summed from. Subtotals corrected with per-class arithmetic; phantom `:227` dropped; four wrong per-file counts fixed. Conclusion unchanged: three classes, no fourth. |
| LOW | C4's line-accounting prose was wrong by 164 lines in two places (shrink "6,961"/12 files, growth "the residual 2,000"). **The headline delta was always exact.** | Replaced with a five-term per-file table — departed 17,685 / shrunk **6,797** (13) / grown **1,836** (7) / arrived 765 — reconciling to 38,308 exactly. Shrink listing gained its missing 13th row. |
| LOW | Two pasted outputs went stale once this evidence file became tracked (`git ls-files` 3→4, `wishes-lint` 84→85). | Both re-run on the current head, each with a one-line note naming the cause. |

---

# Group 7 — proof: wish-level evidence for `skills-everywhere-b`

| Field | Value |
|-------|-------|
| **Measured on** | 2026-09-01 |
| **Measured head** | `wish/skills-everywhere-b-g7`, base commit `3d56eed7e` — the assembled wish head (`wish/skills-everywhere-b` with G1–G6 merged) |
| **Baseline** | `18b85341b` (Wish A merge, PR #2868) |
| **`origin/dev`** | `6b00a9807` — the merge-base of this branch with `dev` **is** `origin/dev`, so every `git diff origin/dev` below is a pure wish diff with no dev drift |
| **Agent** | QA (wave 6), session 17ecb3d2 |
| **Host** | linux-x64-glibc, `bun 1.3.14`, `node v26.7.0`, real `claude` CLI present on PATH |

Every criterion below carries the **exact command** and its **pasted output**, measured on this head.
Nothing is inferred from a group PR. Criteria that cannot be proven pre-merge are recorded as
**post-merge acceptance** with the named run that will prove them, and are **not ticked**.

## Verdict summary

| Criterion | Result | Proof |
|-----------|--------|-------|
| **C4** — ≥ 20,000 non-test `src/` lines out | ✅ **MET** — 60,189 → **38,308** (**−21,881**, −26 files); target ≤ 40,189 | [C4](#c4--non-test-src-line-delta) |
| **C5-lite** — no dangling plugin-root token in `skills/**` | ✅ **MET** (grep empty); Decision-7 worklist handed to Wish C by `file:line` | [C5-lite](#c5-lite--skills-token-guard--wish-c-worklist) |
| **C7** — dogfood matrix gone, six `publish.needs` edges, musl byte-unchanged | ✅ **MET** statically | [C7](#c7--release-publishyml-surgery) |
| **C7 (live leg)** | ⏳ **post-merge acceptance** — the dev-channel candidate `Release publish` run fired by the merge of this wish into `dev` | [Post-merge](#post-merge-acceptance) |
| **C8** — Orca untouched, four Orca suites green | ⚠️ **MET with one classified residual** — 29 pass / 0 fail; the diff is **one comment-only hunk** (zero executable bytes) | [C8](#c8--orca-no-diff--orca-suites) |
| **C9** — `ruleset-main.json` committed, Decision 9 records the gap | ✅ **MET** | [C9](#c9--branch-protection-evidence) |
| **C11** — toolchain | ✅ **MET** locally for every runnable leg | [C11](#c11--buildrelease-toolchain) |
| **C11 (4-platform matrix leg)** | ⏳ **post-merge acceptance** — `build-tarballs.yml` on the merge commit | [Post-merge](#post-merge-acceptance) |
| **C-G** — `plugins/genie` only Orca-owned; gate green | ✅ **MET** — 105 hits, all in three named classes; `check:fast` green locally and the **full gate green in CI on the measured head** (run 33455733167) | [C-G](#c-g--pluginsgenie-references--the-gate) |
| **C-R4** — fresh-host install/uninstall | ✅ **MET** — 57 homes recorded and 57 measured; 1,425 dirs removed; **zero** genie skill dirs left; record gone; foreign skills byte-identical | [C-R4](#c-r4--fresh-host-installuninstall-cycle) |
| **C-A** — Wish A `SHIPPED` | ✅ **MET** | [C-A](#c-a--wish-a-closure) |

> **One HIGH finding, not a criterion failure, found by the C-R4 fresh-host pass and since
> independently reproduced by the Group 7 review:**
> `genie install --integrations claude|all` now **aborts with an unhandled stack trace** on any host
> that has the `claude` CLI, because G4 deleted the marketplace manifest the surviving Claude
> runtime-integration still registers. See **[Finding H1](#finding-h1-high--the-claude-marketplace-registration-outlived-its-payload)**.
> No src change was made by this group; the disposition is an orchestrator/`final-gate` decision.
> It does **not** block this docs-only evidence PR; it **does** block merging the wish into `dev` and
> any release cut from this head.

---

## C4 — non-test `src/` line delta

**Command (identical on both heads), run at `18b85341b` in a detached worktree and on the wish head:**

```bash
git ls-files src | grep '\.ts$' | grep -v '\.test\.ts$' | xargs wc -l | tail -1
```

```
# baseline — git worktree add --detach <tmp> 18b85341b
Preparing worktree (detached HEAD 18b85341b)
HEAD is now at 18b85341b Merge pull request #2868 from automagik-dev/wish/skills-everywhere
  60189 total          <- matches the wish's recorded baseline exactly
97                     <- git ls-files src | grep '\.ts$' | grep -v '\.test\.ts$' | wc -l

# wish head 3d56eed7e
  38308 total
71
```

| | Baseline `18b85341b` | Wish head `3d56eed7e` | Delta |
|---|---|---|---|
| Non-test `src/**/*.ts` lines | **60,189** | **38,308** | **−21,881** |
| Non-test `src/**/*.ts` files | 97 | 71 | −26 |
| C4 target | ≤ 40,189 | **38,308** | **1,881 lines under target** |

**Where the 21,881 lines went** — every term measured per file (baseline `git show 18b85341b:<f> | wc -l`
vs head `wc -l`) over the 68 files common to both sets, and the five terms reconcile exactly:

| Term | Lines | Files |
|---|---:|---:|
| departed (present at baseline, absent at head) | **−17,685** | 29 |
| shrunk (surviving, fewer lines) | **−6,797** | 13 |
| grown (surviving, more lines) | **+1,836** | 7 |
| arrived (absent at baseline, present at head) | **+765** | 3 |
| unchanged | 0 | 48 |

`60,189 − 17,685 − 6,797 + 1,836 + 765 = **38,308**` — the head total, exactly.

The +1,836 of growth is the wish's additive half: `skills-installer.ts` +657 (the G1 discovery scan
and collision snapshot), `legacy-integration-retirement.ts` +626 (G2's retirement surfaces),
`atomic-fs.ts` +298, `codex-project-mcp.ts` +193, `install-link.ts` +43,
`local-delivery-repair.ts` +18, `genie.ts` +1.

### Top-10 largest departed files

Derived from the baseline-vs-head file sets (`comm -23`), ranked by their line count **at the baseline**:

| # | File | Lines at `18b85341b` | Deleted by |
|---|------|---------------------:|-----------|
| 1 | `src/lib/agent-sync.ts` | 6,733 | G5 |
| 2 | `src/lib/codex-activation.ts` | 2,158 | G3 |
| 3 | `src/lib/codex-lifecycle-lease.ts` | 1,068 | G3 |
| 4 | `src/lib/codex-delivery-evidence.ts` | 957 | G3 |
| 5 | `src/lib/codex-activation-executor.ts` | 834 | G3 |
| 6 | `src/lib/hermes-skills-config.ts` | 728 | G5 |
| 7 | `src/hooks/index.ts` | 610 | G4 |
| 8 | `src/hooks/handlers/git-freeze-guard.ts` | 498 | G4 |
| 9 | `src/genie-commands/codex-delivery-repair.ts` | 405 | G3 |
| 10 | `src/lib/codex-host-observation.ts` | 378 | G3 |

<details>
<summary>All 29 departed files (17,685 lines)</summary>

```
6733 src/lib/agent-sync.ts
2158 src/lib/codex-activation.ts
1068 src/lib/codex-lifecycle-lease.ts
 957 src/lib/codex-delivery-evidence.ts
 834 src/lib/codex-activation-executor.ts
 728 src/lib/hermes-skills-config.ts
 610 src/hooks/index.ts
 498 src/hooks/handlers/git-freeze-guard.ts
 405 src/genie-commands/codex-delivery-repair.ts
 378 src/lib/codex-host-observation.ts
 372 src/hooks/handlers/omni-approval.ts
 317 src/hooks/handlers/branch-guard.ts
 279 src/lib/codex-lifecycle-truth.ts
 276 src/genie-commands/codex-delivery.ts
 259 src/genie-commands/codex-rollback.ts
 237 src/hooks/dispatch-command.ts
 214 src/lib/codex-activation-persistence.ts
 209 src/term-commands/hook/trust.ts
 186 src/hooks/handlers/freshness.ts
 156 src/hooks/trust.ts
 147 src/lib/codex-doctor-observation.ts
 134 src/lib/codex-delivery-evidence.test-support.ts
 120 src/hooks/types.ts
 104 src/hooks/codex-adapter.ts
  95 src/hooks/handlers/audit-context.ts
  86 src/hooks/shell-quoting.ts
  48 src/lib/codex-release-version.ts
  45 src/hooks/handlers/identity-inject.ts
  32 src/hooks/env-identity.ts
```

</details>

### All 13 shrinking surviving files — 6,797 lines (`delta baseline head file`)

```
-2260 4348 2088 src/lib/runtime-integrations.ts
-1392 3731 2339 src/genie-commands/uninstall.ts
-1327 2711 1384 src/genie-commands/doctor.ts
 -713 1183  470 src/genie-commands/setup.ts
 -601 3840 3239 src/genie-commands/update.ts
 -244  522  278 src/genie-commands/install.ts
 -154  237   83 src/genie-commands/update-integrations.ts
  -61  115   54 src/lib/ordered-lifecycle-leases.ts
  -18  368  350 src/genie-commands/install-promote.ts
  -11  174  163 src/lib/interactivity.ts
  -11 2080 2069 src/lib/install-promotion.ts
   -4  277  273 src/types/genie-config.ts
   -1  164  163 src/lib/omni-config.ts
```
Sums to exactly −6,797.

### The three files that arrived (765 lines, all planned by G3 deliverable 10)

```
477 src/lib/delivery-evidence-verify.ts
134 src/lib/delivery-evidence-verify.test-support.ts
154 src/lib/release-payload-proof.ts
```

---

## C5-lite — `skills/` token guard + Wish C worklist

**Guard (must be empty):**

```bash
git grep -nE 'CLAUDE_PLUGIN_ROOT|LENS_ROOT' -- skills
```
```
(no output; exit 1)
```
✅ Wish B leaves nothing under `skills/**` pointing at the deleted plugin root.

**Decision-7 worklist for Wish C** — the enumerated tokens, still exactly the 5 files the plan named:

```bash
git grep -nE '\$genie:|genie_(engineer|reviewer|fixer|final_gate|scout)|engineer-(trivial|standard|complex)' -- skills
```
```
skills/README.md:8:- Codex plugin: `$genie:brainstorm`, `$genie:wish`, `$genie:review`, `$genie:work`
skills/README.md:12:The `agents/openai.yaml` starter prompt inside each skill is deliberately selector-free. …
skills/genie-hacks/references/catalog.md:141:  #    engineer-trivial named role (model/effort set in its agent profile)
skills/trace/SKILL.md:40:Trace runs through a fresh read-only scout/explorer role … (runtime profile `genie_scout` when installed).
skills/wish/templates/wish-template.md:66:`engineer-trivial` / low; **2–3** → `engineer-standard` / medium or high;
skills/wish/templates/wish-template.md:67:**4–6** → `engineer-complex` / high; **7+** → `engineer-complex` plus an
skills/work/SKILL.md:56:| Deterministic implementation, complexity 0-1 | `engineer-trivial` (`genie_engineer_trivial`) |
skills/work/SKILL.md:57:| Moderately coupled implementation, complexity 2-3 | `engineer-standard` (`genie_engineer_standard`) |
skills/work/SKILL.md:58:| High-coupling or stateful implementation, complexity 4+ | `engineer-complex` (`genie_engineer_complex`) |
skills/work/SKILL.md:59:| Review | `reviewer` (`genie_reviewer`; never the group's engineer) |
skills/work/SKILL.md:60:| Fix | `fixer` (`genie_fixer`; separate from the reviewer) |
skills/work/SKILL.md:61:| Final plan or execution gate | `final-gate` (`genie_final_gate`) |
skills/work/SKILL.md:62:| Bounded read-only discovery | `scout` (`genie_scout`) |
```

### Worklist handed to Wish C, by `file:line`

| # | Site | What is now false / stale | Owner |
|---|------|---------------------------|-------|
| 1 | `skills/README.md:8` | `$genie:<name>` selectors named as "Codex plugin" invocations — the Codex plugin is deleted | Wish C (BANNED-13 + vocabulary mapping) |
| 2 | `skills/README.md:12` | Same `$genie:<name>` / `$<name>` selector vocabulary | Wish C |
| 3 | **`skills/README.md:37-38`** | **"`plugins/genie/skills/` is a committed physical mirror of this directory … Never edit the mirror directly" — the mirror was deleted by G4 (`e250b9463`); the sentence is now false.** Named in C5-lite as a required worklist addition. | Wish C |
| 4 | **`skills/README.md:40-41`** (found by this group, **not** in the plan's worklist) | The "Distribution contract" code block still tells the reader to run `bun scripts/sync-plugin-skills.ts --write` / `--check` — **G4 deleted that script**, so both commands now fail. Same paragraph as #3. `bun run skills:lint` and `bun scripts/fresh-install-smoke.ts` on the following lines still exist. | Wish C |
| 5 | `skills/genie-hacks/references/catalog.md:141` | `engineer-trivial` named role | Wish C |
| 6 | `skills/trace/SKILL.md:40` | `genie_scout` runtime profile | Wish C |
| 7 | `skills/wish/templates/wish-template.md:66-67` | `engineer-trivial` / `engineer-standard` / `engineer-complex` routing table | Wish C |
| 8 | `skills/work/SKILL.md:56-62` | The whole `genie_*` role-profile mapping table | Wish C |

Sites 3 and 4 are stale-docs only: nothing in `.github/workflows`, `.husky` or `package.json` invokes
them, and Wish B's scope is explicitly "minimum CLAUDE.md / AGENTS.md edits only" (Decision 12), with
the `skills/**` rewrite assigned to Wish C. They are recorded here rather than fixed.

---

## C7 — `release-publish.yml` surgery

**(a) Neither dogfood job survives, anywhere in `.github`:**

```bash
git grep -n "codex-native-dogfood\|codex-dogfood-completeness" -- .github
```
```
(no output; exit 1)
```

**(b) `publish.needs` is exactly six edges, each with its `if:` guard intact** (`release-publish.yml:1359-1377`):

```yaml
  publish:
    name: Publish to GitHub Releases
    needs:
      - admit
      - attest-delivery-evidence
      - delivery-evidence-compatibility
      - skills-install-smoke
      - release-update-path-smoke
      - stable-release-security-gate
    if: >-
      ${{
        always() &&
        needs.admit.result == 'success' &&
        needs.attest-delivery-evidence.result == 'success' &&
        needs.delivery-evidence-compatibility.result == 'success' &&
        needs.skills-install-smoke.result == 'success' &&
        needs.release-update-path-smoke.result == 'success' &&
        needs.stable-release-security-gate.result == 'success'
      }}
```

Seven edges → six; only `codex-dogfood-completeness` left; the six survivors each keep their
`needs.<job>.result == 'success'` guard. ✅

**(c) musl surfaces byte-unchanged:**

```bash
git diff --exit-code origin/dev -- .github/workflows/musl-adapter-smoke.yml scripts/run-musl-dogfood.sh
```
```
(no output; exit 0)
```

**The live leg** — that a real candidate `Release publish` run is green with `skills-install-smoke`
and `release-update-path-smoke` and no Codex dogfood matrix — cannot be proven pre-merge. Recorded as
[post-merge acceptance](#post-merge-acceptance).

---

## C8 — Orca no-diff + Orca suites

```bash
git diff --stat origin/dev -- plugins/genie/orca-* plugins/genie/plugin.json \
  plugins/genie/references/orca-orchestration.md orca-marketplace.json \
  scripts/orca-*.ts src/lib/orca-*.ts .github/workflows/orca-plugin-ref.yml
```
```
 scripts/orca-bundle-parity.ts | 11 +++++------
 1 file changed, 5 insertions(+), 6 deletions(-)
```

**Not empty — classified, and it is comment-only.** Every changed line in the diff, with the file
markers stripped:

```
- * tarball, yet it sits outside tsc, biome, knip and the hook-bundle gate, so a
- * commit that edits only the blob would pass `bun run check`, get attested,
- * and reach every operator. Provenance proves origin, not correspondence to
- * reviewed source. This script binds the committed bundle byte-for-byte to
- * `plugins/genie/orca-entrypoint.ts`, exactly like `hook-bundle-parity.ts`
- * does for the generated hook executables.
+ * tarball, yet it sits outside tsc, biome and knip, so a commit that edits only
+ * the blob would pass `bun run check`, get attested, and reach every operator.
+ * Provenance proves origin, not correspondence to reviewed source. This script
+ * binds the committed bundle byte-for-byte to
+ * `plugins/genie/orca-entrypoint.ts`.
```

Every `+`/`-` line begins with ` * ` — the change is entirely inside the module's header comment, and
**zero executable bytes moved**. It was made by G4 (`e250b9463`) because the old text named
`hook-bundle-parity.ts`, a script that commit deleted; reverting it would restore a dangling
reference to a nonexistent gate. Recorded as an accepted, classified C8 residual rather than a
silent pass.

**The four Orca suites:**

```bash
bun test plugins/genie/orca-runtime.test.ts scripts/orca-manifest-parity.test.ts \
  scripts/orca-bundle-parity.test.ts src/lib/orca-plugin-lifecycle.test.ts
```
```
bun test v1.3.14 (0d9b296a)

 29 pass
 0 fail
 115 expect() calls
Ran 29 tests across 4 files. [451.00ms]
```

---

## C9 — branch-protection evidence

```bash
git ls-files .genie/wishes/skills-everywhere-b/
```
```
.genie/wishes/skills-everywhere-b/HANDOFF.md
.genie/wishes/skills-everywhere-b/WISH.md
.genie/wishes/skills-everywhere-b/qa/20260901.md
.genie/wishes/skills-everywhere-b/ruleset-main.json
```

> Re-run on the current branch head, **after** this evidence file was itself committed — hence four
> tracked files, not the three that existed at the moment the criterion was first measured. The
> criterion is `ruleset-main.json` being committed, which is unaffected.

The committed ruleset, re-read on this head:

```json
{"id": 9203218, "name": "main", "target": "branch", "enforcement": "active",
 "rules": ["deletion", "non_fast_forward", "pull_request", "required_status_checks"]}
```

`pull_request` carries `required_approving_review_count: 1`, `dismiss_stale_reviews_on_push: true`,
`require_last_push_approval: true`, `required_review_thread_resolution: true`,
**`require_extra_approval_for_unattributed_changes: true`** and `allowed_merge_methods: ["merge"]`;
`required_status_checks` carries `Quality Gate (typecheck + lint + test)` (integration 15368);
`bypass_actors` are `RepositoryRole 5` (admin) and one Integration.

Decision 9 (`WISH.md:67`) records both what this proves and the accepted actor gap
(a ruleset cannot distinguish an agent from the human whose `gh` credentials it uses). ✅

---

## C11 — build/release toolchain

```bash
bun scripts/version.ts --check
```
```
version --check: 3 version file(s), no writes performed
  • package.json
  • plugins/genie/orca-plugin.json
  • plugins/genie/package.json

✅ Every version file is present and bump-ready
exit=0
```
Exactly the three targets C11 names — the deviation the criterion itself records
(`plugins/genie/package.json` as a third stamp target) and nothing else. ✅

```bash
bun scripts/release-payload-version.ts --verify-source .
```
```
release-payload-version: OK (verify-source 5.260831.7)
exit=0
```

```bash
bun scripts/fresh-install-smoke.ts
```
```
fresh-install-smoke: OK (25 valid skills, 22 bundled references, Claude variables unset)
exit=0
```

```bash
bun test scripts/version-format.test.ts scripts/version-ci-staging.test.ts scripts/release-docs.test.ts
```
```
 50 pass
 0 fail
 781 expect() calls
Ran 50 tests across 3 files. [373.00ms]
```

**`bash scripts/release-guard.sh` — fails closed outside GitHub Actions, by design.** Both invocation
forms, pasted honestly:

```bash
bash scripts/release-guard.sh
# release-guard: unknown subcommand '<none>'        exit=64

bash scripts/release-guard.sh guard-trusted-release   # the only CI invocation, release.yml:116
# release-guard: privileged release workflow must run from trusted refs/heads/main (got '<empty>')
# exit=3
```

Its runnable proof — the same substitution G6 recorded — is its own suite, plus a direct read of the
version-file list it now enumerates (`release-guard.sh:160-168`: `package.json`,
`plugins/genie/package.json`, and `plugins/genie/orca-plugin.json` only when it changed):

```bash
bun test scripts/release-guard.test.ts
```
```
 39 pass
 0 fail
 81 expect() calls
Ran 39 tests across 1 file. [2.23s]
```

**`bash scripts/build-binary.sh` — run in full for one platform** (it is also the C-R4 candidate):

```bash
bash scripts/build-binary.sh --platform linux-x64-glibc
```
```
fresh-install-smoke: OK (25 valid skills, 22 bundled references, Claude variables unset)
orca-bundle-parity: OK
release-payload-version: OK (verify-source 5.260831.7)
==> [linux-x64-glibc] bun build --compile --target=bun-linux-x64  (v5.260831.7)
  [81ms]  bundle  283 modules
 [387ms] compile  …/dist/linux-x64-glibc/genie
release-payload-version: OK (stamp 5.260831.7)
fresh-install-smoke: OK (25 valid skills, 22 bundled references, Claude variables unset)
release-payload-version: OK (verify 5.260831.7)
fresh-install-smoke: OK (25 valid skills, 22 bundled references, Claude variables unset)
release-payload-version: OK (verify 5.260831.7)
==> …/dist/genie-5.260831.7-linux-x64-glibc.tar.gz  (34 MB)
exit=0
```

**Payload-member allowlist re-proof** (the release-breaking class G3 and G4 each found in their fix
loops — re-measured here on the assembled head, over a freshly built tarball):

```bash
tar -tzf dist/genie-5.260831.7-linux-x64-glibc.tar.gz | sed 's|^\./||' | awk -F/ 'NF>0{print $1}' | sort -u
```
```
LICENSE
VERSION
genie
plugins
skills
templates
```
```ts
// src/lib/install-promotion.ts:32
export const INSTALL_PAYLOAD_MEMBERS = ['LICENSE', 'VERSION', 'genie', 'plugins', 'skills', 'templates'] as const;
```
Byte-equal, six members on both sides. ✅

**The four-platform matrix leg** (`bun run build:binary` green on all four platforms) needs the CI
matrix; recorded as [post-merge acceptance](#post-merge-acceptance).

---

## C-G — `plugins/genie` references + the gate

```bash
git grep -n "plugins/genie" -- src scripts .github package.json
```

105 hits across 27 files. The literal criterion wording is "only Orca-owned lines"; as in G3/G4/G5's
amended headline greps, that literal form is unattainable without deleting the proofs, so every hit is
classified into exactly **three** named classes and any fourth class is a regression. There is no
fourth class: the per-file counts below partition the 27 hit-bearing files with no file in two classes
and no file in none, and the three subtotals sum to the headline 105.

**The full output, pasted (Deliverable 2 — 105 lines, one per hit):**

> _The 105-line raw output is pasted in full in the committed file_ `.genie/wishes/skills-everywhere-b/qa/20260901.md` _- elided here only because reproducing it would push this PR body past GitHub 65 KB limit. The per-file `git grep -c` table below is reproduced verbatim._


**The per-file counts the classification is built on** (this is what the class subtotals are summed
from, so they are counted, never back-fitted from the headline total):

```bash
git grep -c "plugins/genie" -- src scripts .github package.json | sort
```
```
.github/workflows/orca-plugin-ref.yml:8
.github/workflows/release-publish.yml:3
.github/workflows/version.yml:3
package.json:1
scripts/build-binary.sh:2
scripts/build-delivery-evidence.ts:1
scripts/fresh-install-smoke.ts:1
scripts/orca-bundle-parity.ts:4
scripts/orca-manifest-parity.test.ts:10
scripts/release-docs.test.ts:8
scripts/release-guard.sh:3
scripts/release-guard.test.ts:5
scripts/release-payload-version.test.ts:16
scripts/release-payload-version.ts:2
scripts/version-ci-staging.test.ts:6
scripts/version-format.test.ts:12
scripts/version.ts:3
scripts/wishes-lint.ts:1
src/genie-commands/__tests__/update-command-publication.test.ts:1
src/genie-commands/__tests__/update.test.ts:1
src/genie-commands/doctor.ts:1
src/lib/legacy-integration-retirement.test.ts:1
src/lib/legacy-integration-retirement.ts:4
src/lib/orca-plugin-lifecycle.ts:2
src/lib/runtime-integrations.ts:3
src/lib/skills-installer.test.ts:1
src/lib/skills-installer.ts:2
```

27 files; the counts sum to 105, matching the `git grep -n | wc -l` headline.

### Class (i) — Orca payload, its version stamping and its parity gates (86 hits, 15 files)

`.github/workflows/orca-plugin-ref.yml` (8) · `version.yml:15,199,200` (3) ·
`package.json:10` (1 — the published `files` array) · `scripts/build-binary.sh:120,121` (2 — the two
required Orca payload files) · `scripts/orca-bundle-parity.ts` (4) ·
`scripts/orca-manifest-parity.test.ts` (10) ·
`scripts/release-docs.test.ts:41,45,682,744,745,765,773,862` (8) ·
`scripts/release-guard.sh:163,166,167` (3) · `scripts/release-guard.test.ts` (5) ·
`scripts/release-payload-version.ts` (2) + `scripts/release-payload-version.test.ts` (16) ·
`scripts/version.ts:15,16,118` (3) · `scripts/version-format.test.ts` (12) ·
`scripts/version-ci-staging.test.ts` (6) · `src/genie-commands/doctor.ts:1295` (1) and
`src/lib/orca-plugin-lifecycle.ts:162,252` (2) — the three dynamic
`plugins/genie/orca-runtime.js` imports.

`8+3+1+2+4+10+8+3+5+2+16+3+12+6+1+2 = **86**`.

### Class (ii) — the shipped payload **directory** (which is now the Orca tree) as a delivery member (9 hits, 5 files)

`.github/workflows/release-publish.yml:977,981,985` (3 — the update-path smoke stages the payload tree
into `$GENIE_HOME`) · `scripts/build-delivery-evidence.ts:119` (1 — the tree must be a physical,
non-symlinked directory) · `src/lib/runtime-integrations.ts:374,391,1222` (3 — the two doc comments
over the bundle-root resolver and its not-found error string; the probe itself is
`existsSync(join(root, 'plugins', 'genie'))`, re-pointed by G3, so it carries no literal) ·
`src/genie-commands/__tests__/update-command-publication.test.ts:48` (1) ·
`src/genie-commands/__tests__/update.test.ts:1502` (1).

`3+1+3+1+1 = **9**`.

### Class (iii) — negative guards and historical prose about the **deleted** mirror (10 hits, 6 files)

`scripts/fresh-install-smoke.ts:118` (1) — the smoke **forbids** `plugins/genie/references/` and
`$GENIE_HOME/plugins/genie` inside any `SKILL.md`; `src/lib/skills-installer.ts:81,490` (2) and
`skills-installer.test.ts:532` (1) — the comments explaining why the install source is pinned to
`$GENIE_HOME/skills` and why that path is pruned from the discovery scan, both of which say in so many
words that the mirror "left with the Claude plugin";
`src/lib/legacy-integration-retirement.ts:461,476,747,1770` (4) +
`legacy-integration-retirement.test.ts:953` (1)
— retirement surfaces for `plugins/genie` bundles a **previous** Genie wrote onto a real host, which
must keep naming the path to be able to remove it; `scripts/wishes-lint.ts:14` (1) — the rehome note.

`1+2+1+4+1+1 = **10**`.

**Reconciliation:** `86 + 9 + 10 = 105` ✅ — equal to the headline, and every one of the 27
hit-bearing files appears in exactly one class.

### The gate on this head

```bash
bun run check:fast
```
```
…
skills-lint: OK (43 files scanned, 0 missing, 0 resource violations)
wishes-lint: OK (85 files scanned, 0 broken brainstorm links, template validator green)
Cognitive-complexity budget report
Warnings (score > threshold): 2 / 7
Max observed score:           29 / 42
Explicit suppressions:        0 / 8
Retained hotspots (score, location, function):
  -  29  src/lib/orca-orchestration-adapter.ts:789 parseJsonRejectingDuplicateKeys
  -  26  src/genie-commands/doctor.ts:765 codexPluginSurfaceChecks
OK: budget intact.
orca-bundle-parity: OK
exit=0
```

> Re-run on the current branch head after this evidence file was committed: `wishes-lint` now scans
> **85** files, not the 84 it scanned before the file existed. Every gate is still green and no
> criterion moves.

`check` composition on this head, read from `package.json` — the **eight** / **seven** steps the wish
specifies:

```
check     : typecheck && lint && dead-code && skills:lint && wishes:lint && lint:complexity-budget && lint:orca-bundle && bun test
check:fast: typecheck && lint && dead-code && skills:lint && wishes:lint && lint:complexity-budget && lint:orca-bundle
```

**The full `bun run check` is substituted per the host rule** (its last step is the full `bun test`,
which OOMs this host at exit 137 on pre-existing `Worker` tests): `check:fast` covers all seven static
gates locally, and the full test gate is the named CI run below.

> **Full-gate CI leg: green.** `Quality Gate (typecheck + lint + test)` **and**
> `Unit (build + typecheck + lint + dead-code + test)` both succeeded in run
> **[33455733167](https://github.com/automagik-dev/genie/actions/runs/33455733167)** on the exact
> measured head `3d56eed7e`, and again in run
> **[33456983012](https://github.com/automagik-dev/genie/actions/runs/33456983012)** on this branch.
> Full job lists are pasted [below](#named-ci-runs-for-the-full-gate--both-green-).

---

## C-R4 — fresh-host install/uninstall cycle

Run inside a **throwaway fixture**: `HOME` and `GENIE_HOME` were exported **for the child processes
only** (`env HOME=<fixture> GENIE_HOME=<fixture>/.genie …`), never into the session environment. The
real `$HOME` was verified untouched afterwards (`find /home/genie/.claude/skills -maxdepth 1 -newermt
'2026-09-01 00:40'` → empty). `$HOME` below is the fixture root
`…/scratchpad/fresh-host-home`.

### 1. Candidate tarball, laid out exactly as `install.sh` does

`install.sh` extracts the verified tarball into `$GENIE_HOME/bin/` and `genie install`'s
`normalizeAuxLayout` then promotes `bin/{plugins,skills,templates}` to the `$GENIE_HOME` root. The
fixture reproduces that:

```bash
bash scripts/build-binary.sh --platform linux-x64-glibc     # 34 MB, output pasted under C11
mkdir -p "$FH/.genie/bin"
tar -xzpf dist/genie-5.260831.7-linux-x64-glibc.tar.gz -C "$FH/.genie/bin"
ls -la "$FH/.genie/bin"
```
```
-rw-r--r--  1 genie genie     1066 LICENSE
-rw-r--r--  1 genie genie       11 VERSION
-rwxr-xr-x  1 genie genie 96909440 genie
drwxr-xr-x  3 genie genie     4096 plugins
drwxr-xr-x 27 genie genie     4096 skills
drwxr-xr-x  2 genie genie     4096 templates
```

### 2. Foreign skills planted **before** the install

Three, in two homes, covering both cases the wish separates — a foreign name that must survive, and a
**colliding** name that must be snapshotted and backed up (C-R3):

```bash
mkdir -p "$FH/.claude/skills/foreign-tool" "$FH/.claude/skills/quick" "$FH/.config/goose/skills/goose-native"
# … each gets its own SKILL.md …
sha256sum "$FH/.claude/skills/foreign-tool/SKILL.md" "$FH/.claude/skills/quick/SKILL.md" \
          "$FH/.config/goose/skills/goose-native/SKILL.md"
```
```
23e638dab39f60f8ecb7001fe4b4ab48e3986fe56e0fb4d1bd95939ba5638c30  $HOME/.claude/skills/foreign-tool/SKILL.md
837ddad7a07b10944d2bf28dedb878fb208d40d6868ff0fb1b58307956879b11  $HOME/.claude/skills/quick/SKILL.md      <- collides with our `quick`
4d98cf9fd3ba494557adfdc60f03ef6d16c266c35ae1869b82e3853b5d095751  $HOME/.config/goose/skills/goose-native/SKILL.md
```

### 3. Install

```bash
env HOME="$FH" GENIE_HOME="$FH/.genie" "$FH/.genie/bin/genie" install
```
```
  + plugins: refreshed
  + skills: refreshed
  + templates: refreshed
  ! claude: claude plugin marketplace add $HOME/.genie failed: ✘ Failed to add marketplace:
    Marketplace file not found at $HOME/.genie/.claude-plugin/marketplace.json      <-- FINDING H1
skills: installed 25 skill(s) from local:$HOME/.genie/skills into 57 agent dir(s)
skills: collision: $HOME/.claude/skills/quick (quick) — backed up to
        $HOME/.genie/state-backups/skills-collision-2026-09-01T00-46-44-705Z
exit=0
```

**This one line is the whole point of Wish B's G1**, measured on a real host end-to-end:
`local:$HOME/.genie/skills` (not `automagik-dev/genie@…`), and **57** agent dirs — not 4.

### 4. Measure the written homes with the dogfood evidence command

```bash
find "$HOME" -maxdepth 6 -type d -name skills | sort | wc -l
```
```
60
```

```
$HOME/.adal/skills            $HOME/.agents/skills          $HOME/.aider-desk/skills
$HOME/.astrbot/data/skills    $HOME/.augment/skills         $HOME/.autohand/skills
$HOME/.bob/skills             $HOME/.claude/skills          $HOME/.codeartsdoer/skills
$HOME/.codebuddy/skills       $HOME/.codeium/windsurf/skills $HOME/.codemaker/skills
$HOME/.codestudio/skills      $HOME/.commandcode/skills     $HOME/.config/crush/skills
$HOME/.config/devin/skills    $HOME/.config/goose/skills    $HOME/.config/kimchi/harness/skills
$HOME/.continue/skills        $HOME/.factory/skills         $HOME/.forge/skills
$HOME/.genie/skills                                                       <- SOURCE (pruned)
$HOME/.genie/state-backups/skills-collision-…/.claude/skills              <- COLLISION BACKUP (pruned)
$HOME/.grok/skills            $HOME/.hermes/skills          $HOME/.iflow/skills
$HOME/.inferencesh/skills     $HOME/.jazz/skills            $HOME/.junie/skills
$HOME/.kilocode/skills        $HOME/.kiro/skills            $HOME/.kode/skills
$HOME/.lingma/skills          $HOME/.mcpjam/skills          $HOME/.minimax/skills
$HOME/.moxby/skills           $HOME/.mux/skills             $HOME/.neovate/skills
$HOME/.npm/_npx/ee7d2e9969555a41/node_modules/skills                      <- npx CLI cache (pruned)
$HOME/.ona/skills             $HOME/.openclaw/skills        $HOME/.openhands/skills
$HOME/.pi/agent/skills        $HOME/.pochi/skills           $HOME/.posit/assistant/skills
$HOME/.qoder-cn/skills        $HOME/.qoder/skills           $HOME/.qwen/skills
$HOME/.reasonix/skills        $HOME/.roo/skills             $HOME/.rovodev/skills
$HOME/.snowflake/cortex/skills $HOME/.tabnine/agent/skills  $HOME/.terramind/skills
$HOME/.tinycloud/skills       $HOME/.trae-cn/skills         $HOME/.trae/skills
$HOME/.vibe/skills            $HOME/.zcode/skills           $HOME/.zencoder/skills
```

```bash
# measured homes, minus the source, the collision backup and the npx package cache
grep -vE "\.genie/skills$|state-backups|node_modules" homes-after-install.txt | wc -l
```
```
57
```

**C-R1 proven end-to-end: measured 57 === recorded 57**, on a host where
`KNOWN_AGENT_SKILL_HOMES` matches 4. On the pre-Wish-B channel this record would have said `4`, and a
record-driven uninstall would have orphaned 25 × 53 = 1,325 directories.

### 5. The record

```bash
ls -l "$FH/.genie/skills-install.json"
```
```
-rw------- 1 genie genie 341129 Sep  1 00:46 $HOME/.genie/skills-install.json
```
```json
{ "ref": "v5.260831.7",
  "source": "local:$HOME/.genie/skills",
  "inventoryCount": 25,
  "agentDirsCount": 57,
  "collisions": [ { "dir": "$HOME/.claude/skills/quick", "skill": "quick" } ],
  "installedAt": "2026-09-01T00:46:51.600Z" }
```
Record keys: `ref, source, cliVersion, inventory, agentDirs, dirDigests, collisions, installedAt`.
First agent dirs, in table-then-scan order: `.claude/skills`, `.agents/skills`,
`.config/goose/skills`, `.codeium/windsurf/skills` (the known-home floor), then `.adal`,
`.aider-desk`, `.astrbot/data`, `.augment`, … (the scan). Inventory (25):
`architecture brainstorm code-quality council docs dream dx-docs fix genie genie-hacks
genie-orca-review genie-orca-wish genie-orca-work omni perf qa quick refine repo-hygiene report
review supply-chain trace wish work`.

**C-R3 proven on a real host:** the backup holds the *original foreign* bytes and the live directory
now holds *our* bytes.

```bash
sha256sum "$FH/.genie/state-backups/skills-collision-…/.claude/skills/quick/SKILL.md"
# 837ddad7a07b10944d2bf28dedb878fb208d40d6868ff0fb1b58307956879b11   <- == the pre-install foreign sha
sha256sum "$FH/.claude/skills/quick/SKILL.md" "$FH/.genie/skills/quick/SKILL.md"
# 5693413bbb37a78755546985071371cdb250ac6354a21cfb434c2bd457d8bff1  $HOME/.claude/skills/quick/SKILL.md
# 5693413bbb37a78755546985071371cdb250ac6354a21cfb434c2bd457d8bff1  $HOME/.genie/skills/quick/SKILL.md
```

### 6. Uninstall

Run under a PTY (the confirmation prompt is `@inquirer/prompts`), answering `y`:

```bash
printf 'y\n' | script -qec "env HOME=$FH GENIE_HOME=$FH/.genie $FH/.genie/bin/genie uninstall" /dev/null
```
```
⚠ Warning: removing Genie can break current or resumable tasks. …
✔ Are you sure you want to uninstall Genie CLI? Yes

  + skills.sh channel: removed 1425 recorded skill dir(s) (v5.260831.7)
  nothing to retire
Removing genie directory...
  + Install state removed (state backups preserved)

+ Genie CLI uninstalled.
exit=0
```

**1,425 = 25 × 57.** The old 4-home record would have removed 100 and orphaned 1,325.

### 7. Post-uninstall proof

**(a) Zero genie skill directories remain anywhere under `$HOME`** — cross-checked against the whole
25-name inventory, at depth 7 so a deeper home could not hide:

```bash
for n in architecture brainstorm … wish work; do
  find "$HOME" -maxdepth 7 -type d -name "$n" -path "*/skills/*"
done | grep -v state-backups | sort | wc -l
```
```
0
```

**(b) The 59 remaining `skills` directories are empty shells, foreign content, or the deliberately
preserved backup** — every non-empty one, listed exhaustively:

```bash
find "$HOME" -maxdepth 6 -type d -name skills | sort   # 59
# … then, for each, the entry count and contents; only these four are non-empty:
1   $HOME/.claude/skills                                          | foreign-tool
1   $HOME/.config/goose/skills                                    | goose-native
1   $HOME/.genie/state-backups/skills-collision-…/.claude/skills  | quick
6   $HOME/.npm/_npx/ee7d2e9969555a41/node_modules/skills          | LICENSE README.md … package.json
```
The other 55 are empty directories `skills.sh` created and genie never claimed — uninstall removes
only the skill directories it recorded, never a home it did not create.

**(c) The record is gone and `$GENIE_HOME` is reduced to the preserved backups:**

```bash
ls -la "$FH/.genie"; test -e "$FH/.genie/skills-install.json" && echo YES || echo NO
```
```
drwxr-xr-x  3 genie genie 4096 .
drwx------  3 genie genie 4096 state-backups
record exists? NO
```

**(d) Foreign skills survive byte-identical:**

```bash
sha256sum "$FH/.claude/skills/foreign-tool/SKILL.md" "$FH/.config/goose/skills/goose-native/SKILL.md"
```
```
23e638dab39f60f8ecb7001fe4b4ab48e3986fe56e0fb4d1bd95939ba5638c30  $HOME/.claude/skills/foreign-tool/SKILL.md
4d98cf9fd3ba494557adfdc60f03ef6d16c266c35ae1869b82e3853b5d095751  $HOME/.config/goose/skills/goose-native/SKILL.md
```
Both hashes equal their pre-install values. `$HOME/.claude/skills/quick` — the foreign directory
`--copy` overwrote — is gone from the live home and its original bytes sit in the collision backup;
that is the wish's explicit OUT ("Restoring a foreign skill dir that `--copy` overwrote" is not
implemented, only detected, backed up, recorded and reported).

**C-R4 ✅ MET.**

---

## Group-level residual greps, re-run on the assembled head

Each deletion group's amended headline grep names a fixed set of non-importer classes; G3's
acceptance explicitly obliges **G7** to re-run its grep "against the same two-class list, not against
'returns nothing'". All three are re-measured here and none has grown a new class.

**G3 (two classes, 4 hits — unchanged from the G3 review):**
```bash
git grep -n "codex-activation\|codex-lifecycle-lease\|codex-delivery\|codex-rollback\|codex-host-observation\|codex-doctor-observation\|codex-lifecycle-truth\|codex-release-version" -- src scripts
```
```
scripts/build-delivery-evidence.ts:123:  digest.update('genie-codex-activation-tree-v1\0');   <- wire contract
src/genie-commands/setup.test.ts:131:      'codex-activation',                                <- negative guard
src/genie-commands/setup.test.ts:132:      'codex-lifecycle-lease',                           <- negative guard
src/lib/release-payload-proof.ts:93:  digest.update('genie-codex-activation-tree-v1\0');      <- wire contract (other side)
```
Zero importers; the digest domain separator is byte-identical on both sides, as required.

**G4 (two classes, 2 hits):**
```bash
git grep -n "src/hooks\|hook dispatch" -- src scripts package.json
```
```
src/genie-commands/legacy-v4.test.ts:164:  '{\n  "hooks": [{ "command": "genie hook dispatch" }]\n}\n'
src/lib/claude-settings.test.ts:52:  hooks: { PreToolUse: [{ …, command: 'genie hook dispatch' }] }
```
Both are settings fixtures a host installed **before** this wish would carry — exactly what v4-residue
detection and settings-hook removal must still recognize. No importer of `src/hooks/**` survives.

**G5 (three ratified classes, 26 hits, counts matching the amendment exactly):**
```bash
git grep -c "agent-sync" -- src scripts plugins package.json   # total 26
```
| Class | Token | Hits |
|---|---|---|
| (i) wire contract — the `managedBy` value on real hosts | `genie-agent-sync` | **10** |
| (ii) wire contract — the published-release-body idempotency marker | `genie-agent-sync-migration-v1` | **14** |
| (iii) negative guards — `.last-agent-sync` must be absent from `update.ts` | `.last-agent-sync` | **2** |

```bash
git grep -n "agent-sync" -- src scripts plugins package.json | grep -v "genie-agent-sync" | grep -v "last-agent-sync"
```
```
(no output; exit 1)     <- no fourth class, no stale prose
```

**And the G1 pin guard:**
```bash
git grep -n "automagik-dev/genie@" -- src
```
```
(no output; exit 1)
```

---

## C-A — Wish A closure

```bash
grep -n "Status" .genie/wishes/skills-everywhere/WISH.md | head -1
```
```
5:| **Status** | SHIPPED |
```

The dated correction block is present and names Wish B G1 as the owner of the fix:

```
381:- **Dated correction (2026-08-31):** C1/C2's premise that `add automagik-dev/genie@v<ver>` pins the
     release tag is FICTION — skills@1.5.23 ignores the `@ref` suffix and serves the repository
     default branch … Corrected by Wish B G1 (local-source install from `$GENIE_HOME/skills`).
383:### Closure correction, part 2 — 2026-08-31 — owned by Wish B Group 1
385:- **Upstream follow-up (recorded, not filed).** `vercel-labs/skills`: `skills add <repo>@<ref>`
     silently ignores the `@<ref>` suffix …
```

Both halves of the correction are now **independently confirmed on a real host** by C-R4 above: the
production argv names `local:$HOME/.genie/skills` (no `automagik-dev/genie@`), and the reported N is
the measured 57, not 4. ✅

---

## Finding H1 (HIGH) — the Claude marketplace registration outlived its payload

**Found by the C-R4 fresh-host pass. Not a criterion failure — no wish criterion covers it — but it
is a release-breaking regression on the assembled head, and it is exactly the class of defect
(a break invisible to `bun run check`) that Decision 7 and the mandatory importer sweeps exist to
catch.**

### What breaks

G4 (`e250b9463`) deleted the root `.claude-plugin/marketplace.json` and delisted `.claude-plugin`
from `INSTALL_PAYLOAD_MEMBERS`, so **no delivered `$GENIE_HOME` can ever contain a marketplace
manifest again**. But the Claude *runtime integration* that registers one survived G5:
`installRuntimeIntegrations` (`src/lib/runtime-integrations.ts:1203`) still calls
`installClaudeIntegration` → `claude plugin marketplace add <bundleRoot>`.

On any host with the `claude` CLI:

- **`genie install` (default `--integrations auto`)** — a yellow `!` failure line on every fresh
  install; exit code unaffected. Cosmetic but alarming, and it names a file the product deliberately
  deleted.
- **`genie install --integrations claude` (and `all`)** — a **documented installer flag**
  (`README.md:30`, forwarded by `install.sh:821` as `curl … | bash -s -- --integrations claude`) —
  **aborts with an unhandled error and a raw stack trace**, exit 1. Under `install.sh` that is fatal:
  `die "genie install finishing failed; installation remains incomplete and retryable" 1`
  (`install.sh:854`).

Reproduced verbatim in a second throwaway fixture on this head:

```bash
env HOME="$F2" GENIE_HOME="$F2/.genie" "$F2/.genie/bin/genie" install --integrations claude
```
```
  + plugins: refreshed
  + skills: refreshed
  + templates: refreshed
  ! claude: claude plugin marketplace add $HOME/.genie failed: ✘ Failed to add marketplace:
    Marketplace file not found at $HOME/.genie/.claude-plugin/marketplace.json
…
error: Requested integration failed: claude
      at runPermittedPostDeliveryIntegrations (/$bunfs/root/genie:45890:13)
      at installCommand (/$bunfs/root/genie:45919:56)
Bun v1.3.14 (Linux x64)
exit=1
```

The throw is `src/genie-commands/install.ts:185-189` — an explicit selection that reports a failed
runtime is fatal by design; the design just never anticipated a runtime that can no longer succeed.
A raw stack trace also violates the wish's own QA criterion *"gone from the CLI surface with a clear
error, not a stack trace"*.

### That it is wish-introduced, not pre-existing

```bash
git ls-tree -r --name-only 18b85341b -- .claude-plugin   # .claude-plugin/marketplace.json
git ls-tree -r --name-only HEAD       -- .claude-plugin   # (empty)
git log --oneline --diff-filter=D -1 -- .claude-plugin/marketplace.json
# e250b9463 refactor(hooks): delete the hook runtime and the Claude/Kimi plugin payload
```

### Why it slipped through

G5 deliverable 3's keep-list for `runtime-integrations.ts` enumerates `IntegrationSelection` + consent
I/O, `CommandRunner`/`runBoundedIntegrationCommand`, the three retirement-consumed Codex symbols,
`inspectRuntimeIntegrationEvidence` and the `migrateDeadGenieOtel` seam. **`installRuntimeIntegrations`
/ `convergeClaudePlugin` / `verifyClaudePhysicalPayload` are not on it.** The group's acceptance
criterion is "every remaining export is named in the PR with its consumer", which they satisfy
literally (`install.ts:207` consumes it) — so a live-but-doomed subsystem passed a consumer-existence
check that was never a reachability check. G2 pulling in the opposite direction is the tell: it added
a **retirement surface** for `~/.claude/plugins/marketplaces/automagik/` while install still tries to
create it.

### Why this group did **not** fix it

1. **The fix is not minimal.** The correct fix is deleting the Claude convergence half of
   `runtime-integrations.ts` (`installRuntimeIntegrations`, `convergeClaudePlugin`,
   `verifyClaudePhysicalPayload`, `parseClaudePluginState`, `ClaudePayloadVerifier`),
   `src/genie-commands/update-integrations.ts`'s `refreshUpdatePlugins`, `install.ts`'s whole
   integration-results block, and their tests — while **keeping** `inspectRuntimeIntegrationEvidence`
   and `removeRuntimeIntegrations`, which read and remove the very same registration for doctor and
   retirement. That is a G5-sized deliverable, not a QA patch.
2. **It changes a contract the orchestrator ratified on 2026-09-01.** The G5 fix-loop ratification
   defines `genie update --sync-only` as "skills channel → **Claude plugin refresh** → plugin-era
   retirement". Deleting the refresh step re-opens a ratified decision; that is the orchestrator's
   call, not the proof group's.
3. **Reviewer ≠ engineer.** The proof group must not author the change whose evidence it publishes.

### Candidate dispositions (for the orchestrator / `final-gate`)

| # | Disposition | Cost | Note |
|---|-------------|------|------|
| A | **Delete the Claude install-convergence half** (matches G5 D3's keep-list) | ~1,200–1,500 lines across ≥6 files incl. tests; must preserve `inspectRuntimeIntegrationEvidence` / `removeRuntimeIntegrations` | The wish's evident intent; needs a ratification note for the `--sync-only` contract |
| B | **Guard it**: `installRuntimeIntegrations` returns `[]` when the delivered root carries no `.claude-plugin/marketplace.json` | ~5 lines + one test; keeps every export referenced, so `dead-code` stays green | Mirrors `refreshUpdatePlugins`'s existing `installIfAbsent: false` "an absent plugin remains absent" doctrine, but leaves the subsystem as dead weight for Wish C |
| C | Ship as-is | 0 | **Not recommended** — a documented installer flag hard-fails on every host with the `claude` CLI |

`refreshUpdatePlugins` (the `genie update` path) is **not** affected: it passes
`installIfAbsent: false`, so an absent plugin stays absent and no marketplace add is attempted.
The blast radius is `genie install` only.

### Independently confirmed by the Group 7 review (fix loop 1)

The reviewing agent reproduced this end-to-end on its own fixture — a real tarball from
`bash scripts/build-binary.sh --platform linux-x64-glibc`, its own `$HOME`/`$GENIE_HOME` — and got the
same two outcomes (`auto` → yellow `!` line, exit 0; `--integrations claude` → raw Bun stack trace,
`error: Requested integration failed: claude`, exit 1). It also walked the chain line by line and
confirmed every link on this head; re-verified again here after the fix-loop edits:

| Link | Location | State at this head |
|---|---|---|
| Manifest existed at the C4 baseline | `git ls-tree -r --name-only 18b85341b -- .claude-plugin` | one file |
| Manifest gone at head | `git ls-tree -r --name-only HEAD -- .claude-plugin` | empty |
| `.claude-plugin` delisted from the payload | `src/lib/install-promotion.ts:32` | six members, no `.claude-plugin` |
| Install path forces the add | `src/lib/runtime-integrations.ts:1749` `installIfAbsent: true` | defeats the `:1650` early return, so `:1660` always runs |
| The add throws on this output | `src/lib/runtime-integrations.ts:1576-1587` | "Marketplace file not found" matches none of `/already\|exists\|configured\|different source/i` |
| Explicit selection rethrows | `src/genie-commands/install.ts:188` | `Requested integration failed: claude` |
| `genie update` unaffected | `src/genie-commands/update-integrations.ts:74` `installIfAbsent: false` | short-circuits at `:1650`; blast radius is `genie install` only |

**Status:** the review classified it as **not a Group 7 defect** — the proof group found it correctly
and correctly declined to author the fix — and as **not blocking this docs-only evidence PR**. It
**does** block merging the wish into `dev` and any release cut from this head. Disposition A or B
above is an orchestrator / `final-gate` decision, and disposition A additionally needs a ratification
note re-opening the 2026-09-01 `--sync-only` contract.

---

## Post-merge acceptance

Recorded, **not ticked** — each names the run that will prove it.

| Criterion leg | Proven by |
|---|---|
| ~~**Full `bun run check`**~~ — **already proven, not post-merge** | Runs **33455733167** (measured head `3d56eed7e`) and **33456983012** (this branch), both success — see below |
| **C11, four-platform matrix** — `bun run build:binary` green on linux-x64-glibc, linux-arm64-glibc, linux-x64-musl, darwin-arm64 | `build-tarballs.yml` on the merge commit of this wish into `dev`. Only linux-x64-glibc was built locally (pasted under C11). |
| **C11, `bash scripts/release-guard.sh`** — green *in its CI job* | `release.yml:116` (`guard-trusted-release`) on the first release cut from a head carrying this wish. It fails closed outside Actions by design (exit 3, output pasted above); `release-guard.test.ts` 39 pass is the local substitute. |
| **C7 live leg** — a candidate `Release publish` run green with `skills-install-smoke` + `release-update-path-smoke` and no Codex dogfood matrix | The dev-channel candidate run fired by the merge of `wish/skills-everywhere-b` into `dev`. G3's release freeze is closed by G6 (both dogfood jobs and their `publish.needs` edge are gone — proven statically under C7). |
| **QA criterion — plugin-era host retirement** ("a host carrying the full plugin-era surface is fully retired by one `genie update`, second run prints `nothing to retire`") | A real dogfood host on the first dev release carrying this wish. The fresh-host fixture had no plugin-era assets to retire, and correctly printed `nothing to retire` (pasted under C-R4 step 6). |
| **`version.yml` edits** | `workflow_run` executes the default-branch copy, so G6's edit is inert on `dev` until promoted; evidence is `version-format.test.ts` / `version-ci-staging.test.ts` (50 pass, pasted under C11) plus the first post-promotion bump on `main` (design Risk 15). |

### Named CI runs for the full gate — both green ✅

The full `bun run check` (its last step is the full `bun test`) is proven in CI, on **two** heads:

| Run | Event | Head | Result |
|---|---|---|---|
| **[33455733167](https://github.com/automagik-dev/genie/actions/runs/33455733167)** | `pull_request` (PR #2878, `wish/skills-everywhere-b` → `dev`) | **`3d56eed7e`** — the exact assembled head this document measures | **success** |
| **[33456983012](https://github.com/automagik-dev/genie/actions/runs/33456983012)** | `workflow_dispatch` on `wish/skills-everywhere-b-g7` | `6a011f62b` — this branch, evidence commit | **success** |

```bash
gh run view 33455733167 --json displayTitle,conclusion,jobs
```
```
title: feat(wish): skills-everywhere-b — honest pinned install, delete every non-Orca integration
conclusion: success   at: 2026-09-01T00:40:52Z
  success  Secrets Scan (GitGuardian)
  success  Unit (build + typecheck + lint + dead-code + test)      <- the full `bun test`
  success  E2E (v5 lifecycle)
  success  Skills Inventory Parity (skills.sh --list)
  success  Action Pin Resolvability
  success  Quality Gate (typecheck + lint + test)                  <- the required check
```
```bash
gh run view 33456983012 --json event,headSha,conclusion,jobs
```
```
run 33456983012  event=workflow_dispatch  sha=6a011f62b  conclusion=success  at=2026-09-01T00:59:47Z
  success  Unit (build + typecheck + lint + dead-code + test)
  success  Skills Inventory Parity (skills.sh --list)
  success  Secrets Scan (GitGuardian)
  success  E2E (v5 lifecycle)
  success  Action Pin Resolvability
  success  Quality Gate (typecheck + lint + test)
```

`ci.yml` triggers on `pull_request: branches: [main, dev]`, so a group PR based on
`wish/skills-everywhere-b` gets no automatic run; run 33456983012 was raised explicitly with
`gh workflow run ci.yml --ref wish/skills-everywhere-b-g7`. Run 33455733167 is the more important of
the two — it is the full gate on the head every measurement in this document was taken from.

---

## Deviations and host substitutions

1. **`bun run check` → `bun run check:fast` + two named CI runs.** Mandated by the host rule (the
   full `bun test` OOMs this host at exit 137 on pre-existing `Worker` tests). All seven static gates
   ran locally and are green; the full test gate is proven by CI runs **33455733167** (on the exact
   measured head `3d56eed7e`) and **33456983012** (on this branch), both success. Same substitution
   G1, G3 and G5 recorded — but unlike theirs, this one names a run on the head the numbers came
   from, so the substitution costs nothing.
2. **`bun test` run in targeted batches**, never unfiltered:
   `plugins/genie/orca-runtime.test.ts scripts/orca-manifest-parity.test.ts scripts/orca-bundle-parity.test.ts src/lib/orca-plugin-lifecycle.test.ts`
   (29 pass), `scripts/version-format.test.ts scripts/version-ci-staging.test.ts scripts/release-docs.test.ts`
   (50 pass), `scripts/release-guard.test.ts` (39 pass). `src/lib/runtime-integrations.test.ts` was
   not run unfiltered and `scripts/reconcile-release-assets.test.ts` was skipped (pre-existing local
   timeout), both per the host rule.
3. **C8's diff is not empty.** One comment-only hunk, fully quoted and classified above; zero
   executable bytes.
4. **C-G's literal "only Orca-owned lines" is unattainable** and is discharged the way G3/G4/G5's
   amended headline greps are: three named classes, no fourth class.
5. **`bash scripts/release-guard.sh` cannot be run to green locally** — it fails closed outside
   GitHub Actions. Both invocations are pasted with their exit codes rather than omitted.
6. **The C4 baseline was measured two ways** — a detached `git worktree` at `18b85341b` running the
   criterion's exact command (60,189 / 97), and a `git show`-per-file sum (60,189). Identical.
7. **The C-R4 fixture uses the `release-publish.yml` update-path layout** (extract into
   `$GENIE_HOME/bin`, let `genie install`'s `normalizeAuxLayout` promote `plugins`/`skills`/
   `templates`), not `install.sh` itself, because `install.sh` downloads and cosign-verifies a
   *published* GitHub release and this is an unpublished local candidate. That is the same layout
   `install.sh` produces, and `genie install` — the real post-install finisher `install.sh` hands off
   to — ran unmodified.
8. **No `src/` change was made by this group.** Finding H1 is recorded and escalated instead; the
   reasoning is in its own section, and the Group 7 review agreed with that split (reviewer ≠
   engineer; the disposition belongs to the orchestrator / `final-gate`).

---

## Fix loop 1 — corrections applied after the Group 7 review (2026-09-01)

The review returned FIX-FIRST with four findings. Three were evidence-integrity defects in **this
document** and are corrected above; the fourth is Finding H1, which is not a Group 7 defect.

| # | Finding | Correction |
|---|---|---|
| HIGH | Finding H1 reproduced independently by the review | No code change (out of Group 7's approved scope — its Deliverables and ACs are measurement-only). H1 now carries the reviewer's line-by-line confirmation table and an explicit block/no-block status. |
| MEDIUM | C-G was **not** "pasted in full" (Deliverable 2), and all three class subtotals were back-fitted to the correct total instead of counted (79/13/13 published; 86/9/10 actual). One enumerated reference, `scripts/build-delivery-evidence.ts:227`, was not a hit at all. | The raw 105-line `git grep -n` output is now pasted in full, plus the `git grep -c` per-file table the classes are summed from. Subtotals corrected to **86 / 9 / 10** with per-class arithmetic shown; the phantom `:227` is dropped; four wrong per-file counts fixed (`orca-manifest-parity.test.ts` 7→10, `release-payload-version.{ts,test.ts}` 17→18, `version-format.test.ts` 11→12, `version-ci-staging.test.ts` 5→6). The substantive conclusion is unchanged: three classes, no fourth. |
| LOW | C4's line-accounting narrative was wrong by 164 lines in two places (shrink "6,961"/12 files, growth "the residual 2,000"). The **headline delta was always exact.** | Replaced the prose with a five-term table measured per file — departed 17,685 / shrunk **6,797** (13 files) / grown **1,836** (7 files) / arrived 765 / unchanged 0 — reconciling to 38,308 exactly. The shrink listing gained its missing 13th row (`omni-config.ts`, −1) so it sums to −6,797. |
| LOW | Two pasted outputs were stale against the branch head (`git ls-files` returned 3, now 4; `wishes-lint` said 84, now 85) — both caused by this evidence file itself becoming tracked. | Both re-run on the current head and updated, each with a one-line note naming the cause. `bun run check:fast` was re-run in full and is green. |
