### PR TITLE
chore: initialize project brain

### DIFF
--- a/.brain/config.json
+++ b/.brain/config.json
@@ -1,0 +1,4 @@
+{
+  "brainId": "brn_w06loz",
+  "vaultDir": "brain"
+}

--- a/brain/.brain/config.json
+++ b/brain/.brain/config.json
@@ -1,0 +1,4 @@
+{
+  "brainId": "brn_w06loz",
+  "vaultDir": "brain"
+}

--- a/brain/.obsidian/app.json
+++ b/brain/.obsidian/app.json
@@ -1,0 +1,7 @@
+{
+  "alwaysUpdateLinks": true,
+  "newFileLocation": "folder",
+  "newFileFolderPath": "_Templates",
+  "showUnsupportedFiles": false,
+  "useMarkdownLinks": false
+}

--- a/brain/.obsidian/daily-notes.json
+++ b/brain/.obsidian/daily-notes.json
@@ -1,0 +1,5 @@
+{
+  "folder": "Daily",
+  "format": "YYYY-MM-DD",
+  "template": "_Templates/daily"
+}

--- a/brain/.obsidian/graph.json
+++ b/brain/.obsidian/graph.json
@@ -1,0 +1,46 @@
+{
+  "collapse_filter": false,
+  "search": "",
+  "showTags": true,
+  "showAttachments": false,
+  "showOrphans": true,
+  "colorGroups": [
+    {
+      "query": "path:Daily",
+      "color": {
+        "a": 1,
+        "rgb": 5431424
+      }
+    },
+    {
+      "query": "path:Intelligence",
+      "color": {
+        "a": 1,
+        "rgb": 1474816
+      }
+    },
+    {
+      "query": "path:Playbooks",
+      "color": {
+        "a": 1,
+        "rgb": 26112
+      }
+    },
+    {
+      "query": "tag:#decision",
+      "color": {
+        "a": 1,
+        "rgb": 16744448
+      }
+    }
+  ],
+  "showArrow": true,
+  "textFadeMultiplier": 0,
+  "nodeSizeMultiplier": 1,
+  "lineSizeMultiplier": 1,
+  "centerStrength": 0.5,
+  "repelStrength": 10,
+  "linkStrength": 1,
+  "linkDistance": 250,
+  "scale": 1
+}

--- a/brain/.obsidian/templates.json
+++ b/brain/.obsidian/templates.json
@@ -1,0 +1,3 @@
+{
+  "folder": "_Templates"
+}

--- a/brain/_Templates/daily.md
+++ b/brain/_Templates/daily.md
@@ -1,0 +1,13 @@
+---
+type: daily
+created: 2026-09-03
+tags: [daily]
+---
+
+# {{date}}
+
+## Notes
+
+## Decisions
+
+## Next

--- a/brain/_Templates/domain.md
+++ b/brain/_Templates/domain.md
@@ -1,0 +1,18 @@
+---
+title: "{{title}}"
+type: domain
+tags: []
+created: 2026-09-03
+updated: 2026-09-03
+confidence: medium
+---
+
+# {{title}}
+
+## Overview
+
+## Key Concepts
+
+## Open Questions
+
+## Signals to Watch

--- a/brain/_Templates/entity.md
+++ b/brain/_Templates/entity.md
@@ -1,0 +1,19 @@
+---
+title: "{{title}}"
+type: entity
+entity_type:
+tags: []
+created: 2026-09-03
+updated: 2026-09-03
+confidence: medium
+source_type: direct
+aliases: []
+---
+
+# {{title}}
+
+## Overview
+
+## Context
+
+## Relations

--- a/brain/_Templates/intel.md
+++ b/brain/_Templates/intel.md
@@ -1,0 +1,18 @@
+---
+title: "{{title}}"
+type: intel
+tags: []
+created: 2026-09-03
+updated: 2026-09-03
+confidence: medium
+source:
+source_type: direct
+---
+
+# {{title}}
+
+## Key Findings
+
+## Analysis
+
+## Open Questions

--- a/brain/_Templates/playbook.md
+++ b/brain/_Templates/playbook.md
@@ -1,0 +1,16 @@
+---
+title: "{{title}}"
+type: playbook
+tags: []
+created: 2026-09-03
+updated: 2026-09-03
+confidence: high
+---
+
+# {{title}}
+
+## When to Use
+
+## Steps
+
+## Notes

--- a/brain/_index.md
+++ b/brain/_index.md
@@ -1,0 +1,16 @@
+---
+title: "genie"
+type: moc
+created: 2026-09-03
+updated: 2026-09-03
+tags: [moc, root]
+---
+
+# genie
+
+Welcome to the **genie** brain. This is the root Map of Content (MOC).
+
+## Folders
+
+- [[Daily]] — Daily notes and logs
+- [[to_process]] — Raw content awaiting organization

--- a/brain/brain.json
+++ b/brain/brain.json
@@ -1,0 +1,29 @@
+{
+  "id": "brn_w06loz",
+  "slug": "genie",
+  "name": "genie",
+  "type": "engineering",
+  "owner": {
+    "type": "agent",
+    "id": "local"
+  },
+  "homePath": ".",
+  "strategy": {
+    "default": "rag",
+    "segments": []
+  },
+  "embeddings": {
+    "enabled": true,
+    "dims": 768
+  },
+  "extractor": {
+    "gateRules": {
+      "r1TemplateProtection": true,
+      "r2ConversasImmutable": true,
+      "r3PathWhitelist": true,
+      "r4CrossActorIdentity": true,
+      "r5DailyAppendOnly": true,
+      "actorChatIds": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- initialize the project Brain scaffold with the engineering profile
- add root and vault-local Brain pointers for `brn_w06loz`
- add generated Obsidian configuration, templates, and vault index

## Verification

- `with-bws-env brain init /home/genie/workspace/repos/genie/brain --name genie --type engineering`
- `with-bws-env brain status` lists `brn_w06loz` at `/home/genie/workspace/repos/genie/brain`
- root pointer, vault pointer, and `brain/brain.json` agree on the Brain ID
- no Brain init process remains
- `git diff --cached --check`

## Worked on by

- Sofia
- Felipe Rosa
