### PR TITLE
feat(skills-lint): ban retired role vocabulary and undiscoverable skill dirs (wish C G1)

### DIFF
--- a/.github/workflows/build-tarballs.yml
+++ b/.github/workflows/build-tarballs.yml
@@ -60,6 +60,7 @@ on:
       - 'scripts/orca-bundle-parity.ts'
       - 'scripts/fresh-install-smoke.ts'
       - 'scripts/skills-lint.ts'
+      - 'scripts/skills-inventory-parity.ts'
       - 'scripts/release-payload-version.ts'
       - '.github/workflows/build-tarballs.yml'
 

--- a/scripts/release-docs.test.ts
+++ b/scripts/release-docs.test.ts
@@ -888,13 +888,19 @@ describe('Group E release and documentation contracts', () => {
       expect(parsed.interface?.default_prompt).not.toMatch(/\$(?:[a-z0-9][a-z0-9-]*:)?[a-z0-9][a-z0-9-]*/i);
     }
 
+    // skills.sh is the ONE skills channel after wish skills-everywhere-b: the
+    // overview names it, keeps the default-branch caveat on the manual command,
+    // and no longer promises a plugin/user-tier fallback of any kind.
     const skillsOverview = read('skills/README.md');
-    expect(skillsOverview).toContain(
-      'Codex user tier (only a separately installed personal copy; Genie no longer seeds this tier)',
-    );
+    expect(skillsOverview).toContain('npx skills add automagik-dev/genie');
+    expect(skillsOverview).toContain("repository's default branch");
+    expect(skillsOverview).toContain('`genie update` installs the exact delivered');
+    expect(skillsOverview).toContain('separately installed personal copy of a skill is');
     expect(skillsOverview).not.toContain('CLI-managed product fallback');
-    expect(skillsOverview).toContain('persists Codex maintenance consent');
-    expect(skillsOverview).toContain('later explicit `genie update`');
+    expect(skillsOverview).not.toContain('persists Codex maintenance consent');
+    // The retired plugin mirror and its generator are gone from the contract.
+    expect(skillsOverview).not.toContain('sync-plugin-skills');
+    expect(skillsOverview).not.toContain('plugins/genie/skills/');
   });
 
   test('lifecycle and operator docs name design, plan, and implementation review as distinct mandatory gates', () => {

--- a/scripts/skills-inventory-parity.ts
+++ b/scripts/skills-inventory-parity.ts
@@ -2,18 +2,26 @@
 /**
  * CI guard for the skills.sh inventory contract (wish `skills-everywhere`, C6).
  *
- * The published skill inventory is whatever `skills@<PINNED> add
- * automagik-dev/genie@<ref> --list` names at that ref. Genie's own record
+ * The published skill inventory is whatever `skills@<PINNED> add <local
+ * checkout> --list` names for THIS commit. Genie's own record
  * (`inventoryFromSkillsDir`, `src/lib/skills-installer.ts`) instead derives the
  * inventory from the TOP-LEVEL `skills/*​/SKILL.md` names in the checkout. The
  * two must agree, or `genie uninstall` removes the wrong set and `doctor`
  * reports freshness against a list nobody published.
  *
- * Usage (the CI job pipes the real CLI's human output in):
- *   npx -y skills@<PINNED> add automagik-dev/genie@<sha> --list 2>&1 \
- *     | bun scripts/skills-inventory-parity.ts --repo .
+ * REF CAVEAT: the source is the LOCAL checkout, never `automagik-dev/genie@<ref>`
+ * — `skills@1.5.23` binds the third capture of its source spec to `skillFilter`,
+ * not to a ref, so an `@<ref>` suffix is ignored and the repository's DEFAULT
+ * branch is served (verified 2026-08-31). The ref-pinned form made this check
+ * vacuous on PRs; a local path is the only way to list the commit under test.
  *
- *   bun scripts/skills-inventory-parity.ts --repo . --list-file captured.txt
+ * Usage (the `ci.yml` form — the CI job captures the real CLI's human output):
+ *   npx -y skills@<PINNED> add "$PWD" --list > "$RUNNER_TEMP/skills-list.txt" 2>&1
+ *   bun scripts/skills-inventory-parity.ts --repo . --list-file "$RUNNER_TEMP/skills-list.txt"
+ *
+ * The list may also arrive on stdin:
+ *   npx -y skills@<PINNED> add "$PWD" --list 2>&1 \
+ *     | bun scripts/skills-inventory-parity.ts --repo .
  *
  * Exit 0 only when every one of these holds:
  *   - the parsed `--list` names and the repo's top-level skill dirs are the
@@ -178,9 +186,15 @@ function collectSkillFiles(skillsRoot: string, skipped?: Set<string>): string[] 
   return found.sort();
 }
 
-/** The checkout side of the contract: top-level `skills/<name>/SKILL.md` only. */
-export function scanRepoSkills(repoRoot: string): RepoSkillsScan {
-  const skillsRoot = join(repoRoot, 'skills');
+/**
+ * The checkout side of the contract: top-level `skills/<name>/SKILL.md` only.
+ *
+ * `skillsRoot` defaults to `<repoRoot>/skills`. It is an explicit override so a
+ * caller that already holds a skills root — `scripts/skills-lint.ts`, whose
+ * `SKILLS_LINT_DIR` fixture hook points straight at one — reuses THIS walk
+ * instead of re-deriving the nested/empty contract in a second implementation.
+ */
+export function scanRepoSkills(repoRoot: string, skillsRoot: string = join(repoRoot, 'skills')): RepoSkillsScan {
   const skippedSymlinks = new Set<string>();
   const topLevel = listPhysicalEntries(skillsRoot, '', skippedSymlinks);
   const directories = topLevel.filter((entry) => entry.isDirectory).map((entry) => entry.relativePath);

--- a/scripts/skills-lint.test.ts
+++ b/scripts/skills-lint.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { execFileSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+  BANNED_TOKEN_GUIDANCE,
   checkResourceLine,
+  collectBannedTokenViolations,
   collectResourceViolations,
   extractInlineCodeSpans,
   getGenieCommands,
@@ -13,6 +15,46 @@ import {
 } from './skills-lint.ts';
 
 const SCRIPT = join(import.meta.dir, 'skills-lint.ts');
+
+interface LintRun {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Write a structurally valid fixture skill (`SKILL.md` + `agents/openai.yaml`). */
+function writeSkillIn(dir: string, name: string, body: string): string {
+  const skillDir = join(dir, name);
+  mkdirSync(join(skillDir, 'agents'), { recursive: true });
+  const skill = body.startsWith('---\n')
+    ? body
+    : `---\nname: ${name}\ndescription: "Use ${name} for this test workflow."\n---\n\n${body}`;
+  writeFileSync(join(skillDir, 'SKILL.md'), skill);
+  writeFileSync(
+    join(skillDir, 'agents', 'openai.yaml'),
+    [
+      'interface:',
+      `  display_name: "${name}"`,
+      `  short_description: "Run the ${name} workflow safely"`,
+      `  default_prompt: "Run the ${name} workflow for this task."`,
+      '',
+    ].join('\n'),
+  );
+  return skillDir;
+}
+
+/**
+ * Run the gate with `SKILLS_LINT_DIR` pointed at a fixture tree. `spawnSync`
+ * (not `execFileSync`) so stderr is captured on the SUCCESS path too — the
+ * "OK (…)" summary the positive fixtures assert against is written to stderr.
+ */
+function runLintIn(dir: string): LintRun {
+  const result = spawnSync('bun', [SCRIPT], {
+    env: { ...process.env, SKILLS_LINT_DIR: dir },
+    encoding: 'utf8',
+  });
+  return { code: result.status ?? 1, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
+}
 
 test('clean checkout probes the current source CLI when dist is absent', () => {
   const root = mkdtempSync(join(tmpdir(), 'skills-lint-clean-root-'));
@@ -122,39 +164,11 @@ describe('end-to-end: skills-lint against fixture skills trees', () => {
   });
 
   function writeSkill(name: string, body: string): void {
-    const skillDir = join(dir, name);
-    mkdirSync(join(skillDir, 'agents'), { recursive: true });
-    const skill = body.startsWith('---\n')
-      ? body
-      : `---\nname: ${name}\ndescription: "Use ${name} for this test workflow."\n---\n\n${body}`;
-    writeFileSync(join(skillDir, 'SKILL.md'), skill);
-    writeFileSync(
-      join(skillDir, 'agents', 'openai.yaml'),
-      [
-        'interface:',
-        `  display_name: "${name}"`,
-        `  short_description: "Run the ${name} workflow safely"`,
-        `  default_prompt: "Run the ${name} workflow for this task."`,
-        '',
-      ].join('\n'),
-    );
+    writeSkillIn(dir, name, body);
   }
 
-  function runLint(): { code: number; stdout: string; stderr: string } {
-    try {
-      const stdout = execFileSync('bun', [SCRIPT], {
-        env: { ...process.env, SKILLS_LINT_DIR: dir },
-        encoding: 'utf8',
-      });
-      return { code: 0, stdout, stderr: '' };
-    } catch (err) {
-      const e = err as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
-      return {
-        code: e.status ?? 1,
-        stdout: e.stdout?.toString() ?? '',
-        stderr: e.stderr?.toString() ?? '',
-      };
-    }
+  function runLint(): LintRun {
+    return runLintIn(dir);
   }
 
   test('an offending skill (cp templates/...) exits non-zero', () => {
@@ -259,6 +273,172 @@ describe('validateSkillMetadata', () => {
     const violations = validateSkillMetadata(skillDir).violations.join('\n');
     expect(violations).toContain('CLAUDE_SKILL_DIR');
     expect(violations).toContain('missing agents/openai.yaml');
+  });
+});
+
+describe('collectBannedTokenViolations — plain-substring vocabulary scan', () => {
+  test('BANNED-13 is exactly thirteen tokens with no duplicates', () => {
+    const tokens = BANNED_TOKEN_GUIDANCE.map(([token]) => token);
+    expect(tokens).toHaveLength(13);
+    expect(new Set(tokens).size).toBe(13);
+  });
+
+  test('matches as a plain substring, with no word boundary and no allowlist', () => {
+    // Embedded mid-word: a word-boundary regex would MISS this; String.includes must not.
+    const hits = collectBannedTokenViolations('prefixgenie_reviewerSUFFIX').map((v) => v.token);
+    expect(hits).toEqual(['genie_reviewer']);
+  });
+
+  test('reports the 1-indexed line of every hit', () => {
+    const text = ['clean line', 'route to engineer-standard here', 'clean', 'and to engineer-standard again'].join(
+      '\n',
+    );
+    expect(collectBannedTokenViolations(text).map((v) => v.line)).toEqual([2, 4]);
+  });
+
+  test('legitimate prose and the surviving bare role names are clean', () => {
+    const text = [
+      'genie task checkout <id> --worker w',
+      'bun run check',
+      'The engineer implements; the reviewer reviews; the fixer fixes.',
+      'A final-gate pass, then a scout for read-only discovery.',
+      'implementor-low / implementor-mid / implementor-high',
+    ].join('\n');
+    expect(collectBannedTokenViolations(text)).toEqual([]);
+  });
+});
+
+describe('end-to-end: retired-vocabulary and directory-shape fixtures', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'skills-lint-tokens-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // One negative fixture per BANNED-13 token: exit code AND message text.
+  // The frontmatter is written explicitly so the offending line number (6) is
+  // asserted, not inferred.
+  for (const [token, guidance] of BANNED_TOKEN_GUIDANCE) {
+    test(`rejects the retired token ${token}`, () => {
+      writeSkillIn(
+        dir,
+        'offender',
+        [
+          '---',
+          'name: offender',
+          'description: "Use offender for this test workflow."',
+          '---',
+          '',
+          `Dispatch through ${token} for this group.`,
+          '',
+        ].join('\n'),
+      );
+      const { code, stderr } = runLintIn(dir);
+      expect(code).toBe(1);
+      expect(stderr).toContain('file(s) name a retired agent/runtime token');
+      expect(stderr).toContain(`offender/SKILL.md:6: [retired-token] ${token} — ${guidance}`);
+    });
+  }
+
+  test('scans NON-markdown files — a banned token in agents/openai.yaml fails', () => {
+    const skillDir = writeSkillIn(dir, 'yaml-offender', '# yaml-offender\n\nOrdinary prose.\n');
+    writeFileSync(
+      join(skillDir, 'agents', 'openai.yaml'),
+      [
+        '# starter card for the genie_scout role',
+        'interface:',
+        '  display_name: "yaml-offender"',
+        '  short_description: "Run the yaml-offender workflow"',
+        '  default_prompt: "Run the yaml-offender workflow for this task."',
+        '',
+      ].join('\n'),
+    );
+    const { code, stderr } = runLintIn(dir);
+    expect(code).toBe(1);
+    expect(stderr).toContain('yaml-offender/agents/openai.yaml:1: [retired-token] genie_scout');
+  });
+
+  test('the skills-lint:ignore marker does NOT exempt a file from the vocabulary scan', () => {
+    writeSkillIn(
+      dir,
+      'ignored',
+      [
+        '---',
+        'name: ignored',
+        'description: "Use ignored for this test workflow."',
+        '---',
+        '',
+        '<!-- skills-lint:ignore -->',
+        '',
+        'Route complexity 2-3 to genie_engineer_standard.',
+        '',
+        '```bash',
+        'cp templates/wish-template.md dest.md',
+        '```',
+        '',
+      ].join('\n'),
+    );
+    const { code, stderr } = runLintIn(dir);
+    expect(code).toBe(1);
+    // The token rule runs BEFORE the bailout...
+    expect(stderr).toContain('ignored/SKILL.md:8: [retired-token] genie_engineer_standard');
+    // ...while the bailout still suppresses only the command/resource checks.
+    expect(stderr).not.toContain('cp-repo-template');
+  });
+
+  test('rejects a nested SKILL.md that skills.sh cannot discover', () => {
+    writeSkillIn(dir, 'outer', '# outer\n\nOrdinary prose.\n');
+    mkdirSync(join(dir, 'outer', 'inner'), { recursive: true });
+    writeFileSync(
+      join(dir, 'outer', 'inner', 'SKILL.md'),
+      '---\nname: inner\ndescription: "Nested."\n---\n\n# inner\n',
+    );
+    const { code, stderr } = runLintIn(dir);
+    expect(code).toBe(1);
+    expect(stderr).toContain('skills/ directory shape violation(s)');
+    expect(stderr).toContain('[nested skill dir] outer/inner/SKILL.md hides under outer/');
+    expect(stderr).toContain('move it to a uniquely named top-level directory');
+  });
+
+  test('rejects a top-level skill directory with no root SKILL.md', () => {
+    writeSkillIn(dir, 'present', '# present\n\nOrdinary prose.\n');
+    mkdirSync(join(dir, 'hollow', 'references'), { recursive: true });
+    writeFileSync(join(dir, 'hollow', 'references', 'notes.md'), '# notes\n');
+    const { code, stderr } = runLintIn(dir);
+    expect(code).toBe(1);
+    expect(stderr).toContain('[empty skill dir] hollow/ has no SKILL.md at its root');
+    expect(stderr).toContain('add hollow/SKILL.md or remove the directory');
+  });
+
+  test('legitimate prose, bundled subdirectories and surviving role names pass', () => {
+    const skillDir = writeSkillIn(
+      dir,
+      'clean',
+      [
+        '# clean',
+        '',
+        'The engineer implements, the reviewer reviews, the fixer fixes,',
+        'a final-gate closes the wish and a scout does read-only discovery.',
+        'Route by complexity to implementor-low, implementor-mid or implementor-high.',
+        '',
+        '```bash',
+        'genie task checkout t_1 --worker w',
+        'bun run check',
+        '```',
+        '',
+      ].join('\n'),
+    );
+    // references/ and templates/ carry no SKILL.md and must never trip the shape rule.
+    mkdirSync(join(skillDir, 'references'), { recursive: true });
+    mkdirSync(join(skillDir, 'templates'), { recursive: true });
+    writeFileSync(join(skillDir, 'references', 'catalog.md'), '# catalog\n\nAn implementor-mid recipe.\n');
+    writeFileSync(join(skillDir, 'templates', 'brief.md'), '# brief\n\nDispatch a scout first.\n');
+    const { code, stderr } = runLintIn(dir);
+    expect(code).toBe(0);
+    expect(stderr).toContain('0 retired tokens, 0 structure violations');
   });
 });
 

--- a/scripts/skills-lint.ts
+++ b/scripts/skills-lint.ts
@@ -2,15 +2,19 @@
 /**
  * skills-lint validates both the command surface and the shipped Codex skill
  * contract: strict SKILL.md frontmatter, matching agents/openai.yaml metadata,
- * skill-relative resources, and real `genie` / `omni` commands.
+ * skill-relative resources, real `genie` / `omni` commands, the retired-role
+ * vocabulary ban, and the skills.sh directory shape.
  *
  * Exit non-zero if any skill has missing commands.
- * Honors a `<!-- skills-lint:ignore -->` bailout marker to skip a file.
+ * Honors a `<!-- skills-lint:ignore -->` bailout marker to skip a file's
+ * command/resource checks — the vocabulary scan below is deliberately NOT
+ * skippable (see BANNED_TOKEN_GUIDANCE).
  */
 
 import { execFileSync, execSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { basename, join, relative, sep } from 'node:path';
+import { scanRepoSkills } from './skills-inventory-parity.ts';
 
 const ROOT = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
 // SKILLS_LINT_DIR lets tests point the scanner at a fixture tree; defaults to
@@ -30,6 +34,110 @@ export function isResourceAllowlisted(file: string, skillsDir: string = SKILLS_D
   if (rel === 'README.md') return true;
   const first = rel.split(sep)[0];
   return RESOURCE_ALLOWLIST_SEGMENTS.has(first);
+}
+
+/**
+ * BANNED-13 — the retired role/runtime vocabulary, matched as PLAIN SUBSTRINGS
+ * (`String.includes`; no regex, no word boundaries, no "used as an agent name"
+ * judgement call) in EVERY file under the scanned skills dir, `.md` and
+ * non-`.md` alike: `agents/openai.yaml` starter prompts are shipped skill
+ * content an agent reads and acts on.
+ *
+ * Two properties are deliberate and must not be relaxed:
+ *   - There is NO allowlist. `RESOURCE_ALLOWLIST_SEGMENTS` and the README
+ *     exemption are scoped to the resource-path rule only: a hack recipe naming
+ *     a deleted agent profile misleads exactly as much as an executable skill
+ *     does, because a recipe is copied, not read.
+ *   - The scan runs BEFORE the `<!-- skills-lint:ignore -->` bailout, so an
+ *     ignore marker added for a command fence cannot silently disable the
+ *     vocabulary contract for that file.
+ *
+ * Each entry carries the replacement the offending file must adopt, so the
+ * failure names the fix and not just the sin.
+ */
+export const BANNED_TOKEN_GUIDANCE: ReadonlyArray<readonly [token: string, guidance: string]> = [
+  [
+    'genie_engineer_trivial',
+    'name the portable role `implementor-low`, not the runtime profile `genie_engineer_trivial`',
+  ],
+  [
+    'genie_engineer_standard',
+    'name the portable role `implementor-mid`, not the runtime profile `genie_engineer_standard`',
+  ],
+  [
+    'genie_engineer_complex',
+    'name the portable role `implementor-high`, not the runtime profile `genie_engineer_complex`',
+  ],
+  ['genie_reviewer', 'name the portable role `reviewer`, not the runtime profile `genie_reviewer`'],
+  ['genie_fixer', 'name the portable role `fixer`, not the runtime profile `genie_fixer`'],
+  ['genie_final_gate', 'name the portable role `final-gate`, not the runtime profile `genie_final_gate`'],
+  ['genie_scout', 'name the portable role `scout`, not the runtime profile `genie_scout`'],
+  ['engineer-trivial', 'name the portable role `implementor-low`, not the retired tier `engineer-trivial`'],
+  ['engineer-standard', 'name the portable role `implementor-mid`, not the retired tier `engineer-standard`'],
+  ['engineer-complex', 'name the portable role `implementor-high`, not the retired tier `engineer-complex`'],
+  [
+    '$genie:',
+    'describe invocation as skills.sh discovery (`$wish`, `$work`, a bare name, or natural language), not a `$genie:` plugin selector',
+  ],
+  [
+    'CLAUDE_PLUGIN_ROOT',
+    'resolve skill-shipped files from the loaded SKILL.md directory; `CLAUDE_PLUGIN_ROOT` is a retired host-specific root',
+  ],
+  [
+    'LENS_ROOT',
+    'resolve skill-shipped files from the loaded SKILL.md directory; `LENS_ROOT` is a retired host-specific root',
+  ],
+];
+
+export interface BannedTokenViolation {
+  token: string;
+  /** 1-indexed line within the scanned file. */
+  line: number;
+  guidance: string;
+}
+
+/** Every BANNED-13 substring hit in `text`, with its 1-indexed line. */
+export function collectBannedTokenViolations(text: string): BannedTokenViolation[] {
+  const violations: BannedTokenViolation[] = [];
+  const lines = text.split('\n');
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] as string;
+    for (const [token, guidance] of BANNED_TOKEN_GUIDANCE) {
+      if (line.includes(token)) violations.push({ token, line: index + 1, guidance });
+    }
+  }
+  return violations;
+}
+
+export interface StructureViolation {
+  rule: 'empty skill dir' | 'nested skill dir';
+  detail: string;
+}
+
+/**
+ * The skills.sh directory shape, IMPORTED rather than re-derived:
+ * `scanRepoSkills` already computes both findings and is already CI-gated by
+ * the `skills-inventory-parity` job. Two implementations of one contract can
+ * disagree; one cannot.
+ */
+export function collectStructureViolations(skillsDir: string = SKILLS_DIR): StructureViolation[] {
+  const scan = scanRepoSkills(ROOT, skillsDir);
+  const violations: StructureViolation[] = [];
+  for (const name of scan.dirsWithoutSkillMd) {
+    violations.push({
+      rule: 'empty skill dir',
+      detail: `${name}/ has no SKILL.md at its root — skills.sh does not discover it; add ${name}/SKILL.md or remove the directory`,
+    });
+  }
+  for (const nested of scan.nestedSkillFiles) {
+    const segments = nested.split('/');
+    const where = segments.length > 1 ? `hides under ${segments[0]}/` : 'sits at the skills root';
+    violations.push({
+      rule: 'nested skill dir',
+      detail: `${nested} ${where} — skills.sh does not discover it, and \`--full-depth\` collides with the top-level name; move it to a uniquely named top-level directory`,
+    });
+  }
+  return violations;
 }
 
 function collectSubcommands(helpText: string): Set<string> {
@@ -100,13 +208,19 @@ function getOmniCommands(): Set<string> | null {
   return cmds;
 }
 
+/**
+ * Every file under `dir`, `.md` and non-`.md` alike. The vocabulary scan needs
+ * the whole tree (Decision 10: `agents/openai.yaml` starter prompts are shipped
+ * skill content); the command/resource/metadata checks stay markdown-only and
+ * filter this list themselves.
+ */
 function walk(dir: string): string[] {
   const out: string[] = [];
   for (const entry of readdirSync(dir)) {
     const p = join(dir, entry);
     const s = statSync(p);
     if (s.isDirectory()) out.push(...walk(p));
-    else if (entry.endsWith('.md')) out.push(p);
+    else out.push(p);
   }
   return out;
 }
@@ -320,6 +434,54 @@ interface Report {
   missingCommands: Array<{ tool: string; command: string }>;
   resourceViolations: ResourceViolation[];
   metadataViolations: string[];
+  bannedTokens: BannedTokenViolation[];
+}
+
+/** Emit every failing category. Returns true when the gate must exit non-zero. */
+function reportFailures(reports: Report[], structureViolations: StructureViolation[]): boolean {
+  const missingFailed = reports.filter((r) => r.missingCommands.length > 0);
+  const resourceFailed = reports.filter((r) => r.resourceViolations.length > 0);
+  const metadataFailed = reports.filter((r) => r.metadataViolations.length > 0);
+  const tokenFailed = reports.filter((r) => r.bannedTokens.length > 0);
+  if (
+    missingFailed.length === 0 &&
+    resourceFailed.length === 0 &&
+    metadataFailed.length === 0 &&
+    tokenFailed.length === 0 &&
+    structureViolations.length === 0
+  ) {
+    return false;
+  }
+
+  if (missingFailed.length > 0) {
+    console.error(`\nskills-lint: ${missingFailed.length} skill(s) reference missing commands`);
+  }
+  if (resourceFailed.length > 0) {
+    console.error(`\nskills-lint: ${resourceFailed.length} skill(s) reference repo-only resources`);
+    console.error('skills-lint: resolve skill-shipped paths from the loaded SKILL.md directory');
+    for (const r of resourceFailed) {
+      for (const v of r.resourceViolations) console.error(`  ${r.skill}: [${v.rule}] ${v.snippet}`);
+    }
+  }
+  if (metadataFailed.length > 0) {
+    console.error(`\nskills-lint: ${metadataFailed.length} skill(s) have invalid Codex metadata`);
+    for (const r of metadataFailed) {
+      for (const violation of r.metadataViolations) console.error(`  ${r.skill}: ${violation}`);
+    }
+  }
+  if (tokenFailed.length > 0) {
+    console.error(`\nskills-lint: ${tokenFailed.length} file(s) name a retired agent/runtime token`);
+    for (const r of tokenFailed) {
+      for (const v of r.bannedTokens) {
+        console.error(`  ${r.skill}:${v.line}: [retired-token] ${v.token} — ${v.guidance}`);
+      }
+    }
+  }
+  if (structureViolations.length > 0) {
+    console.error(`\nskills-lint: ${structureViolations.length} skills/ directory shape violation(s)`);
+    for (const v of structureViolations) console.error(`  [${v.rule}] ${v.detail}`);
+  }
+  return true;
 }
 
 function main() {
@@ -331,6 +493,7 @@ function main() {
   }
 
   const files = walk(SKILLS_DIR);
+  const structureViolations = collectStructureViolations(SKILLS_DIR);
   const reports: Report[] = [];
   const metadataBySkill = new Map<string, string[]>();
   for (const entry of readdirSync(SKILLS_DIR, { withFileTypes: true })) {
@@ -342,10 +505,24 @@ function main() {
   // is only probed when some scanned skill actually references it; when the
   // probe fails, getOmniCommands() returns null and omni checks are skipped
   // (loudly) instead of failing the gate — see its contract comment.
-  const scanned: Array<{ file: string; genie: string[]; omni: string[]; resource: ResourceViolation[] }> = [];
+  const scanned: Array<{
+    file: string;
+    genie: string[];
+    omni: string[];
+    resource: ResourceViolation[];
+    banned: BannedTokenViolation[];
+  }> = [];
   for (const file of files) {
     const text = readFileSync(file, 'utf8');
-    if (text.includes('<!-- skills-lint:ignore -->')) continue;
+    // Decision 9: the vocabulary scan runs on EVERY file the walk finds and
+    // BEFORE the ignore bailout. The bailout below skips only the
+    // command/resource checks it was introduced for.
+    const banned = collectBannedTokenViolations(text);
+    const commandChecksSkipped = !file.endsWith('.md') || text.includes('<!-- skills-lint:ignore -->');
+    if (commandChecksSkipped) {
+      scanned.push({ file, genie: [], omni: [], resource: [], banned });
+      continue;
+    }
     const genie: string[] = [];
     const omni: string[] = [];
     for (const fence of extractBashFences(text)) {
@@ -356,14 +533,14 @@ function main() {
     // show repo-root commands; executable skill instructions must ship their
     // own resources.
     const resource = isResourceAllowlisted(file) ? [] : collectResourceViolations(text);
-    scanned.push({ file, genie, omni, resource });
+    scanned.push({ file, genie, omni, resource, banned });
   }
 
   const omniNeeded = scanned.some((s) => s.omni.length > 0);
   const omniCmds = omniNeeded ? getOmniCommands() : new Set<string>();
   const omniSkipped = omniCmds === null;
 
-  for (const { file, genie, omni, resource } of scanned) {
+  for (const { file, genie, omni, resource, banned } of scanned) {
     const missing: Report['missingCommands'] = [];
     for (const cmd of genie) {
       if (!genieCmds.has(cmd)) missing.push({ tool: 'genie', command: cmd });
@@ -380,37 +557,17 @@ function main() {
       missingCommands: missing,
       resourceViolations: resource,
       metadataViolations,
+      bannedTokens: banned,
     });
   }
 
-  const missingFailed = reports.filter((r) => r.missingCommands.length > 0);
-  const resourceFailed = reports.filter((r) => r.resourceViolations.length > 0);
-  const metadataFailed = reports.filter((r) => r.metadataViolations.length > 0);
   console.log(JSON.stringify(reports, null, 2));
 
-  if (missingFailed.length > 0 || resourceFailed.length > 0 || metadataFailed.length > 0) {
-    if (missingFailed.length > 0) {
-      console.error(`\nskills-lint: ${missingFailed.length} skill(s) reference missing commands`);
-    }
-    if (resourceFailed.length > 0) {
-      console.error(`\nskills-lint: ${resourceFailed.length} skill(s) reference repo-only resources`);
-      console.error('skills-lint: resolve skill-shipped paths from the loaded SKILL.md directory');
-      for (const r of resourceFailed) {
-        for (const v of r.resourceViolations) {
-          console.error(`  ${r.skill}: [${v.rule}] ${v.snippet}`);
-        }
-      }
-    }
-    if (metadataFailed.length > 0) {
-      console.error(`\nskills-lint: ${metadataFailed.length} skill(s) have invalid Codex metadata`);
-      for (const r of metadataFailed) {
-        for (const violation of r.metadataViolations) console.error(`  ${r.skill}: ${violation}`);
-      }
-    }
-    process.exit(1);
-  }
+  if (reportFailures(reports, structureViolations)) process.exit(1);
   const omniNote = omniSkipped ? ', omni checks skipped' : '';
-  console.error(`skills-lint: OK (${reports.length} files scanned, 0 missing, 0 resource violations${omniNote})`);
+  console.error(
+    `skills-lint: OK (${reports.length} files scanned, 0 missing, 0 resource violations, 0 retired tokens, 0 structure violations${omniNote})`,
+  );
 }
 
 // Only run the linter when executed directly, not when imported by tests.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,15 +1,15 @@
 # Genie Skills
 
-`skills/` is the canonical, runtime-neutral source for Genie's 22 product skills. Each directory contains a
+`skills/` is the canonical, runtime-neutral source for Genie's 25 product skills. Each directory contains a
 `SKILL.md`, optional bundled resources, and `agents/openai.yaml` for Codex UI metadata.
 
-Shared skill bodies name semantic routes without a host-specific prefix. Invoke them through the active owner tier:
+Shared skill bodies name semantic routes without a host-specific prefix. Skills are installed into each agent's own global skills home by skills.sh (`npx skills add automagik-dev/genie`, or `genie update`), and every runtime discovers them from there. Invoke them the way the active runtime surfaces a discovered skill:
 
-- Codex plugin: `$genie:brainstorm`, `$genie:wish`, `$genie:review`, `$genie:work`
-- Codex user tier (only a separately installed personal copy; Genie no longer seeds this tier): `$brainstorm`, `$wish`, `$review`, `$work`
-- Claude Code and Hermes: `/brainstorm`, `/wish`, `/review`, `/work`
+- Codex: `$brainstorm`, `$wish`, `$review`, `$work`
+- Claude Code: `/brainstorm`, `/wish`, `/review`, `/work`
+- Any runtime: the bare skill name, or plain natural language describing the workflow
 
-The `agents/openai.yaml` starter prompt inside each skill is deliberately selector-free. A starter card already belongs to one discovered physical skill, and repeating either `$genie:<name>` or `$<name>` inside that card could redirect execution to a different tier. Manual invocation still uses the explicit selector mapping above.
+The `agents/openai.yaml` starter prompt inside each skill is deliberately selector-free. A starter card already belongs to one discovered physical skill, and repeating any selector — a bare `$<name>` included — inside that card could redirect execution to a different physical copy of the skill. Manual invocation uses the discovery forms above.
 
 The lifecycle is:
 
@@ -34,24 +34,25 @@ All runtimes share the same durable contracts:
 
 ## Distribution contract
 
-`plugins/genie/skills/` is a committed physical mirror of this directory so a source marketplace install and an
-extracted release contain the same in-root payload. Never edit the mirror directly.
+This directory is the single physical source; there is no committed mirror. The release tarball ships it verbatim, and
+`genie install` / `genie update` hand that delivered copy to the pinned skills.sh CLI, which writes it into every
+detected agent skills home. Editing a skill here is the only way to change what ships.
 
 ```bash
-bun scripts/sync-plugin-skills.ts --write  # regenerate after canonical edits
-bun scripts/sync-plugin-skills.ts --check  # fail on inventory or byte drift
-bun run skills:lint                         # validate metadata and command/resource contracts
-bun scripts/fresh-install-smoke.ts          # exercise source and copied plugin layouts
+bun run skills:lint                         # metadata, command, resource, vocabulary and directory-shape contracts
+bun scripts/fresh-install-smoke.ts          # exercise the tree exactly as a fresh install delivers it
 ```
 
-The build and version paths run the parity check before producing release state. Adding or removing a shipped skill
-therefore requires an intentional update to `SHIPPED_SKILL_NAMES` in `scripts/sync-plugin-skills.ts`.
+CI additionally runs `skills-inventory-parity`, which compares what the pinned skills CLI publishes for this commit
+against the top-level `skills/<name>/SKILL.md` set. Adding or removing a shipped skill therefore needs nothing beyond
+the directory itself — the inventory is derived from the tree, never hand-listed.
 
-An explicit successful `genie setup --codex` persists Codex maintenance consent. A later explicit `genie update` may
-therefore refresh the plugin, MCP, and optional role profiles. The installed plugin is the sole Genie-managed skill
-provider — no supported path writes product skills into the user tier; the only user-tier mutation is retiring provably
-clean historical fallbacks into a hidden quarantine transaction after a plugin health proof. Unmanaged, modified, or
-separately installed personal skills remain user-owned and are never adopted by that consent.
+Skills reach a host through exactly one channel: the pinned skills.sh CLI, run for you by `genie update` against the
+delivered tree, or run by hand as `npx skills add automagik-dev/genie`. The manual command publishes from the
+repository's default branch, so it can be ahead of or behind any release; `genie update` installs the exact delivered
+release. Genie writes skills nowhere else, and skills a user installed themselves stay user-owned — the installer
+records what it wrote so `genie uninstall` removes only that set. A separately installed personal copy of a skill is
+never adopted, refreshed, or removed by Genie.
 
 ## Shipped inventory
 
@@ -60,6 +61,7 @@ separately installed personal skills remain user-owned and are never adopted by 
 | Lifecycle | `brainstorm`, `quick`, `wish`, `review`, `work`, `fix`, `trace` |
 | Orchestration | `genie`, `dream`, `council`, `omni` |
 | Quality lanes | `architecture`, `code-quality`, `dx-docs`, `perf`, `qa`, `repo-hygiene`, `supply-chain` |
+| Orca lane | `genie-orca-wish`, `genie-orca-work`, `genie-orca-review` |
 | Supporting workflows | `docs`, `refine`, `report`, `genie-hacks` |
 
 Personal specialist-panel/persona skills are intentionally not part of this product payload.

--- a/skills/genie-hacks/references/catalog.md
+++ b/skills/genie-hacks/references/catalog.md
@@ -110,7 +110,7 @@ The local registry powering `genie-hacks list|search|show|help`. Canonical publi
 - **Solution:** Use the selected client's documented hook surface and keep commands deterministic and local. In Codex, non-managed hooks are skipped until the user reviews and trusts the exact definition hash; use canonical tool names (`Bash`, `apply_patch`, MCP names) and plugin `PLUGIN_ROOT`/`PLUGIN_DATA`. Claude/Hermes keep their own event envelopes. Never use lifecycle hooks for silent installers or self-updates.
 - **Code:**
   ```bash
-  # Identity used by hook dispatch (also the default task-checkout worker)
+  # Identity the genie CLI reads (also the default task-checkout worker)
   export GENIE_AGENT_NAME=my-agent
 
   # In an interactive Codex session, inspect and trust with /hooks.
@@ -138,7 +138,7 @@ The local registry powering `genie-hacks list|search|show|help`. Canonical publi
 - **Code:**
   ```bash
   # 1. Cheaper driver for bulk scaffolding wishes: dispatch with the
-  #    engineer-trivial named role (model/effort set in its agent profile)
+  #    implementor-low named role (model/effort set in its agent profile)
 
   # 2. Tight wish scoping
   # BAD:  "Refactor the entire codebase"

--- a/skills/trace/SKILL.md
+++ b/skills/trace/SKILL.md
@@ -37,7 +37,7 @@ Include file paths and line numbers in every root-cause claim so `fix` can act w
 
 ## Dispatch
 
-Trace runs through a fresh read-only scout/explorer role on the active runtime (runtime profile `genie_scout` when installed). It may search files and run non-mutating diagnostic commands, but it must not edit, stage, commit, or publish. Use native follow-up messaging to keep the same investigation context.
+Trace runs through a fresh read-only `scout` role on the active runtime. It may search files and run non-mutating diagnostic commands, but it must not edit, stage, commit, or publish. Use native follow-up messaging to keep the same investigation context.
 
 ## Rules
 - Report findings and stop — investigation only. `fix` applies the correction; never combine the two.

--- a/skills/wish/templates/wish-template.md
+++ b/skills/wish/templates/wish-template.md
@@ -63,11 +63,10 @@ Complexity scoring rubric: score each group independently and record the total p
 - **+1** each for multi-package work; OTel-label dependency; no deterministic test; prior rework; prompt-skill change; CI / release work.
 
 Route the total in **Model** by portable role and reasoning effort: **0–1** →
-`engineer-trivial` / low; **2–3** → `engineer-standard` / medium or high;
-**4–6** → `engineer-complex` / high; **7+** → `engineer-complex` plus an
+`implementor-low` / low; **2–3** → `implementor-mid` / medium or high;
+**4–6** → `implementor-high` / high; **7+** → `implementor-high` plus an
 independent `final-gate` at the highest justified effort. Each runtime maps
-these to its matching native roles (such as the `genie_*` profiles where
-installed). Keep
+these to its matching native roles. Keep
 model and effort in runtime session/agent configuration, never skill frontmatter.
 
 ## Execution Groups

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -49,17 +49,17 @@ When you are spawned as a subagent for a group, your dispatch prompt carries the
 
 Spawn subagents with the **native delegation surface**; never execute group work directly. Dispatch a wave together so independent groups can run concurrently. Subagents notify you on completion. Every dispatch selects one named role below; implicit or unnamed roles are forbidden.
 
-Use the active runtime's named roles: the matching `genie_*` custom-agent profile when the runtime has one installed, otherwise the runtime's native named-role surface. Parallel writers must have disjoint file ownership or dedicated worktrees; otherwise sequence them. Shared-workspace subagents never mutate repo-level git state (no `checkout`/`switch`/`reset`/`stash`/`rebase`) — **only the orchestrator moves HEAD**; work needing repo-level mutation gets an isolated worktree arranged by the orchestrator (client-provided worktrees or explicit `git worktree add` plumbing) or gets sequenced. `git worktree add/remove/prune` on snapshot/lane paths is orchestrator-side plumbing and permitted. Reviewers and scouts stay read-only. Wait for completion notifications, steer a running thread with native follow-up messaging, and interrupt drift rather than spawning a duplicate worker.
+Use the active runtime's named roles: the portable role names below map onto whatever native named-role surface the runtime provides. Parallel writers must have disjoint file ownership or dedicated worktrees; otherwise sequence them. Shared-workspace subagents never mutate repo-level git state (no `checkout`/`switch`/`reset`/`stash`/`rebase`) — **only the orchestrator moves HEAD**; work needing repo-level mutation gets an isolated worktree arranged by the orchestrator (client-provided worktrees or explicit `git worktree add` plumbing) or gets sequenced. The git-state freeze and the "agents merge to `dev`; `main` is humans-only" rule are operator policy carried in briefs and AGENTS.md, enforced by server-side branch protection on `main` and by nothing client-side. `git worktree add/remove/prune` on snapshot/lane paths is orchestrator-side plumbing and permitted. Reviewers and scouts stay read-only. Wait for completion notifications, steer a running thread with native follow-up messaging, and interrupt drift rather than spawning a duplicate worker.
 
-| Need | Portable role (runtime profile) |
+| Need | Portable role |
 |------|----------------------------|
-| Deterministic implementation, complexity 0-1 | `engineer-trivial` (`genie_engineer_trivial`) |
-| Moderately coupled implementation, complexity 2-3 | `engineer-standard` (`genie_engineer_standard`) |
-| High-coupling or stateful implementation, complexity 4+ | `engineer-complex` (`genie_engineer_complex`) |
-| Review | `reviewer` (`genie_reviewer`; never the group's engineer) |
-| Fix | `fixer` (`genie_fixer`; separate from the reviewer) |
-| Final plan or execution gate | `final-gate` (`genie_final_gate`) |
-| Bounded read-only discovery | `scout` (`genie_scout`) |
+| Deterministic implementation, complexity 0-1 | `implementor-low` |
+| Moderately coupled implementation, complexity 2-3 | `implementor-mid` |
+| High-coupling or stateful implementation, complexity 4+ | `implementor-high` |
+| Review | `reviewer` (never the group's engineer) |
+| Fix | `fixer` (separate from the reviewer) |
+| Final plan or execution gate | `final-gate` |
+| Bounded read-only discovery | `scout` |
 | Quick validation | The active runtime's shell directly — no subagent |
 | Follow-up to a running subagent | **native follow-up messaging** (keeps its context) |
 
@@ -96,7 +96,7 @@ Extract the group's context from WISH.md and paste it into the dispatch prompt �
 
 When the wave shares one workspace, every brief carries the file scope from item 6 **and** the freeze rule verbatim:
 
-> You share this workspace with concurrent engineers on disjoint files. Shared-workspace subagents never mutate repo-level git state (no `checkout`/`switch`/`reset`/`stash`/`rebase`) — **only the orchestrator moves HEAD**. Work needing repo-level mutation gets an isolated worktree arranged by the orchestrator (client-provided worktrees or explicit `git worktree add` plumbing) or gets sequenced. Leave your changes in the working tree; do not commit.
+> You share this workspace with concurrent engineers on disjoint files. Shared-workspace subagents never mutate repo-level git state (no `checkout`/`switch`/`reset`/`stash`/`rebase`) — **only the orchestrator moves HEAD**. Work needing repo-level mutation gets an isolated worktree arranged by the orchestrator (client-provided worktrees or explicit `git worktree add` plumbing) or gets sequenced. The git-state freeze and the "agents merge to `dev`; `main` is humans-only" rule are operator policy carried in briefs and AGENTS.md, enforced by server-side branch protection on `main` and by nothing client-side. Leave your changes in the working tree; do not commit.
 
 ## State Management
 

--- a/src/lib/skills-installer.ts
+++ b/src/lib/skills-installer.ts
@@ -68,7 +68,16 @@ import {
   runBoundedIntegrationCommand,
 } from './runtime-integrations.js';
 
-/** Pinned skills CLI. Bumping it is an ordinary dependency PR (wish decision 1). */
+/**
+ * Pinned skills CLI. Bumping it is an ordinary dependency PR (wish decision 1),
+ * but never a blind one: `KNOWN_AGENT_SKILL_HOMES` below is GENIE-owned, while
+ * the set of homes the CLI actually writes and the discovery scan that finds
+ * them afterwards are the CLI's. The two drift independently. Bumping this pin
+ * therefore requires re-verifying, against what the NEW CLI writes on a real
+ * host, both the homes table and the post-install discovery scan — otherwise
+ * `genie doctor` compares the recorded `agentDirs` against a set the installer
+ * no longer produces and reports a permanent false stale/missing result.
+ */
 export const SKILLS_CLI_VERSION = '1.5.23';
 
 /**
@@ -92,9 +101,12 @@ export function skillsSourceRoot(genieHome: string): string {
 export const SKILLS_INSTALL_RECORD_NAME = 'skills-install.json';
 
 /**
- * npm download + 22 skills across every detected agent home is well inside a
- * minute on a warm cache and can take a few on a cold one. 5 minutes is the
- * ceiling `runBoundedIntegrationCommand` accepts.
+ * npm download + the full inventory across every detected agent home is well
+ * inside a minute on a warm cache and can take a few on a cold one. 5 minutes
+ * is the ceiling `runBoundedIntegrationCommand` accepts. (Deliberately no
+ * literal skill count here: the top-level inventory is 25 at the time of
+ * writing and moves with every skill added, and a stale number in a timeout
+ * rationale reads as a contract nobody re-measured.)
  */
 const SKILLS_INSTALL_TIMEOUT_MS = 300_000;
 const SKILLS_INSTALL_OUTPUT_LIMIT_BYTES = 1024 * 1024;


### PR DESCRIPTION
# Wish `skills-everywhere-c` — Group 1: skills-lint rules + skill-content corrections

Base: `wish/skills-everywhere-c` @ `0efc288b5` (Wish B fully merged, PR #2878).

## What landed

**Deliverable 1 — token rule.** BANNED-13 matched as **plain substrings**
(`String.includes`; no regex, no word boundaries, no allowlist) over **every
file** `walk()` finds under `SKILLS_DIR` — `.md` and non-`.md` alike, so all 25
`agents/openai.yaml` starter prompts are in scope (Decision 10). `walk()` now
returns every file; the command/resource/metadata checks filter to `.md`
themselves, preserving today's behaviour exactly. Each violation reports
`<path>:<line>`, the offending token, and the mapped replacement from the
BANNED-13 → portable-role table. Not routed through `isResourceAllowlisted`
(Decision 2). The scan runs **before** the `<!-- skills-lint:ignore -->`
early-`continue`; the loop was restructured so the bailout skips only the
command/resource checks (Decision 9).

**Deliverable 2 — structure rules by import.** `scanRepoSkills` is imported
from `scripts/skills-inventory-parity.ts`; its `dirsWithoutSkillMd` and
`nestedSkillFiles` findings are surfaced as `empty skill dir` and
`nested skill dir` errors, replacing the silent `continue`. No second walk.
`scanRepoSkills` was widened with an explicit `skillsRoot` override (default
`<repoRoot>/skills`) so the `SKILLS_LINT_DIR` fixture root reuses that one
implementation; `scripts/skills-inventory-parity.test.ts` stays green
unchanged.

**Deliverables 3–7 — content.** `work/SKILL.md` (role table + dispatch
paragraph + the verbatim policy sentence in both required places),
`wish/templates/wish-template.md` (routing rubric + the `genie_*` parenthetical),
`skills/README.md` (skills.sh discovery instead of `$genie:` selectors, with
the selector-free-starter-card reason preserved), `trace/SKILL.md`
(bare `scout`), `genie-hacks/references/catalog.md` (`implementor-low`).

**Deliverables 8–9 — comments/docstrings.** `SKILLS_CLI_VERSION` now ties every
bump to a re-audit of `KNOWN_AGENT_SKILL_HOMES` **and** the post-install
discovery scan; the `SKILLS_INSTALL_TIMEOUT_MS` rationale drops its stale
"22 skills" literal (measured today: `ls -d skills/*/ | wc -l` = **25**).
`skills-inventory-parity.ts`'s header docstring now documents the `ci.yml`
local-source invocation and states the ref caveat in one line.

**Deliverable 10 — fixtures.** See the matrix below.

## Evidence

### C5-vocabulary — 13 hits → 0 over `skills/`

Baseline on this branch's base (`git grep -F` with the exact 13 `-e` terms,
no regex, no `-E`, no allowlist):

```
skills/README.md:8                                  $genie:
skills/README.md:12                                 $genie:
skills/genie-hacks/references/catalog.md:141        engineer-trivial
skills/trace/SKILL.md:40                            genie_scout
skills/wish/templates/wish-template.md:66           engineer-trivial, engineer-standard
skills/wish/templates/wish-template.md:67           engineer-complex
skills/work/SKILL.md:56                             genie_engineer_trivial, engineer-trivial
skills/work/SKILL.md:57                             genie_engineer_standard, engineer-standard
skills/work/SKILL.md:58                             genie_engineer_complex, engineer-complex
skills/work/SKILL.md:59                             genie_reviewer
skills/work/SKILL.md:60                             genie_fixer
skills/work/SKILL.md:61                             genie_final_gate
skills/work/SKILL.md:62                             genie_scout
```
13 hits across 5 files.

After:

```
$ git grep -F -n -e genie_engineer_trivial -e genie_engineer_standard \
    -e genie_engineer_complex -e genie_reviewer -e genie_fixer \
    -e genie_final_gate -e genie_scout -e engineer-trivial \
    -e engineer-standard -e engineer-complex -e '$genie:' \
    -e CLAUDE_PLUGIN_ROOT -e LENS_ROOT -- skills/
(no output)   exit=1
```

RETIRED-9 over `skills/` also returns nothing now — see "Plan measurement
correction" below.

### C5-policy — verbatim sentence, positive assertion

```
$ grep -F -c 'operator policy carried in briefs and AGENTS.md, enforced by server-side branch protection on `main` and by nothing client-side' skills/work/SKILL.md
2
```

Two occurrences, as deliverable 3(c) requires: the shared-workspace paragraph
under `## Dispatch`, and the freeze block quoted into every brief under
`## Context Curation`. D3 is additive — the block lost nothing and is still
verbatim-quotable.

### Fixture matrix — `bun test scripts/skills-lint.test.ts` → 43 pass / 0 fail

Every fixture asserts the **exit code (1)** *and* the **message text**.

| Fixture | Assertion | Result |
|---|---|---|
| `rejects the retired token genie_engineer_trivial` | `code === 1` + `offender/SKILL.md:6: [retired-token] genie_engineer_trivial — name the portable role \`implementor-low\`, …` | pass |
| `rejects the retired token genie_engineer_standard` | same shape, `implementor-mid` guidance | pass |
| `rejects the retired token genie_engineer_complex` | same shape, `implementor-high` guidance | pass |
| `rejects the retired token genie_reviewer` | same shape, `reviewer` guidance | pass |
| `rejects the retired token genie_fixer` | same shape, `fixer` guidance | pass |
| `rejects the retired token genie_final_gate` | same shape, `final-gate` guidance | pass |
| `rejects the retired token genie_scout` | same shape, `scout` guidance | pass |
| `rejects the retired token engineer-trivial` | same shape, `implementor-low` guidance | pass |
| `rejects the retired token engineer-standard` | same shape, `implementor-mid` guidance | pass |
| `rejects the retired token engineer-complex` | same shape, `implementor-high` guidance | pass |
| `rejects the retired token $genie:` | same shape, skills.sh-discovery guidance | pass |
| `rejects the retired token CLAUDE_PLUGIN_ROOT` | same shape, skill-relative-path guidance | pass |
| `rejects the retired token LENS_ROOT` | same shape, skill-relative-path guidance | pass |
| **non-`.md`**: `scans NON-markdown files — a banned token in agents/openai.yaml fails` | `code === 1` + `yaml-offender/agents/openai.yaml:1: [retired-token] genie_scout` | pass |
| **ignore marker**: `the skills-lint:ignore marker does NOT exempt a file from the vocabulary scan` | `code === 1` + `ignored/SKILL.md:8: [retired-token] genie_engineer_standard`, **and** `stderr` does **not** contain `cp-repo-template` (the bailout still suppresses only command/resource checks) | pass |
| **nested**: `rejects a nested SKILL.md that skills.sh cannot discover` | `code === 1` + `[nested skill dir] outer/inner/SKILL.md hides under outer/` + `move it to a uniquely named top-level directory` | pass |
| **empty dir**: `rejects a top-level skill directory with no root SKILL.md` | `code === 1` + `[empty skill dir] hollow/ has no SKILL.md at its root` + `add hollow/SKILL.md or remove the directory` | pass |
| **positive prose**: `legitimate prose, bundled subdirectories and surviving role names pass` | `code === 0` + `0 retired tokens, 0 structure violations`; fixture carries `genie task checkout`, `bun run check`, the bare words engineer / reviewer / fixer / final-gate / scout, and both `references/` and `templates/` subdirectories | pass |
| unit: `BANNED-13 is exactly thirteen tokens with no duplicates` | length 13, set size 13 | pass |
| unit: `matches as a plain substring, with no word boundary and no allowlist` | `prefixgenie_reviewerSUFFIX` matches (a word-boundary regex would not) | pass |
| unit: `reports the 1-indexed line of every hit` | lines `[2, 4]` | pass |
| unit: `legitimate prose and the surviving bare role names are clean` | no violations | pass |

### Gates

```
$ bun run skills:lint
skills-lint: OK (72 files scanned, 0 missing, 0 resource violations, 0 retired tokens, 0 structure violations)   exit=0

$ bun test scripts/skills-lint.test.ts scripts/skills-inventory-parity.test.ts
 69 pass  0 fail  (43 + 26)

$ bun run wishes:lint
wishes-lint: OK (85 files scanned, 0 broken brainstorm links, template validator green)   exit=0

$ bun run lint
exit=0   (biome: 2 pre-existing complexity warnings, both retained budget hotspots)

$ bun run check:fast          # typecheck + lint + dead-code + skills:lint + wishes:lint + complexity-budget + orca-bundle-parity
exit=0

$ bun test scripts/release-docs.test.ts scripts/fresh-install-smoke.test.ts src/lib/skills-installer.test.ts
 97 pass  0 fail

$ git diff --stat origin/dev...HEAD -- .github/workflows/release-publish.yml .github/workflows/musl-adapter-smoke.yml
(empty)   # C7-untouched holds
```

## Two forced edits outside the enumerated file list

Both are gate-forced, not discretionary.

1. **`.github/workflows/build-tarballs.yml`** — one added PR-path line,
   `- 'scripts/skills-inventory-parity.ts'`. `scripts/release-docs.test.ts`'s
   `buildHelperInputs()` walks `scripts/build-binary.sh` and then follows
   `from './x.ts'` imports transitively, asserting every reachable helper
   appears in the workflow's PR filter. Deliverable 2 mandates the import, so
   the helper became reachable and the assertion demanded the path. Neither
   `release-publish.yml` nor `musl-adapter-smoke.yml` is touched (C7 holds).
2. **`scripts/release-docs.test.ts`** — the four assertions that pinned
   `skills/README.md`'s pre-B wording (`Codex user tier …`,
   `persists Codex maintenance consent`, …). They guard the exact file
   deliverable 5 rewrites, so they move with it ("test alongside
   implementation"). Replaced with assertions on the new contract:
   `npx skills add automagik-dev/genie` present, the default-branch caveat
   present, `genie update` installs the exact delivered release, and negative
   assertions that `sync-plugin-skills` / `plugins/genie/skills/` /
   `persists Codex maintenance consent` are gone. **Root-`README.md`
   assertions in that same test were left untouched for Group 2** — the
   `$genie:<skill>` loop above them currently passes via root `README.md`, and
   Group 2's rewrite will force its update.

## Plan measurement correction (for the wish ledger)

The WISH's C10-repo criterion records `skills/` at **0** RETIRED-9 hits. On
this base it is **2**:

```
skills/README.md:50                            genie setup --codex
skills/genie-hacks/references/catalog.md:113   hook dispatch
```

Both are inside Group 1's file scope (Group 2 owns only `CLAUDE.md`,
`AGENTS.md`, root `README.md`), so they are fixed here rather than left to
collide. That pulled two adjacent corrections into `skills/README.md` that the
deliverables did not enumerate but that were provably false after Wish B:
the "Distribution contract" section named `plugins/genie/skills/` and
`scripts/sync-plugin-skills.ts` (both deleted by Wish B), and the shipped
inventory said 22 skills and omitted the three `genie-orca-*` lanes. Rewritten
to the post-B truth; count corrected to 25 (measured).

## Acceptance criteria

- [x] `bun run skills:lint` exits 0 against the repo's own `skills/`, including `skills/genie-orca-{wish,work,review}` and all 25 `agents/openai.yaml` (72 files scanned).
- [x] C5-vocabulary plain-substring grep returns nothing over `skills/` — 13 → 0.
- [x] Every BANNED-13 token and both structure rules have a failing fixture asserting exit code **and** message; the non-`.md` and `skills-lint:ignore` fixtures both fail.
- [x] `skills/work/SKILL.md` contains the policy sentence verbatim (`grep -F` → 2); the freeze paragraph lost nothing.
- [x] `bun test scripts/skills-inventory-parity.test.ts` green (26 pass), unchanged.
- [x] `bun run wishes:lint` green over every wish after the template edit.
- [x] No skill's steps, ordering, gates or acceptance rules changed meaning; only role vocabulary (plus the two RETIRED-9 corrections above).
